### PR TITLE
Export root cgroup as machine info.

### DIFF
--- a/heapster.go
+++ b/heapster.go
@@ -37,11 +37,11 @@ func doWork() error {
 	for {
 		select {
 		case <-ticker.C:
-			stats, err := source.GetAllStats()
+			data, err := source.GetInfo()
 			if err != nil {
 				return err
 			}
-			if err := sink.StoreData(stats); err != nil {
+			if err := sink.StoreData(data); err != nil {
 				return err
 			}
 		}

--- a/sinks/types.go
+++ b/sinks/types.go
@@ -15,6 +15,8 @@ type Sink interface {
 
 const (
 	statsTable            string = "stats"
+	specTable             string = "spec"
+	machineTable          string = "machine"
 	colTimestamp          string = "time"
 	colPodName            string = "pod"
 	colPodStatus          string = "pod_status"

--- a/sources/external.go
+++ b/sources/external.go
@@ -40,18 +40,22 @@ func (self *ExternalSource) GetPods() ([]Pod, error) {
 	return []Pod{}, nil
 }
 
-func (self *ExternalSource) GetAllStats() (StatsData, error) {
+func (self *ExternalSource) GetInfo() (ContainerData, error) {
 	hosts, err := self.getCadvisorHosts()
 	if err != nil {
-		return nil, err
+		return ContainerData{}, err
 	}
 
-	stats, err := self.cadvisor.fetchData(hosts)
+	containers, nodes, err := self.cadvisor.fetchData(hosts)
 	if err != nil {
 		glog.Error(err)
-		return nil, nil
+		return ContainerData{}, nil
 	}
-	return stats, nil
+
+	return ContainerData{
+		Containers: containers,
+		Machine:    nodes,
+	}, nil
 }
 
 func newExternalSource() (Source, error) {

--- a/sources/types.go
+++ b/sources/types.go
@@ -32,9 +32,15 @@ type Pod struct {
 	Labels     map[string]string `json:"labels,omitempty"`
 }
 
-type AnonContainer struct {
+type RawContainer struct {
 	Hostname string `json:"hostname,omitempty"`
-	*Container
+	Container
+}
+
+type ContainerData struct {
+	Pods       []Pod
+	Containers []RawContainer
+	Machine    []RawContainer
 }
 
 type CadvisorHosts struct {
@@ -42,11 +48,13 @@ type CadvisorHosts struct {
 	Hosts map[string]string `json:"hosts"`
 }
 
-type StatsData interface{}
-
 type Source interface {
-	// Returns either a slice of Pod or a slice of AnonContainer.
-	GetAllStats() (StatsData, error)
+	// Fetches containers or pod information from all the nodes in the cluster.
+	// Returns:
+	// 1. podsOrContainers: A slice of Pod or a slice of RawContainer
+	// 2. nodes: A slice of RawContainer, one for each node in the cluster, that contains
+	// root cgroup information.
+	GetInfo() (ContainerData, error)
 }
 
 func NewSource() (Source, error) {


### PR DESCRIPTION
 Fetch root cgroup information from Kubelet and export it to backend as a separate table.
1. Internal code refactoring - mainly around reducing the use of pointers.
