### PR TITLE
Sync storage-schema doc to reflect the current state of the storage driver

### DIFF
--- a/docs/storage-schema.md
+++ b/docs/storage-schema.md
@@ -4,10 +4,10 @@ Heapster exports the following metrics to its backends.
 
 | Metric Name        | Description                                                                                        | Type       | Units       | Supported Since |
 |--------------------|----------------------------------------------------------------------------------------------------|------------|-------------|-----------------|
-| uptime             | Number of milliseconds since the container was started                                             | Cumulative | Nanoseconds | v0.9            |
-| cpu/usage          | Cumulative CPU usage on all cores                                                                  | Cumulative | Bytes       | v0.9            |
+| uptime             | Number of millisecond since the container was started                                             | Cumulative | Milliseconds | v0.9            |
+| cpu/usage          | Cumulative CPU usage on all cores                                                                  | Cumulative | Nanoseconds       | v0.9            |
 | memory/usage       | Total memory usage                                                                                 | Gauge      | Bytes       | v0.9            |
-| memory/page_faults | Number of major page faults                                                                        | Gauge      | Count       | v0.9            |
+| memory/page_faults | Number of major page faults                                                                        | Cumulative      | Count       | v0.9            |
 | memory/working_set | Total working set usage. Working set is the memory being used and not easily dropped by the Kernel | Gauge      | Bytes       | v0.9            |
 | network/rx         | Cumulative number of bytes received over the network                                               | Cumulative | Bytes       | v0.9            |
 | network/rx_errors  | Cumulative number of errors while receiving over the network                                       | Cumulative | Count       | v0.9            |

--- a/sinks/api/supported_metrics.go
+++ b/sinks/api/supported_metrics.go
@@ -88,7 +88,7 @@ var statMetrics = []SupportedStatMetric{
 		MetricDescriptor: MetricDescriptor{
 			Name:        "memory/page_faults",
 			Description: "Number of major page faults",
-			Type:        MetricGauge,
+			Type:        MetricCumulative,
 			ValueType:   ValueInt64,
 			Units:       UnitsCount,
 		},

--- a/sinks/gcm/driver.go
+++ b/sinks/gcm/driver.go
@@ -101,6 +101,10 @@ func getDescription(metric sink_api.MetricDescriptor) string {
 			description: "Rate of total CPU usage in millicores per second",
 		},
 		{
+			name:        "memory/page_faults",
+			description: "Rate of major page faults in counts per second",
+		},
+		{
 			name:        "network/rx",
 			description: "Rate of bytes received over the network in bytes per second",
 		},
@@ -250,6 +254,7 @@ func (self *gcmSink) StoreTimeseries(input []sink_api.Timeseries) error {
 
 		// TODO(vmarmol): Stop doing this when GCM supports graphing cumulative metrics.
 		// Translate cumulative to gauge by taking the delta over the time period.
+		// TODO: Push instantaneous metrics as separate metrics.
 		doubleValue := float64(value)
 		if entry.MetricDescriptor.Type == sink_api.MetricCumulative {
 			key := lastValueKey{


### PR DESCRIPTION
Marked memory page faults as a cumulative metric.
