### PR TITLE
Adding support for Bosun

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -11,6 +11,26 @@
 			"Rev": "75cd24fc2f2c2a2088577d12123ddee5f54e0675"
 		},
 		{
+			"ImportPath": "bosun.org/metadata",
+			"Comment": "20150428222252-13-gfab31df",
+			"Rev": "fab31df2f087bfba0ee6d2a0784d5ebbe8b80401"
+		},
+		{
+			"ImportPath": "bosun.org/opentsdb",
+			"Comment": "20150428222252-13-gfab31df",
+			"Rev": "fab31df2f087bfba0ee6d2a0784d5ebbe8b80401"
+		},
+		{
+			"ImportPath": "bosun.org/slog",
+			"Comment": "20150428222252-13-gfab31df",
+			"Rev": "fab31df2f087bfba0ee6d2a0784d5ebbe8b80401"
+		},
+		{
+			"ImportPath": "bosun.org/util",
+			"Comment": "20150428222252-13-gfab31df",
+			"Rev": "fab31df2f087bfba0ee6d2a0784d5ebbe8b80401"
+		},
+		{
 			"ImportPath": "code.google.com/p/go-uuid/uuid",
 			"Comment": "null-12",
 			"Rev": "7dda39b2e7d5e265014674c5af696ba4186679e9"

--- a/Godeps/_workspace/src/bosun.org/metadata/ifaces.go
+++ b/Godeps/_workspace/src/bosun.org/metadata/ifaces.go
@@ -1,0 +1,31 @@
+package metadata
+
+import (
+	"fmt"
+	"net"
+	"strings"
+
+	"bosun.org/opentsdb"
+)
+
+func metaIfaces(f func(iface net.Interface, tags opentsdb.TagSet)) {
+	ifaces, _ := net.Interfaces()
+	for _, iface := range ifaces {
+		if strings.HasPrefix(iface.Name, "lo") {
+			continue
+		}
+		tags := opentsdb.TagSet{"iface": fmt.Sprint("Interface", iface.Index)}
+		AddMeta("", tags, "name", iface.Name, true)
+		if mac := iface.HardwareAddr.String(); mac != "" {
+			AddMeta("", tags, "mac", iface.HardwareAddr.String(), true)
+		}
+		ads, _ := iface.Addrs()
+		for i, ad := range ads {
+			addr := strings.Split(ad.String(), "/")[0]
+			AddMeta("", opentsdb.TagSet{"addr": fmt.Sprint("Addr", i)}.Merge(tags), "addr", addr, true)
+		}
+		if f != nil {
+			f(iface, tags)
+		}
+	}
+}

--- a/Godeps/_workspace/src/bosun.org/metadata/metadata.go
+++ b/Godeps/_workspace/src/bosun.org/metadata/metadata.go
@@ -1,0 +1,234 @@
+// Package metadata provides metadata information between bosun and OpenTSDB.
+package metadata
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"reflect"
+	"sync"
+	"time"
+
+	"bosun.org/opentsdb"
+	"bosun.org/slog"
+	"bosun.org/util"
+)
+
+// RateType is the type of rate for a metric: gauge, counter, or rate.
+type RateType string
+
+const (
+	// Unknown is a not-yet documented rate type.
+	Unknown RateType = ""
+	// Gauge rate type.
+	Gauge = "gauge"
+	// Counter rate type.
+	Counter = "counter"
+	// Rate rate type.
+	Rate = "rate"
+)
+
+// Unit is the unit for a metric.
+type Unit string
+
+const (
+	// None is a not-yet documented unit.
+	None           Unit = ""
+	A                   = "A" // Amps
+	Alert               = "alerts"
+	Abort               = "aborts"
+	Bool                = "bool"
+	BitsPerSecond       = "bits per second"
+	Bytes               = "bytes"
+	BytesPerSecond      = "bytes per second"
+	C                   = "C" // Celsius
+	Check               = "checks"
+	CHz                 = "CentiHertz"
+	Connection          = "connections"
+	Context             = "contexts"
+	ContextSwitch       = "context switches"
+	Count               = ""
+	Document            = "documents"
+	Entropy             = "entropy"
+	Error               = "errors"
+	Event               = ""
+	Eviction            = "evictions"
+	Fault               = "faults"
+	Flush               = "flushes"
+	Files               = "files"
+	Get                 = "gets"
+	GetExists           = "get exists"
+	Interupt            = "interupts"
+	Item                = "items"
+	KBytes              = "kbytes"
+	Key                 = "keys"
+	Load                = "load"
+	EMail               = "emails"
+	MHz                 = "MHz" // MegaHertz
+	Megabit             = "Mbit"
+	Merge               = "merges"
+	MilliSecond         = "milliseconds"
+	Ok                  = "ok" // "OK" or not status, 0 = ok, 1 = not ok
+	Operation           = "Operations"
+	Page                = "pages"
+	Pct                 = "percent" // Range of 0-100.
+	PerSecond           = "per second"
+	Process             = "processes"
+	Priority            = "priority"
+	Query               = "queries"
+	Redispatch          = "redispatches"
+	Refresh             = "refreshes"
+	Replica             = "replicas"
+	Retry               = "retries"
+	Response            = "responses"
+	Request             = "requests"
+	RPM                 = "RPM" // Rotations per minute.
+	Second              = "seconds"
+	Segment             = "segments"
+	Server              = "servers"
+	Session             = "sessions"
+	Shard               = "shards"
+	Socket              = "sockets"
+	Suggest             = "suggests"
+	StatusCode          = "status code"
+	Syscall             = "system calls"
+	Thread              = "threads"
+	Transition          = "transitions"
+	V                   = "V" // Volts
+	V10                 = "tenth-Volts"
+	Watt                = "Watts"
+	Weight              = "weight"
+	Yield               = "yields"
+)
+
+// Metakey uniquely identifies a metadata entry.
+type Metakey struct {
+	Metric string
+	Tags   string
+	Name   string
+}
+
+// TagSet returns m's tags.
+func (m Metakey) TagSet() opentsdb.TagSet {
+	tags, err := opentsdb.ParseTags(m.Tags)
+	if err != nil {
+		return nil
+	}
+	return tags
+}
+
+var (
+	metadata  = make(map[Metakey]interface{})
+	metalock  sync.Mutex
+	metahost  string
+	metafuncs []func()
+	metadebug bool
+)
+
+// AddMeta adds a metadata entry to memory, which is queued for later sending.
+func AddMeta(metric string, tags opentsdb.TagSet, name string, value interface{}, setHost bool) {
+	if tags == nil {
+		tags = make(opentsdb.TagSet)
+	}
+	if _, present := tags["host"]; setHost && !present {
+		tags["host"] = util.Hostname
+	}
+	if err := tags.Clean(); err != nil {
+		slog.Error(err)
+		return
+	}
+	ts := tags.Tags()
+	metalock.Lock()
+	defer metalock.Unlock()
+	prev, present := metadata[Metakey{metric, ts, name}]
+	if present && !reflect.DeepEqual(prev, value) {
+		slog.Infof("metadata changed for %s/%s/%s: %v to %v", metric, ts, name, prev, value)
+		go sendMetadata([]Metasend{{
+			Metric: metric,
+			Tags:   tags,
+			Name:   name,
+			Value:  value,
+		}})
+	} else if metadebug {
+		slog.Infof("AddMeta for %s/%s/%s: %v", metric, ts, name, value)
+	}
+	metadata[Metakey{metric, ts, name}] = value
+}
+
+// AddMetricMeta is a convenience function to set the main metadata fields for a
+// metric. Those fields are rate, unit, and description. If you need to document
+// tag keys then use AddMeta.
+func AddMetricMeta(metric string, rate RateType, unit Unit, desc string) {
+	AddMeta(metric, nil, "rate", rate, false)
+	AddMeta(metric, nil, "unit", unit, false)
+	AddMeta(metric, nil, "desc", desc, false)
+}
+
+// Init initializes the metadata send queue.
+func Init(u *url.URL, debug bool) error {
+	mh, err := u.Parse("/api/metadata/put")
+	if err != nil {
+		return err
+	}
+	metahost = mh.String()
+	metadebug = debug
+	go collectMetadata()
+	return nil
+}
+
+func collectMetadata() {
+	// Wait a bit so hopefully our collectors have run once and populated the
+	// metadata.
+	time.Sleep(time.Second * 5)
+	for {
+		for _, f := range metafuncs {
+			f()
+		}
+		metalock.Lock()
+		if len(metadata) == 0 {
+			metalock.Unlock()
+			continue
+		}
+		ms := make([]Metasend, len(metadata))
+		i := 0
+		for k, v := range metadata {
+			ms[i] = Metasend{
+				Metric: k.Metric,
+				Tags:   k.TagSet(),
+				Name:   k.Name,
+				Value:  v,
+			}
+			i++
+		}
+		metalock.Unlock()
+		sendMetadata(ms)
+		time.Sleep(time.Hour)
+	}
+}
+
+// Metasend is the struct for sending metadata to bosun.
+type Metasend struct {
+	Metric string          `json:",omitempty"`
+	Tags   opentsdb.TagSet `json:",omitempty"`
+	Name   string          `json:",omitempty"`
+	Value  interface{}
+	Time   time.Time `json:",omitempty"`
+}
+
+func sendMetadata(ms []Metasend) {
+	b, err := json.Marshal(&ms)
+	if err != nil {
+		slog.Error(err)
+		return
+	}
+	resp, err := http.Post(metahost, "application/json", bytes.NewBuffer(b))
+	if err != nil {
+		slog.Error(err)
+		return
+	}
+	if resp.StatusCode != 204 {
+		slog.Errorln("bad metadata return:", resp.Status)
+		return
+	}
+}

--- a/Godeps/_workspace/src/bosun.org/metadata/metadata_darwin.go
+++ b/Godeps/_workspace/src/bosun.org/metadata/metadata_darwin.go
@@ -1,0 +1,44 @@
+package metadata
+
+import (
+	"fmt"
+	"strings"
+
+	"bosun.org/util"
+)
+
+func init() {
+	metafuncs = append(metafuncs, metaDarwinVersion, metaDarwinInterfaces)
+}
+
+func metaDarwinVersion() {
+	util.ReadCommand(func(line string) error {
+		AddMeta("", nil, "uname", line, true)
+		return nil
+	}, "uname", "-a")
+	var name, vers, build string
+	util.ReadCommand(func(line string) error {
+		sp := strings.SplitN(line, ":", 2)
+		if len(sp) != 2 {
+			return nil
+		}
+		v := strings.TrimSpace(sp[1])
+		switch sp[0] {
+		case "ProductName":
+			name = v
+		case "ProductVersion":
+			vers = v
+		case "BuildVersion":
+			build = v
+		}
+		return nil
+	}, "sw_vers")
+	if name != "" && vers != "" && build != "" {
+		AddMeta("", nil, "version", fmt.Sprintf("%s.%s", vers, build), true)
+		AddMeta("", nil, "versionCaption", fmt.Sprintf("%s %s", name, vers), true)
+	}
+}
+
+func metaDarwinInterfaces() {
+	metaIfaces(nil)
+}

--- a/Godeps/_workspace/src/bosun.org/metadata/metadata_dell_linux.go
+++ b/Godeps/_workspace/src/bosun.org/metadata/metadata_dell_linux.go
@@ -1,0 +1,30 @@
+package metadata
+
+// Restrict to Linux because, although omreport runs fine on Windows, the
+// Windows metadata uses WMI to fetch this information.
+
+import (
+	"strings"
+
+	"bosun.org/util"
+)
+
+func init() {
+	metafuncs = append(metafuncs, collectMetadataOmreport)
+}
+
+func collectMetadataOmreport() {
+	_ = util.ReadCommand(func(line string) error {
+		fields := strings.Split(line, ";")
+		if len(fields) != 2 {
+			return nil
+		}
+		switch fields[0] {
+		case "Chassis Service Tag":
+			AddMeta("", nil, "serialNumber", fields[1], true)
+		case "Chassis Model":
+			AddMeta("", nil, "model", fields[1], true)
+		}
+		return nil
+	}, "omreport", "chassis", "info", "-fmt", "ssv")
+}

--- a/Godeps/_workspace/src/bosun.org/metadata/metadata_linux.go
+++ b/Godeps/_workspace/src/bosun.org/metadata/metadata_linux.go
@@ -1,0 +1,74 @@
+package metadata
+
+import (
+	"errors"
+	"io/ioutil"
+	"net"
+	"strconv"
+	"strings"
+
+	"bosun.org/opentsdb"
+	"bosun.org/util"
+)
+
+func init() {
+	metafuncs = append(metafuncs, metaLinuxVersion, metaLinuxIfaces)
+}
+
+func metaLinuxVersion() {
+	_ = util.ReadCommand(func(line string) error {
+		AddMeta("", nil, "uname", line, true)
+		return nil
+	}, "uname", "-a")
+	_ = util.ReadCommand(func(line string) error {
+		fields := strings.Fields(line)
+		hasNum := false
+		for i := 0; i < len(fields); {
+			if strings.HasPrefix(fields[i], `\`) {
+				fields = append(fields[:i], fields[i+1:]...)
+			} else {
+				if v, _ := strconv.ParseFloat(fields[i], 32); v > 0 {
+					hasNum = true
+				}
+				i++
+			}
+		}
+		if !hasNum {
+			return nil
+		}
+		AddMeta("", nil, "version", strings.Join(fields, " "), true)
+		return nil
+	}, "cat", "/etc/issue")
+}
+
+var doneErr = errors.New("")
+
+// metaLinuxIfacesMaster returns the bond master from s or "" if none exists.
+func metaLinuxIfacesMaster(line string) string {
+	sp := strings.Fields(line)
+	for i := 4; i < len(sp); i += 2 {
+		if sp[i-1] == "master" {
+			return sp[i]
+		}
+	}
+	return ""
+}
+
+func metaLinuxIfaces() {
+	metaIfaces(func(iface net.Interface, tags opentsdb.TagSet) {
+		if speed, err := ioutil.ReadFile("/sys/class/net/" + iface.Name + "/speed"); err == nil {
+			v, _ := strconv.Atoi(strings.TrimSpace(string(speed)))
+			if v > 0 {
+				const MbitToBit = 1e6
+				AddMeta("", tags, "speed", v*MbitToBit, true)
+			}
+		}
+		_ = util.ReadCommand(func(line string) error {
+			if v := metaLinuxIfacesMaster(line); v != "" {
+				AddMeta("", tags, "master", v, true)
+				return doneErr
+			}
+			return nil
+		}, "ip", "-o", "addr", "show", iface.Name)
+	})
+}

--- a/Godeps/_workspace/src/bosun.org/metadata/metadata_linux_test.go
+++ b/Godeps/_workspace/src/bosun.org/metadata/metadata_linux_test.go
@@ -1,0 +1,17 @@
+package metadata
+
+import "testing"
+
+func TestLinuxIpAddrShowMaster(t *testing.T) {
+	inputs := map[string]string{
+		"bond0": `2: em1: <BROADCAST,MULTICAST,SLAVE,UP,LOWER_UP> mtu 1500 qdisc mq master bond0 state UP qlen 1000\    link/ether bc:30:5b:ed:c0:80 brd ff:ff:ff:ff:ff:ff`,
+		"bond1": `5: em4: <BROADCAST,MULTICAST,SLAVE,UP,LOWER_UP> mtu 1500 qdisc mq master bond1 state UP qlen 1000\    link/ether bc:30:5b:ed:c0:3a brd ff:ff:ff:ff:ff:ff`,
+		"":      `7: bond1: <BROADCAST,MULTICAST,MASTER,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP \    link/ether bc:30:5b:ed:c0:3a brd ff:ff:ff:ff:ff:ff`,
+	}
+	for expect, val := range inputs {
+		got := metaLinuxIfacesMaster(val)
+		if got != expect {
+			t.Errorf("%v: expected %v, got %v", val, expect, got)
+		}
+	}
+}

--- a/Godeps/_workspace/src/bosun.org/metadata/metadata_windows.go
+++ b/Godeps/_workspace/src/bosun.org/metadata/metadata_windows.go
@@ -1,0 +1,150 @@
+package metadata
+
+import (
+	"fmt"
+	"strings"
+
+	"bosun.org/_third_party/github.com/StackExchange/wmi"
+	"bosun.org/opentsdb"
+	"bosun.org/slog"
+)
+
+func init() {
+	metafuncs = append(metafuncs, metaWindowsVersion, metaWindowsIfaces)
+}
+
+func metaWindowsVersion() {
+	var dst []Win32_OperatingSystem
+	q := wmi.CreateQuery(&dst, "")
+	err := wmi.Query(q, &dst)
+	if err != nil {
+		slog.Error(err)
+		return
+	}
+
+	var dstComputer []Win32_ComputerSystem
+	q = wmi.CreateQuery(&dstComputer, "")
+	err = wmi.Query(q, &dstComputer)
+	if err != nil {
+		slog.Error(err)
+		return
+	}
+
+	var dstBIOS []Win32_BIOS
+	q = wmi.CreateQuery(&dstBIOS, "")
+	err = wmi.Query(q, &dstBIOS)
+	if err != nil {
+		slog.Error(err)
+		return
+	}
+
+	for _, v := range dst {
+		AddMeta("", nil, "version", v.Version, true)
+		AddMeta("", nil, "versionCaption", v.Caption, true)
+	}
+
+	for _, v := range dstComputer {
+		AddMeta("", nil, "manufacturer", v.Manufacturer, true)
+		AddMeta("", nil, "model", v.Model, true)
+		AddMeta("", nil, "memoryTotal", v.TotalPhysicalMemory, true)
+	}
+
+	for _, v := range dstBIOS {
+		AddMeta("", nil, "serialNumber", v.SerialNumber, true)
+	}
+}
+
+type Win32_OperatingSystem struct {
+	Caption string
+	Version string
+}
+
+type Win32_ComputerSystem struct {
+	Manufacturer        string
+	Model               string
+	TotalPhysicalMemory uint64
+}
+
+type Win32_BIOS struct {
+	SerialNumber string
+}
+
+func metaWindowsIfaces() {
+	var dstConfigs []Win32_NetworkAdapterConfiguration
+	q := wmi.CreateQuery(&dstConfigs, "WHERE MACAddress != null")
+	err := wmi.Query(q, &dstConfigs)
+	if err != nil {
+		slog.Error(err)
+		return
+	}
+
+	mNicConfigs := make(map[uint32]*Win32_NetworkAdapterConfiguration)
+	for i, nic := range dstConfigs {
+		mNicConfigs[nic.InterfaceIndex] = &dstConfigs[i]
+	}
+
+	mNicTeamIDtoSpeed := make(map[string]uint64)
+	mNicTeamIDtoMaster := make(map[string]string)
+	var dstTeamMembers []MSFT_NetLbfoTeamMember
+	q = wmi.CreateQuery(&dstTeamMembers, "")
+	err = wmi.QueryNamespace(q, &dstTeamMembers, "root\\StandardCimv2")
+	if err == nil {
+		for _, teamMember := range dstTeamMembers {
+			mNicTeamIDtoSpeed[teamMember.InstanceID] = teamMember.ReceiveLinkSpeed
+			mNicTeamIDtoMaster[teamMember.InstanceID] = teamMember.Team
+		}
+	}
+
+	var dstAdapters []Win32_NetworkAdapter
+	q = wmi.CreateQuery(&dstAdapters, "WHERE PhysicalAdapter=True and MACAddress <> null and NetConnectionStatus = 2") //Only adapters with MAC addresses and status="Connected"
+	err = wmi.Query(q, &dstAdapters)
+	if err != nil {
+		slog.Error(err)
+		return
+	}
+
+	for _, v := range dstAdapters {
+		tag := opentsdb.TagSet{"iface": fmt.Sprint("Interface", v.InterfaceIndex)}
+		AddMeta("", tag, "description", v.Description, true)
+		AddMeta("", tag, "name", v.NetConnectionID, true)
+		AddMeta("", tag, "mac", strings.Replace(v.MACAddress, ":", "", -1), true)
+		if v.Speed != nil && *v.Speed != 0 {
+			AddMeta("", tag, "speed", v.Speed, true)
+		} else {
+			nicSpeed := mNicTeamIDtoSpeed[v.GUID]
+			AddMeta("", tag, "speed", nicSpeed, true)
+		}
+
+		nicMaster := mNicTeamIDtoMaster[v.GUID]
+		if nicMaster != "" {
+			AddMeta("", tag, "master", nicMaster, true)
+		}
+
+		nicConfig := mNicConfigs[v.InterfaceIndex]
+		if nicConfig != nil {
+			for _, ip := range *nicConfig.IPAddress {
+				AddMeta("", tag, "addr", ip, true) // blocked by array support in WMI See https://github.com/StackExchange/wmi/issues/5
+			}
+		}
+	}
+}
+
+type Win32_NetworkAdapter struct {
+	NetConnectionID string  //NY-WEB09-PRI-NIC-A
+	Speed           *uint64 //Bits per Second
+	Description     string  //Intel(R) Gigabit ET Quad Port Server Adapter #2
+	InterfaceIndex  uint32
+	MACAddress      string //00:1B:21:93:00:00
+	GUID            string
+}
+
+type Win32_NetworkAdapterConfiguration struct {
+	IPAddress      *[]string //Both IPv4 and IPv6
+	InterfaceIndex uint32
+}
+type MSFT_NetLbfoTeamMember struct {
+	Name             string
+	ReceiveLinkSpeed uint64
+	Team             string
+	InstanceID       string
+}

--- a/Godeps/_workspace/src/bosun.org/opentsdb/duration.go
+++ b/Godeps/_workspace/src/bosun.org/opentsdb/duration.go
@@ -1,0 +1,154 @@
+// Copyright 2010 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package opentsdb
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+const (
+	Millisecond Duration = Duration(time.Millisecond)
+	Second               = 1000 * Millisecond
+	Minute               = 60 * Second
+	Hour                 = 60 * Minute
+	Day                  = Hour * 24
+	Week                 = Day * 7
+	Month                = Day * 30
+	Year                 = Day * 365
+)
+
+// Duration extends time.Duration to support OpenTSDB time-format specifiers:
+// http://opentsdb.net/docs/build/html/user_guide/query/dates.html#relative.
+type Duration time.Duration
+
+var unitMap = map[string]float64{
+	"ms": float64(time.Millisecond),
+	"s":  float64(time.Second),
+	"m":  float64(time.Minute),
+	"h":  float64(time.Hour),
+	"d":  float64(time.Hour) * 24,
+	"w":  float64(time.Hour) * 24 * 7,
+	"n":  float64(time.Hour) * 24 * 30,
+	"y":  float64(time.Hour) * 24 * 365,
+}
+
+// ParseDuration is equivalent to time.ParseDuration, but supports time units specified at http://opentsdb.net/docs/build/html/user_guide/query/dates.html.
+func ParseDuration(s string) (Duration, error) {
+	// [-+]?([0-9]*(\.[0-9]*)?[a-z]+)+
+	orig := s
+	f := float64(0)
+	neg := false
+
+	// Consume [-+]?
+	if s != "" {
+		c := s[0]
+		if c == '-' || c == '+' {
+			neg = c == '-'
+			s = s[1:]
+		}
+	}
+	// Special case: if all that is left is "0", this is zero.
+	if s == "0" {
+		return 0, nil
+	}
+	if s == "" {
+		return 0, errors.New("time: invalid duration " + orig)
+	}
+	for s != "" {
+		g := float64(0) // this element of the sequence
+
+		var x int64
+		var err error
+
+		// The next character must be [0-9.]
+		if !(s[0] == '.' || ('0' <= s[0] && s[0] <= '9')) {
+			return 0, errors.New("time: invalid duration " + orig)
+		}
+		// Consume [0-9]*
+		pl := len(s)
+		x, s, err = leadingInt(s)
+		if err != nil {
+			return 0, errors.New("time: invalid duration " + orig)
+		}
+		g = float64(x)
+		pre := pl != len(s) // whether we consumed anything before a period
+
+		// Consume (\.[0-9]*)?
+		post := false
+		if s != "" && s[0] == '.' {
+			s = s[1:]
+			pl := len(s)
+			x, s, err = leadingInt(s)
+			if err != nil {
+				return 0, errors.New("time: invalid duration " + orig)
+			}
+			scale := 1.0
+			for n := pl - len(s); n > 0; n-- {
+				scale *= 10
+			}
+			g += float64(x) / scale
+			post = pl != len(s)
+		}
+		if !pre && !post {
+			// no digits (e.g. ".s" or "-.s")
+			return 0, errors.New("time: invalid duration " + orig)
+		}
+
+		// Consume unit.
+		i := 0
+		for ; i < len(s); i++ {
+			c := s[i]
+			if c == '.' || ('0' <= c && c <= '9') {
+				break
+			}
+		}
+		if i == 0 {
+			return 0, errors.New("time: missing unit in duration " + orig)
+		}
+		u := s[:i]
+		s = s[i:]
+		unit, ok := unitMap[u]
+		if !ok {
+			return 0, errors.New("time: unknown unit " + u + " in duration " + orig)
+		}
+
+		f += g * unit
+	}
+
+	if neg {
+		f = -f
+	}
+	return Duration(f), nil
+}
+
+var errLeadingInt = errors.New("time: bad [0-9]*") // never printed
+
+// leadingInt consumes the leading [0-9]* from s.
+func leadingInt(s string) (x int64, rem string, err error) {
+	i := 0
+	for ; i < len(s); i++ {
+		c := s[i]
+		if c < '0' || c > '9' {
+			break
+		}
+		if x >= (1<<63-10)/10 {
+			// overflow
+			return 0, "", errLeadingInt
+		}
+		x = x*10 + int64(c) - '0'
+	}
+	return x, s[i:], nil
+}
+
+func (d Duration) String() string {
+	return fmt.Sprintf("%dms", time.Duration(d).Nanoseconds()/1e6)
+}
+
+// Seconds returns the duration as a floating point number of seconds.
+func (d Duration) Seconds() float64 {
+	return time.Duration(d).Seconds()
+}

--- a/Godeps/_workspace/src/bosun.org/opentsdb/tsdb.go
+++ b/Godeps/_workspace/src/bosun.org/opentsdb/tsdb.go
@@ -1,0 +1,848 @@
+// Package opentsdb defines structures for interacting with an OpenTSDB server.
+package opentsdb
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math"
+	"math/big"
+	"net/http"
+	"net/url"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf8"
+)
+
+// ResponseSet is a Multi-Set Response:
+// http://opentsdb.net/docs/build/html/api_http/query/index.html#example-multi-set-response.
+type ResponseSet []*Response
+
+func (r ResponseSet) Copy() ResponseSet {
+	newSet := make(ResponseSet, len(r))
+	for i, resp := range r {
+		newSet[i] = resp.Copy()
+	}
+	return newSet
+}
+
+// Point is the Response data point type.
+type Point float64
+
+// Response is a query response:
+// http://opentsdb.net/docs/build/html/api_http/query/index.html#response.
+type Response struct {
+	Metric        string           `json:"metric"`
+	Tags          TagSet           `json:"tags"`
+	AggregateTags []string         `json:"aggregateTags"`
+	DPS           map[string]Point `json:"dps"`
+}
+
+func (r *Response) Copy() *Response {
+	newR := Response{}
+	newR.Metric = r.Metric
+	newR.Tags = r.Tags.Copy()
+	copy(newR.AggregateTags, r.AggregateTags)
+	newR.DPS = map[string]Point{}
+	for k, v := range r.DPS {
+		newR.DPS[k] = v
+	}
+	return &newR
+}
+
+// DataPoint is a data point for the /api/put route:
+// http://opentsdb.net/docs/build/html/api_http/put.html#example-single-data-point-put.
+type DataPoint struct {
+	Metric    string      `json:"metric"`
+	Timestamp int64       `json:"timestamp"`
+	Value     interface{} `json:"value"`
+	Tags      TagSet      `json:"tags"`
+}
+
+// MarshalJSON verifies d is valid and converts it to JSON.
+func (d *DataPoint) MarshalJSON() ([]byte, error) {
+	if err := d.clean(); err != nil {
+		return nil, err
+	}
+	return json.Marshal(struct {
+		Metric    string      `json:"metric"`
+		Timestamp int64       `json:"timestamp"`
+		Value     interface{} `json:"value"`
+		Tags      TagSet      `json:"tags"`
+	}{
+		d.Metric,
+		d.Timestamp,
+		d.Value,
+		d.Tags,
+	})
+}
+
+// Valid returns whether d contains valid data (populated fields, valid tags)
+// for submission to OpenTSDB.
+func (d *DataPoint) Valid() bool {
+	if d.Metric == "" || d.Timestamp == 0 || d.Value == nil || !d.Tags.Valid() {
+		return false
+	}
+	if _, err := strconv.ParseFloat(fmt.Sprint(d.Value), 64); err != nil {
+		return false
+	}
+	return true
+}
+
+// MultiDataPoint holds multiple DataPoints:
+// http://opentsdb.net/docs/build/html/api_http/put.html#example-multiple-data-point-put.
+type MultiDataPoint []*DataPoint
+
+// TagSet is a helper class for tags.
+type TagSet map[string]string
+
+// Copy creates a new TagSet from t.
+func (t TagSet) Copy() TagSet {
+	n := make(TagSet)
+	for k, v := range t {
+		n[k] = v
+	}
+	return n
+}
+
+// Merge adds or overwrites everything from o into t and returns t.
+func (t TagSet) Merge(o TagSet) TagSet {
+	for k, v := range o {
+		t[k] = v
+	}
+	return t
+}
+
+// Equal returns true if t and o contain only the same k=v pairs.
+func (t TagSet) Equal(o TagSet) bool {
+	if len(t) != len(o) {
+		return false
+	}
+	for k, v := range t {
+		if ov, ok := o[k]; !ok || ov != v {
+			return false
+		}
+	}
+	return true
+}
+
+// Subset returns true if all k=v pairs in o are in t.
+func (t TagSet) Subset(o TagSet) bool {
+	if len(o) > len(t) {
+		return false
+	}
+	for k, v := range o {
+		if tv, ok := t[k]; !ok || tv != v {
+			return false
+		}
+	}
+	return true
+}
+
+// Compatible returns true if all keys that are in both o and t, have the same value.
+func (t TagSet) Compatible(o TagSet) bool {
+	for k, v := range o {
+		if tv, ok := t[k]; ok && tv != v {
+			return false
+		}
+	}
+	return true
+}
+
+// Intersection returns the intersection of t and o.
+func (t TagSet) Intersection(o TagSet) TagSet {
+	r := make(TagSet)
+	for k, v := range t {
+		if o[k] == v {
+			r[k] = v
+		}
+	}
+	return r
+}
+
+// String converts t to an OpenTSDB-style {a=b,c=b} string, alphabetized by key.
+func (t TagSet) String() string {
+	return fmt.Sprintf("{%s}", t.Tags())
+}
+
+// Tags is identical to String() but without { and }.
+func (t TagSet) Tags() string {
+	var keys []string
+	for k := range t {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	b := &bytes.Buffer{}
+	for i, k := range keys {
+		if i > 0 {
+			fmt.Fprint(b, ",")
+		}
+		fmt.Fprintf(b, "%s=%s", k, t[k])
+	}
+	return b.String()
+}
+
+// Returns true if the two tagsets "overlap".
+// Two tagsets overlap if they:
+// 1. Have at least one key/value pair that matches
+// 2. Have no keys in common where the values do not match
+func (a TagSet) Overlaps(b TagSet) bool {
+	anyMatch := false
+	for k, v := range a {
+		v2, ok := b[k]
+		if !ok {
+			continue
+		}
+		if v2 != v {
+			return false
+		}
+		anyMatch = true
+	}
+	return anyMatch
+}
+
+// Valid returns whether t contains OpenTSDB-submittable tags.
+func (t TagSet) Valid() bool {
+	if len(t) == 0 {
+		return true
+	}
+	_, err := ParseTags(t.Tags())
+	return err == nil
+}
+
+func (d *DataPoint) clean() error {
+	if err := d.Tags.Clean(); err != nil {
+		return err
+	}
+	m, err := Clean(d.Metric)
+	if err != nil {
+		return fmt.Errorf("cleaning metric %s: %s", d.Metric, err)
+	}
+	if d.Metric != m {
+		d.Metric = m
+	}
+	switch v := d.Value.(type) {
+	case string:
+		if i, err := strconv.ParseInt(v, 10, 64); err == nil {
+			d.Value = i
+		} else if f, err := strconv.ParseFloat(v, 64); err == nil {
+			d.Value = f
+		} else {
+			return fmt.Errorf("Unparseable number %v", v)
+		}
+	case uint64:
+		if v > math.MaxInt64 {
+			d.Value = float64(v)
+		}
+	case *big.Int:
+		if bigMaxInt64.Cmp(v) < 0 {
+			if f, err := strconv.ParseFloat(v.String(), 64); err == nil {
+				d.Value = f
+			}
+		}
+	}
+	return nil
+}
+
+var bigMaxInt64 = big.NewInt(math.MaxInt64)
+
+// Clean removes characters from t that are invalid for OpenTSDB metric and tag
+// values. An error is returned if a resulting tag is empty.
+func (t TagSet) Clean() error {
+	for k, v := range t {
+		kc, err := Clean(k)
+		if err != nil {
+			return fmt.Errorf("cleaning tag %s: %s", k, err)
+		}
+		vc, err := Clean(v)
+		if err != nil {
+			return fmt.Errorf("cleaning key %s: %s", v, err)
+		}
+		if kc != k || vc != v {
+			delete(t, k)
+			t[kc] = vc
+		}
+	}
+	return nil
+}
+
+// Clean is Replace with an empty replacement string.
+func Clean(s string) (string, error) {
+	return Replace(s, "")
+}
+
+// Replace removes characters from s that are invalid for OpenTSDB metric and
+// tag values and replaces them.
+// See: http://opentsdb.net/docs/build/html/user_guide/writing.html#metrics-and-tags
+func Replace(s, replacement string) (string, error) {
+	var c string
+	replaced := false
+	for len(s) > 0 {
+		r, size := utf8.DecodeRuneInString(s)
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '-' || r == '_' || r == '.' || r == '/' {
+			c += string(r)
+			replaced = false
+		} else if !replaced {
+			c += replacement
+			replaced = true
+		}
+		s = s[size:]
+	}
+	if len(c) == 0 {
+		return "", fmt.Errorf("clean result is empty")
+	}
+	return c, nil
+}
+
+// MustReplace is like Replace, but returns an empty string on error.
+func MustReplace(s, replacement string) string {
+	r, err := Replace(s, replacement)
+	if err != nil {
+		return ""
+	}
+	return r
+}
+
+// Request holds query objects:
+// http://opentsdb.net/docs/build/html/api_http/query/index.html#requests.
+type Request struct {
+	Start             interface{} `json:"start"`
+	End               interface{} `json:"end,omitempty"`
+	Queries           []*Query    `json:"queries"`
+	NoAnnotations     bool        `json:"noAnnotations,omitempty"`
+	GlobalAnnotations bool        `json:"globalAnnotations,omitempty"`
+	MsResolution      bool        `json:"msResolution,omitempty"`
+	ShowTSUIDs        bool        `json:"showTSUIDs,omitempty"`
+}
+
+// RequestFromJSON creates a new request from JSON.
+func RequestFromJSON(b []byte) (*Request, error) {
+	var r Request
+	if err := json.Unmarshal(b, &r); err != nil {
+		return nil, err
+	}
+	r.Start = TryParseAbsTime(r.Start)
+	r.End = TryParseAbsTime(r.End)
+	return &r, nil
+}
+
+// Query is a query for a request:
+// http://opentsdb.net/docs/build/html/api_http/query/index.html#sub-queries.
+type Query struct {
+	Aggregator  string      `json:"aggregator"`
+	Metric      string      `json:"metric"`
+	Rate        bool        `json:"rate,omitempty"`
+	RateOptions RateOptions `json:"rateOptions,omitempty"`
+	Downsample  string      `json:"downsample,omitempty"`
+	Tags        TagSet      `json:"tags,omitempty"`
+}
+
+// RateOptions are rate options for a query.
+type RateOptions struct {
+	Counter    bool  `json:"counter,omitempty"`
+	CounterMax int64 `json:"counterMax,omitempty"`
+	ResetValue int64 `json:"resetValue,omitempty"`
+}
+
+// ParseRequest parses OpenTSDB requests of the form: start=1h-ago&m=avg:cpu.
+func ParseRequest(req string) (*Request, error) {
+	v, err := url.ParseQuery(req)
+	if err != nil {
+		return nil, err
+	}
+	r := Request{}
+	s := v.Get("start")
+	if s == "" {
+		return nil, fmt.Errorf("opentsdb: missing start: %s", req)
+	}
+	r.Start = s
+	for _, m := range v["m"] {
+		q, err := ParseQuery(m)
+		if err != nil {
+			return nil, err
+		}
+		r.Queries = append(r.Queries, q)
+	}
+	if len(r.Queries) == 0 {
+		return nil, fmt.Errorf("opentsdb: missing m: %s", req)
+	}
+	return &r, nil
+}
+
+var qRE = regexp.MustCompile(`^(\w+):(?:(\w+-\w+):)?(?:(rate.*):)?([\w./-]+)(?:\{([\w./,=*-|]+)\})?$`)
+
+// ParseQuery parses OpenTSDB queries of the form: avg:rate:cpu{k=v}. Validation
+// errors will be returned along with a valid Query.
+func ParseQuery(query string) (q *Query, err error) {
+	q = new(Query)
+	m := qRE.FindStringSubmatch(query)
+	if m == nil {
+		return nil, fmt.Errorf("opentsdb: bad query format: %s", query)
+	}
+	q.Aggregator = m[1]
+	q.Downsample = m[2]
+	q.Rate = strings.HasPrefix(m[3], "rate")
+	if q.Rate && len(m[3]) > 4 {
+		s := m[3][4:]
+		if !strings.HasSuffix(s, "}") || !strings.HasPrefix(s, "{") {
+			err = fmt.Errorf("opentsdb: invalid rate options")
+			return
+		}
+		sp := strings.Split(s[1:len(s)-1], ",")
+		q.RateOptions.Counter = sp[0] == "counter"
+		if len(sp) > 1 {
+			if sp[1] != "" {
+				if q.RateOptions.CounterMax, err = strconv.ParseInt(sp[1], 10, 64); err != nil {
+					return
+				}
+			}
+		}
+		if len(sp) > 2 {
+			if q.RateOptions.ResetValue, err = strconv.ParseInt(sp[2], 10, 64); err != nil {
+				return
+			}
+		}
+	}
+	q.Metric = m[4]
+	if m[5] != "" {
+		tags, e := ParseTags(m[5])
+		if e != nil {
+			err = e
+			if tags == nil {
+				return
+			}
+		}
+		q.Tags = tags
+	}
+	return
+}
+
+// ParseTags parses OpenTSDB tagk=tagv pairs of the form: k=v,m=o. Validation
+// errors do not stop processing, and will return a non-nil TagSet.
+func ParseTags(t string) (TagSet, error) {
+	ts := make(TagSet)
+	var err error
+	for _, v := range strings.Split(t, ",") {
+		sp := strings.SplitN(v, "=", 2)
+		if len(sp) != 2 {
+			return nil, fmt.Errorf("opentsdb: bad tag: %s", v)
+		}
+		for i, s := range sp {
+			sp[i] = strings.TrimSpace(s)
+			if i > 0 {
+				continue
+			}
+			if !ValidTag(sp[i]) {
+				err = fmt.Errorf("invalid character in %s", sp[i])
+			}
+		}
+		for _, s := range strings.Split(sp[1], "|") {
+			if s == "*" {
+				continue
+			}
+			if !ValidTag(s) {
+				err = fmt.Errorf("invalid character in %s", sp[1])
+			}
+		}
+		if _, present := ts[sp[0]]; present {
+			return nil, fmt.Errorf("opentsdb: duplicated tag: %s", v)
+		}
+		ts[sp[0]] = sp[1]
+	}
+	return ts, err
+}
+
+// ValidTag returns true if s is a valid metric or tag.
+func ValidTag(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, c := range s {
+		switch {
+		case c >= 'a' && c <= 'z':
+		case c >= 'A' && c <= 'Z':
+		case c >= '0' && c <= '9':
+		case strings.ContainsAny(string(c), `-_./`):
+		case unicode.IsLetter(c):
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+var groupRE = regexp.MustCompile("{[^}]+}")
+
+// ReplaceTags replaces all tag-like strings with tags from the given
+// group. For example, given the string "test.metric{host=*}" and a TagSet
+// with host=test.com, this returns "test.metric{host=test.com}".
+func ReplaceTags(text string, group TagSet) string {
+	return groupRE.ReplaceAllStringFunc(text, func(s string) string {
+		tags, err := ParseTags(s[1 : len(s)-1])
+		if err != nil {
+			return s
+		}
+		for k := range tags {
+			if group[k] != "" {
+				tags[k] = group[k]
+			}
+		}
+		return fmt.Sprintf("{%s}", tags.Tags())
+	})
+}
+
+func (q Query) String() string {
+	s := q.Aggregator + ":"
+	if q.Downsample != "" {
+		s += q.Downsample + ":"
+	}
+	if q.Rate {
+		s += "rate"
+		if q.RateOptions.Counter {
+			s += "{counter"
+			if q.RateOptions.CounterMax != 0 {
+				s += ","
+				s += strconv.FormatInt(q.RateOptions.CounterMax, 10)
+			}
+			if q.RateOptions.ResetValue != 0 {
+				if q.RateOptions.CounterMax == 0 {
+					s += ","
+				}
+				s += ","
+				s += strconv.FormatInt(q.RateOptions.ResetValue, 10)
+			}
+			s += "}"
+		}
+		s += ":"
+	}
+	s += q.Metric
+	if len(q.Tags) > 0 {
+		s += q.Tags.String()
+	}
+	return s
+}
+
+func (r *Request) String() string {
+	v := make(url.Values)
+	for _, q := range r.Queries {
+		v.Add("m", q.String())
+	}
+	if start, err := CanonicalTime(r.Start); err == nil {
+		v.Add("start", start)
+	}
+	if end, err := CanonicalTime(r.End); err == nil {
+		v.Add("end", end)
+	}
+	return v.Encode()
+}
+
+// Search returns a string suitable for OpenTSDB's `/` route.
+func (r *Request) Search() string {
+	// OpenTSDB uses the URL hash, not search parameters, to do this. The values are
+	// not URL encoded. So it's the same as a url.Values just left as normal
+	// strings.
+	v, err := url.ParseQuery(r.String())
+	if err != nil {
+		return ""
+	}
+	buf := &bytes.Buffer{}
+	for k, values := range v {
+		for _, value := range values {
+			fmt.Fprintf(buf, "%s=%s&", k, value)
+		}
+	}
+	return buf.String()
+}
+
+// TSDBTimeFormat is the OpenTSDB-required time format for the time package.
+const TSDBTimeFormat = "2006/01/02-15:04:05"
+
+// CanonicalTime converts v to a string for use with OpenTSDB's `/` route.
+func CanonicalTime(v interface{}) (string, error) {
+	if s, ok := v.(string); ok {
+		if strings.HasSuffix(s, "-ago") {
+			return s, nil
+		}
+	}
+	t, err := ParseTime(v)
+	if err != nil {
+		return "", err
+	}
+	return t.Format(TSDBTimeFormat), nil
+}
+
+// TryParseAbsTime attempts to parse v as an absolute time. It may be a string
+// in the format of TSDBTimeFormat or a float64 of seconds since epoch. If so,
+// the epoch as an int64 is returned. Otherwise, v is returned.
+func TryParseAbsTime(v interface{}) interface{} {
+	switch v := v.(type) {
+	case string:
+		d, err := ParseAbsTime(v)
+		if err == nil {
+			return d.Unix()
+		}
+	case float64:
+		return int64(v)
+	}
+	return v
+}
+
+// ParseAbsTime returns the time of s, which must be of any non-relative (not
+// "X-ago") format supported by OpenTSDB.
+func ParseAbsTime(s string) (time.Time, error) {
+	var t time.Time
+	tFormats := [4]string{
+		"2006/01/02-15:04:05",
+		"2006/01/02-15:04",
+		"2006/01/02-15",
+		"2006/01/02",
+	}
+	for _, f := range tFormats {
+		if t, err := time.Parse(f, s); err == nil {
+			return t, nil
+		}
+	}
+	i, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		return t, err
+	}
+	return time.Unix(i, 0), nil
+}
+
+// ParseTime returns the time of v, which can be of any format supported by
+// OpenTSDB.
+func ParseTime(v interface{}) (time.Time, error) {
+	now := time.Now().UTC()
+	switch i := v.(type) {
+	case string:
+		if i != "" {
+			if strings.HasSuffix(i, "-ago") {
+				s := strings.TrimSuffix(i, "-ago")
+				d, err := ParseDuration(s)
+				if err != nil {
+					return now, err
+				}
+				return now.Add(time.Duration(-d)), nil
+			}
+			return ParseAbsTime(i)
+		}
+		return now, nil
+	case int64:
+		return time.Unix(i, 0).UTC(), nil
+	case float64:
+		return time.Unix(int64(i), 0).UTC(), nil
+	default:
+		return time.Time{}, fmt.Errorf("type must be string or int64, got: %v", v)
+	}
+}
+
+// GetDuration returns the duration from the request's start to end.
+func GetDuration(r *Request) (Duration, error) {
+	var t Duration
+	if v, ok := r.Start.(string); ok && v == "" {
+		return t, errors.New("start time must be provided")
+	}
+	start, err := ParseTime(r.Start)
+	if err != nil {
+		return t, err
+	}
+	var end time.Time
+	if r.End != nil {
+		end, err = ParseTime(r.End)
+		if err != nil {
+			return t, err
+		}
+	} else {
+		end = time.Now()
+	}
+	t = Duration(end.Sub(start))
+	return t, nil
+}
+
+// AutoDownsample sets the avg downsample aggregator to produce l points.
+func (r *Request) AutoDownsample(l int) error {
+	if l == 0 {
+		return errors.New("opentsdb: target length must be > 0")
+	}
+	cd, err := GetDuration(r)
+	if err != nil {
+		return err
+	}
+	d := cd / Duration(l)
+	ds := ""
+	if d > Duration(time.Second)*15 {
+		ds = fmt.Sprintf("%ds-avg", int64(d.Seconds()))
+	}
+	for _, q := range r.Queries {
+		q.Downsample = ds
+	}
+	return nil
+}
+
+// SetTime adjusts the start and end time of the request to assume t is now.
+// Relative times ("1m-ago") are changed to absolute times. Existing absolute
+// times are adjusted by the difference between time.Now() and t.
+func (r *Request) SetTime(t time.Time) error {
+	diff := -time.Since(t)
+	start, err := ParseTime(r.Start)
+	if err != nil {
+		return err
+	}
+	r.Start = start.Add(diff).Unix()
+	if r.End != nil {
+		end, err := ParseTime(r.End)
+		if err != nil {
+			return err
+		}
+		r.End = end.Add(diff).Unix()
+	} else {
+		r.End = t.UTC().Unix()
+	}
+	return nil
+}
+
+// Query performs a v2 OpenTSDB request to the given host. host should be of the
+// form hostname:port. Uses DefaultClient. Can return a RequestError.
+func (r *Request) Query(host string) (ResponseSet, error) {
+	resp, err := r.QueryResponse(host, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	var tr ResponseSet
+	if err := json.NewDecoder(resp.Body).Decode(&tr); err != nil {
+		return nil, err
+	}
+	return tr, nil
+}
+
+// DefaultClient is the default http client for requests.
+var DefaultClient = &http.Client{
+	Timeout: time.Minute,
+}
+
+// QueryResponse performs a v2 OpenTSDB request to the given host. host should
+// be of the form hostname:port. A nil client uses DefaultClient.
+func (r *Request) QueryResponse(host string, client *http.Client) (*http.Response, error) {
+	u := url.URL{
+		Scheme: "http",
+		Host:   host,
+		Path:   "/api/query",
+	}
+	b, err := json.Marshal(&r)
+	if err != nil {
+		return nil, err
+	}
+	if client == nil {
+		client = DefaultClient
+	}
+	resp, err := client.Post(u.String(), "application/json", bytes.NewReader(b))
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		e := RequestError{Request: string(b)}
+		defer resp.Body.Close()
+		body, _ := ioutil.ReadAll(resp.Body)
+		if err := json.NewDecoder(bytes.NewBuffer(body)).Decode(&e); err == nil {
+			return nil, &e
+		}
+		s := fmt.Sprintf("opentsdb: %s", resp.Status)
+		if len(body) > 0 {
+			s = fmt.Sprintf("%s: %s", s, body)
+		}
+		return nil, errors.New(s)
+	}
+	return resp, nil
+}
+
+// RequestError is the error structure for request errors.
+type RequestError struct {
+	Request string
+	Err     struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+		Details string `json:"details"`
+	} `json:"error"`
+}
+
+func (r *RequestError) Error() string {
+	return fmt.Sprintf("opentsdb: %s: %s", r.Request, r.Err.Message)
+}
+
+// Context is the interface for querying an OpenTSDB server.
+type Context interface {
+	Query(*Request) (ResponseSet, error)
+}
+
+// Host is a simple OpenTSDB Context with no additional features.
+type Host string
+
+// Query performs the request to the OpenTSDB server.
+func (h Host) Query(r *Request) (ResponseSet, error) {
+	return r.Query(string(h))
+}
+
+// LimitContext is a context that enables limiting response size and filtering tags
+type LimitContext struct {
+	Host string
+	// Limit limits response size in bytes
+	Limit int64
+	// FilterTags removes tagks from results if that tagk was not in the request
+	FilterTags bool
+}
+
+// NewLimitContext returns a new context for the given host with response sizes limited
+// to limit bytes.
+func NewLimitContext(host string, limit int64) *LimitContext {
+	return &LimitContext{
+		Host:       host,
+		Limit:      limit,
+		FilterTags: true,
+	}
+}
+
+// Query returns the result of the request. r may be cached. The request is
+// byte-limited and filtered by c's properties.
+func (c *LimitContext) Query(r *Request) (tr ResponseSet, err error) {
+	resp, err := r.QueryResponse(c.Host, nil)
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+	lr := &io.LimitedReader{R: resp.Body, N: c.Limit}
+	err = json.NewDecoder(lr).Decode(&tr)
+	if lr.N == 0 {
+		err = fmt.Errorf("TSDB response too large: limited to %E bytes", float64(c.Limit))
+		return
+	}
+	if err != nil {
+		return
+	}
+	if c.FilterTags {
+		FilterTags(r, tr)
+	}
+	return
+}
+
+// FilterTags removes tagks in tr not present in r. Does nothing in the event of
+// multiple queries in the request.
+func FilterTags(r *Request, tr ResponseSet) {
+	if len(r.Queries) != 1 {
+		return
+	}
+	for _, resp := range tr {
+		for k := range resp.Tags {
+			if _, present := r.Queries[0].Tags[k]; !present {
+				delete(resp.Tags, k)
+			}
+		}
+	}
+}

--- a/Godeps/_workspace/src/bosun.org/opentsdb/tsdb_test.go
+++ b/Godeps/_workspace/src/bosun.org/opentsdb/tsdb_test.go
@@ -1,0 +1,175 @@
+package opentsdb
+
+import "testing"
+
+func TestClean(t *testing.T) {
+	clean := "aoeSNVT152-./_"
+	if c, err := Clean(clean); c != clean {
+		t.Error("was clean", clean)
+	} else if err != nil {
+		t.Fatal(err)
+	}
+	notclean := "euon@#$sar:.03   n  ]e/"
+	notcleaned := "euonsar.03ne/"
+	if c, err := Clean(notclean); c != notcleaned {
+		t.Error("wasn't cleaned", notclean, "into:", c)
+	} else if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestParseQuery(t *testing.T) {
+	tests := []struct {
+		query string
+		error bool
+	}{
+		{"sum:10m-avg:proc.stat.cpu{t=v,o=k}", false},
+		{"sum:10m-avg:rate:proc.stat.cpu", false},
+		{"sum:10m-avg:rate{counter,1,2}:proc.stat.cpu{t=v,o=k}", false},
+		{"sum:proc.stat.cpu", false},
+		{"sum:rate:proc.stat.cpu{t=v,o=k}", false},
+
+		{"", true},
+		{"sum:cpu+", true},
+		{"sum:cpu{}", true},
+		{"sum:stat{a=b=c}", true},
+	}
+	for _, q := range tests {
+		_, err := ParseQuery(q.query)
+		if err != nil && !q.error {
+			t.Errorf("got error: %s: %s", q.query, err)
+		} else if err == nil && q.error {
+			t.Errorf("expected error: %s", q.query)
+		}
+	}
+}
+
+func TestParseRequest(t *testing.T) {
+	tests := []struct {
+		query string
+		error bool
+	}{
+		{"start=1&m=sum:c", false},
+		{"start=1&m=sum:c&end=2", false},
+		{"start=1&m=sum:10m-avg:rate:proc.stat.cpu{t=v,o=k}", false},
+
+		{"start=&m=", true},
+		{"m=sum:c", true},
+		{"start=1", true},
+	}
+	for _, q := range tests {
+		_, err := ParseRequest(q.query)
+		if err != nil && !q.error {
+			t.Errorf("got error: %s: %s", q.query, err)
+		} else if err == nil && q.error {
+			t.Errorf("expected error: %s", q.query)
+		}
+	}
+}
+
+func TestQueryString(t *testing.T) {
+	tests := []struct {
+		in  Query
+		out string
+	}{
+		{
+			Query{
+				Aggregator: "avg",
+				Metric:     "test.metric",
+				Rate:       true,
+				RateOptions: RateOptions{
+					Counter:    true,
+					CounterMax: 1,
+					ResetValue: 2,
+				},
+			},
+			"avg:rate{counter,1,2}:test.metric",
+		},
+		{
+			Query{
+				Aggregator: "avg",
+				Metric:     "test.metric",
+				Rate:       true,
+				RateOptions: RateOptions{
+					Counter:    true,
+					CounterMax: 1,
+				},
+			},
+			"avg:rate{counter,1}:test.metric",
+		},
+		{
+			Query{
+				Aggregator: "avg",
+				Metric:     "test.metric",
+				Rate:       true,
+				RateOptions: RateOptions{
+					Counter: true,
+				},
+			},
+			"avg:rate{counter}:test.metric",
+		},
+		{
+			Query{
+				Aggregator: "avg",
+				Metric:     "test.metric",
+				Rate:       true,
+				RateOptions: RateOptions{
+					CounterMax: 1,
+					ResetValue: 2,
+				},
+			},
+			"avg:rate:test.metric",
+		},
+		{
+			Query{
+				Aggregator: "avg",
+				Metric:     "test.metric",
+				RateOptions: RateOptions{
+					Counter:    true,
+					CounterMax: 1,
+					ResetValue: 2,
+				},
+			},
+			"avg:test.metric",
+		},
+	}
+	for _, q := range tests {
+		s := q.in.String()
+		if s != q.out {
+			t.Errorf(`got "%s", expected "%s"`, s, q.out)
+		}
+	}
+}
+
+func TestValidTag(t *testing.T) {
+	tests := map[string]bool{
+		"abcXYZ012_./-": true,
+
+		"":    false,
+		"a|c": false,
+		"a=b": false,
+	}
+	for s, v := range tests {
+		r := ValidTag(s)
+		if v != r {
+			t.Errorf("%v: got %v, expected %v", s, r, v)
+		}
+	}
+}
+
+func TestValidTags(t *testing.T) {
+	tests := map[string]bool{
+		"a=b|c,d=*": true,
+
+		"":        false,
+		"a=b,a=c": false,
+		"a=b=c":   false,
+	}
+	for s, v := range tests {
+		_, err := ParseTags(s)
+		r := err == nil
+		if v != r {
+			t.Errorf("%v: got %v, expected %v", s, r, v)
+		}
+	}
+}

--- a/Godeps/_workspace/src/bosun.org/slog/README.md
+++ b/Godeps/_workspace/src/bosun.org/slog/README.md
@@ -1,0 +1,4 @@
+slog
+====
+
+Cross-platform logger for Go

--- a/Godeps/_workspace/src/bosun.org/slog/slog.go
+++ b/Godeps/_workspace/src/bosun.org/slog/slog.go
@@ -1,0 +1,152 @@
+// Package slog provides a cross-platform logging interface. It is designed to
+// provide a universal logging interface on any operating system. It defaults to
+// using the log package of the standard library, but can easily be used with
+// other logging backends. Thus, we can use syslog on unicies and the event log
+// on windows.
+package slog
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+var (
+	// LogLineNumber prints the file and line number of the caller.
+	LogLineNumber = true
+)
+
+// Logger is the slog logging interface.
+type Logger interface {
+	Error(v string)
+	Info(v string)
+	Warning(v string)
+	Fatal(v string)
+}
+
+// StdLog logs to a log.Logger.
+type StdLog struct {
+	Log *log.Logger
+}
+
+// Fatal logs a fatal message and calls os.Exit(1).
+func (s *StdLog) Fatal(v string) {
+	s.Log.Fatalln("fatal:", rmNl(v))
+}
+
+// Error logs an error message.
+func (s *StdLog) Error(v string) {
+	s.Log.Println("error:", rmNl(v))
+}
+
+// Info logs an info message.
+func (s *StdLog) Info(v string) {
+	s.Log.Println("info:", rmNl(v))
+}
+
+// Warning logs a warning message.
+func (s *StdLog) Warning(v string) {
+	s.Log.Println("warning:", rmNl(v))
+}
+
+func rmNl(v string) string {
+	if strings.HasSuffix(v, "\n") {
+		v = v[:len(v)-1]
+	}
+	return v
+}
+
+var logging Logger = &StdLog{Log: log.New(os.Stderr, "", log.LstdFlags)}
+
+// Set configures l to be the default logger for slog.
+func Set(l Logger) {
+	logging = l
+}
+
+// Info logs an info message.
+func Info(v ...interface{}) {
+	output(logging.Info, v...)
+}
+
+// Infof logs an info message.
+func Infof(format string, v ...interface{}) {
+	outputf(logging.Info, format, v...)
+}
+
+// Infoln logs an info message.
+func Infoln(v ...interface{}) {
+	outputln(logging.Info, v...)
+}
+
+// Warning logs a warning message.
+func Warning(v ...interface{}) {
+	output(logging.Warning, v...)
+}
+
+// Warningf logs a warning message.
+func Warningf(format string, v ...interface{}) {
+	outputf(logging.Warning, format, v...)
+}
+
+// Warningln logs a warning message.
+func Warningln(v ...interface{}) {
+	outputln(logging.Warning, v...)
+}
+
+// Error logs an error message.
+func Error(v ...interface{}) {
+	output(logging.Error, v...)
+}
+
+// Errorf logs an error message.
+func Errorf(format string, v ...interface{}) {
+	outputf(logging.Error, format, v...)
+}
+
+// Errorln logs an error message.
+func Errorln(v ...interface{}) {
+	outputln(logging.Error, v...)
+}
+
+// Fatal logs a fatal message and calls os.Exit(1).
+func Fatal(v ...interface{}) {
+	output(logging.Fatal, v...)
+	// Call os.Exit here just in case the logging package we are using doesn't.
+	os.Exit(1)
+}
+
+// Fatalf logs a fatal message and calls os.Exit(1).
+func Fatalf(format string, v ...interface{}) {
+	outputf(logging.Fatal, format, v...)
+	os.Exit(1)
+}
+
+// Fatalln logs a fatal message and calls os.Exit(1).
+func Fatalln(v ...interface{}) {
+	outputln(logging.Fatal, v...)
+	os.Exit(1)
+}
+
+func out(f func(string), s string) {
+	if LogLineNumber {
+		if _, filename, line, ok := runtime.Caller(3); ok {
+			s = fmt.Sprintf("%s:%d: %v", filepath.Base(filename), line, s)
+		}
+	}
+	f(s)
+}
+
+func output(f func(string), v ...interface{}) {
+	out(f, fmt.Sprint(v...))
+}
+
+func outputf(f func(string), format string, v ...interface{}) {
+	out(f, fmt.Sprintf(format, v...))
+}
+
+func outputln(f func(string), v ...interface{}) {
+	out(f, fmt.Sprintln(v...))
+}

--- a/Godeps/_workspace/src/bosun.org/slog/slog_unix.go
+++ b/Godeps/_workspace/src/bosun.org/slog/slog_unix.go
@@ -1,0 +1,41 @@
+// +build !windows,!nacl,!plan9
+
+package slog
+
+import "log/syslog"
+
+// SetSyslog configures slog to use the system syslog daemon.
+func SetSyslog(tag string) error {
+	w, err := syslog.New(syslog.LOG_LOCAL6, tag)
+	if err != nil {
+		return err
+	}
+	Set(&Syslog{W: w})
+	return nil
+}
+
+// Syslog logs to syslog.
+type Syslog struct {
+	W *syslog.Writer
+}
+
+// Fatal logs a fatal message and calls os.Exit(1).
+func (s *Syslog) Fatal(v string) {
+	s.W.Crit("crit: " + v)
+}
+
+// Error logs an error message.
+func (s *Syslog) Error(v string) {
+	s.W.Err("error: " + v)
+}
+
+// Info logs an info message.
+func (s *Syslog) Info(v string) {
+	// Mac OSX ignores levels info and debug by default, so use notice.
+	s.W.Notice("info: " + v)
+}
+
+// Warning logs a warning message.
+func (s *Syslog) Warning(v string) {
+	s.W.Warning("warning: " + v)
+}

--- a/Godeps/_workspace/src/bosun.org/slog/slog_windows.go
+++ b/Godeps/_workspace/src/bosun.org/slog/slog_windows.go
@@ -1,0 +1,34 @@
+package slog
+
+import (
+	"fmt"
+
+	"bosun.org/_third_party/code.google.com/p/winsvc/debug"
+)
+
+type eventLog struct {
+	l  debug.Log
+	id uint32
+}
+
+// Sets the logger to a Windows Event Log. Designed for use with the
+// code.google.com/p/winsvc/eventlog and code.google.com/p/winsvc/debug
+// packages.
+func SetEventLog(l debug.Log, eid uint32) {
+	Set(&eventLog{l, eid})
+}
+
+func (e *eventLog) Fatal(v string) {
+	e.l.Error(e.id, fmt.Sprintf("fatal: %s", v))
+}
+
+func (e *eventLog) Info(v string) {
+	e.l.Info(e.id, fmt.Sprintf("info: %s", v))
+}
+
+func (e *eventLog) Warning(v string) {
+	e.l.Warning(e.id, fmt.Sprintf("warning: %s", v))
+}
+func (e *eventLog) Error(v string) {
+	e.l.Error(e.id, fmt.Sprintf("error: %s", v))
+}

--- a/Godeps/_workspace/src/bosun.org/util/Windows_WMI_Metadata.linq
+++ b/Godeps/_workspace/src/bosun.org/util/Windows_WMI_Metadata.linq
@@ -1,0 +1,192 @@
+<Query Kind="Program">
+  <Reference>&lt;RuntimeDirectory&gt;\System.Management.dll</Reference>
+  <Reference>&lt;RuntimeDirectory&gt;\System.Configuration.Install.dll</Reference>
+  <Reference>&lt;RuntimeDirectory&gt;\Microsoft.JScript.dll</Reference>
+  <Namespace>System.Management</Namespace>
+</Query>
+
+//LinqPad script used to codegen metadata for WMI classes
+void Main()
+{
+	//Follow steps 1-4 to generate the GO code from a wmi class
+	//See step 1 at bottom of page.
+	string strPrefix = "descWinSystem"; 	//Step 2: Set this to the prefix you want to use for metadata
+	string server = "localhost";  		//Step 3: Change this to another server if you need specific WMI information
+	string WMIClass = "Win32_PerfRawData_PerfOS_System"; //Step 4: WMI class for which you want to find metadata
+	bool GenerateFromMSDNClass = true; //Set to true if using an MSDN class in step 1. Set to false if text is an existing Add/AddTS block of code.
+	
+	//Load details about WMI Class and properties
+	var htWMIDetails = new Dictionary<string,WMIDetail>(StringComparer.InvariantCultureIgnoreCase);
+	ManagementScope s = new ManagementScope(string.Format("\\\\{0}\\root\\cimv2", server));
+    ManagementPath p = new ManagementPath(WMIClass);
+    ObjectGetOptions o = new ObjectGetOptions(null, System.TimeSpan.MaxValue, true);
+    ManagementClass osClass = new ManagementClass(s, p, o);
+	osClass.Options.UseAmendedQualifiers = true; //Adds Description details (which are missing otherwise)
+	//osClass.Properties.Dump();
+	foreach (PropertyData property in osClass.Properties)
+	{
+		WMIDetail d = WMIDetail.FromPropertyData(property);
+		//d.Dump();
+		htWMIDetails.Add(property.Name, d);
+	}
+	//htWMIDetails.Values.Dump("WMI Details");
+	if(string.IsNullOrWhiteSpace(text)){
+		StringBuilder sbText = new StringBuilder();
+		foreach(var key in htWMIDetails.Keys){
+			sbText.AppendFormat("{0};\r\n",key);
+		}
+		text = sbText.ToString();
+	}
+	
+	//text.Dump("Input lines pre transform");
+	var PropertiesUsed = new List<string>();
+	var matches = new List<Match>();
+	int countLines = -1;
+	using (StringReader sr = new StringReader(text)) {
+		string line;
+		while ((line = sr.ReadLine()) != null) {
+			countLines++;
+			if(GenerateFromMSDNClass){
+				//Regex to parse metrics out of the class ___ : ____ found on MSDN pages
+				var m = Regex.Match(line, @"(?<wmiName>[^ ;\{\}]+);$", RegexOptions.Multiline);
+				if(m.Success){
+					matches.Add(m);
+					PropertiesUsed.Add(m.Groups["wmiName"].Value);
+				}
+			} else {
+				//Regex to parse out the details from an Add or AddTS line in a *_windows.go. Change ""(?<metric>[^"",]*)"" to ""?(?<metric>[^"",]*)""? to capture osXXX based metrics
+				var m = Regex.Match(line, @"\s{0,4}Add\(&md, ""(?<metric>[^"",]*)"", v\.(?<wmiName>[a-zA-Z_]*)[^,]*, (nil|opentsdb.TagSet\{(?<tagset>[^}]*)\}), metadata\.(?<type>[^\,]*), metadata\.(?<units>[^\,]*), (""""|[a-zA-Z_]*)\)", RegexOptions.Multiline); //Get wmi details
+				if(m.Success){
+					matches.Add(m);
+					//m.Groups.Dump();
+					//m.Groups["tagset"].Value.Dump();
+					var t = Regex.Match(m.Groups["tagset"].Value, @"'site': v.Name, '(?<tagkey>[^']*)': '(?<tagvalue>[^']*)'", RegexOptions.Singleline); //Get tag names
+					//t.Dump();
+					if(t.Success){ //Use different identifier for lines with tags?
+						//result.Add(string.Format("{0}_{1}", m.Groups["wmiName"].Value,t.Groups["tagvalue"].Value));
+						PropertiesUsed.Add(m.Groups["wmiName"].Value);
+					} else {
+						PropertiesUsed.Add(m.Groups["wmiName"].Value);
+					}				
+				}
+			}
+		}//while
+	}//using
+	countLines.Dump("Total Lines pre-processing:");
+	PropertiesUsed.Distinct().Count().Dump("Distinct WMI Properties detected:");
+	//PropertiesUsed.Dump("WMI Properties used in the text block");	
+	
+	
+	if(GenerateFromMSDNClass){
+	    //Create lines for adding metric and for the GO struct
+		Console.WriteLine("//Metrics:");
+		foreach(var m in matches){
+			WMIDetail details;
+			if(htWMIDetails.TryGetValue(m.Groups["wmiName"].Value, out details)) {
+				Console.WriteLine("Add(&md, \"win.system.{0}\", v.{0}, tags, metadata.Counter, metadata.PerSecond, {1}{0})", details.Name,strPrefix);
+			}
+		}
+	}
+	
+	//Generate const for metadata
+	var sb = new StringBuilder("Errors:\r\n");
+	Console.WriteLine("\r\nconst (");
+	foreach(var wmiproperty in PropertiesUsed){
+		WMIDetail details;
+		if(htWMIDetails.TryGetValue(wmiproperty, out details)) {
+			Console.WriteLine(string.Format("  {2}{0} = \"{1}\"", details.Name,details.Description,strPrefix));
+		} else {
+		 	sb.AppendLine(string.Format("Could not find WMIDetail for '{0}'. Make sure it matches the WMI Property below. (Case Sensitive)", wmiproperty));
+		}
+	}
+	Console.WriteLine(")\r\n");
+	if(sb.Length > 9){
+		Console.WriteLine(sb.ToString());
+	} 
+	
+	if(GenerateFromMSDNClass){
+		Console.WriteLine("\r\ntype {0} struct {{", WMIClass);
+		foreach(var m in matches){
+			WMIDetail details;
+			if(htWMIDetails.TryGetValue(m.Groups["wmiName"].Value, out details)) {
+				Console.WriteLine("  {0} {1}", details.Name, details.CIMTYPE);
+			}
+		}
+		Console.WriteLine("}\r\n");
+	} else {
+		Console.WriteLine("\r\n//Insert metadata variable to Add/AddTS method call");
+		foreach(var m in matches){
+			var desc = string.Format("{1}{0}", m.Groups["wmiName"].Value,strPrefix);
+			var line = m.Value.Replace("\"\")",""+desc+")");
+			line = line.Replace("metadata.Unknown", "metadata.Counter"); //Default to counter, must manually set gauge types.
+			Console.WriteLine(line);
+		}
+	}
+	
+	Console.WriteLine("\r\n//WMI Counter Types");
+	foreach(var m in matches){
+		WMIDetail details;
+		if(htWMIDetails.TryGetValue(m.Groups["wmiName"].Value, out details)) {
+			Console.WriteLine("{0} {1}", details.CounterType, details.Name);
+		} else {
+			Console.WriteLine("No WMIDetails for {0}", m.Groups["wmiName"].Value);
+		}
+	} 
+	
+	htWMIDetails.Values.Dump("WMI Property Details");
+}
+class WMIDetail {
+	public WMIDetail()
+	{
+	}
+	public WMIDetail(string name, string cimtype, string countertype, string description, string displayname)
+	{
+		this.Name = name;
+		this.CIMTYPE = cimtype;
+		this.CounterType = countertype;
+		this.Description = description;
+		this.DisplayName = displayname;
+	}
+	
+	public static WMIDetail FromPropertyData(PropertyData property){
+		var result = new WMIDetail();
+		result.Name = property.Name;
+		foreach(System.Management.QualifierData item in property.Qualifiers){
+			switch (item.Name)
+			{
+				case "CIMTYPE":
+					result.CIMTYPE = item.Value.ToString();
+					break;
+				case "CounterType":
+					result.CounterType = item.Value.ToString();
+					break;
+				case "Description":
+					result.Description = item.Value.ToString();
+					break;
+				case "DisplayName":
+					result.DisplayName = item.Value.ToString();
+					break;
+			}
+		}
+		return result;
+	}
+	
+	public string Name { get; set; }
+	public string CIMTYPE { get; set; }
+	public string CounterType { get; set; }
+	public string Description { get; set; }
+	public string DisplayName { get; set; }
+}
+
+//Step 1: Paste MSDN class here. Remove any lines you don't want in your go struct.
+//Step 1: Paste current block of GO "Add()" lines here. Then replace " with "" to fix escapping.
+string text = @"
+  uint32 ExceptionDispatchesPerSec;
+  uint64 FileControlBytesPerSec;
+  uint32 FileControlOperationsPerSec;
+  uint32 FileDataOperationsPerSec;
+  uint64 FileReadBytesPerSec;
+  uint32 FileReadOperationsPerSec;
+";
+//Step 1: Or use empty string for all properties
+//string text = "";

--- a/Godeps/_workspace/src/bosun.org/util/command.go
+++ b/Godeps/_workspace/src/bosun.org/util/command.go
@@ -1,0 +1,83 @@
+package util
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"time"
+
+	"bosun.org/slog"
+)
+
+var (
+	// ErrPath is returned by Command if the program is not in the PATH.
+	ErrPath = errors.New("program not in PATH")
+	// ErrTimeout is returned by Command if the program timed out.
+	ErrTimeout = errors.New("program killed after timeout")
+
+	// Debug enables debug logging.
+	Debug = false
+)
+
+// Command executes the named program with the given arguments. If it does not
+// exit within timeout, it is sent SIGINT (if supported by Go). After
+// another timeout, it is killed.
+func Command(timeout time.Duration, stdin io.Reader, name string, arg ...string) (io.Reader, error) {
+	if _, err := exec.LookPath(name); err != nil {
+		return nil, ErrPath
+	}
+	if Debug {
+		slog.Infof("executing command: %v %v", name, arg)
+	}
+	c := exec.Command(name, arg...)
+	var b bytes.Buffer
+	c.Stdout = &b
+	c.Stdin = stdin
+	done := make(chan error, 1)
+	go func() {
+		done <- c.Run()
+	}()
+	interrupt := time.After(timeout)
+	kill := time.After(timeout * 2)
+	for {
+		select {
+		case err := <-done:
+			return &b, err
+		case <-interrupt:
+			c.Process.Signal(os.Interrupt)
+		case <-kill:
+			// todo: figure out if this can leave the done chan hanging open
+			c.Process.Kill()
+			return nil, ErrTimeout
+		}
+	}
+}
+
+// ReadCommand runs command name with args and calls line for each line from its
+// stdout. Command is interrupted (if supported by Go) after 10 seconds and
+// killed after 20 seconds.
+func ReadCommand(line func(string) error, name string, arg ...string) error {
+	return ReadCommandTimeout(time.Second*10, line, nil, name, arg...)
+}
+
+// ReadCommandTimeout is the same as ReadCommand with a specifiable timeout.
+// It can also take a []byte as input (useful for chaining commands).
+func ReadCommandTimeout(timeout time.Duration, line func(string) error, stdin io.Reader, name string, arg ...string) error {
+	b, err := Command(timeout, stdin, name, arg...)
+	if err != nil {
+		return err
+	}
+	scanner := bufio.NewScanner(b)
+	for scanner.Scan() {
+		if err := line(scanner.Text()); err != nil {
+			return err
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		slog.Infof("%v: %v\n", name, err)
+	}
+	return nil
+}

--- a/Godeps/_workspace/src/bosun.org/util/util.go
+++ b/Godeps/_workspace/src/bosun.org/util/util.go
@@ -1,0 +1,40 @@
+// Package util defines utilities for bosun.
+package util
+
+import (
+	"os"
+	"strings"
+)
+
+var (
+	// Hostname is the machine's hostname.
+	Hostname string
+	// FullHostname will, if false, uses the hostname upto the first ".". Run Set()
+	// manually after changing.
+	FullHostname bool
+)
+
+// Clean cleans a hostname based on the current FullHostname setting.
+func Clean(s string) string {
+	if !FullHostname {
+		s = strings.SplitN(s, ".", 2)[0]
+	}
+	return strings.ToLower(s)
+}
+
+// Set sets Hostntame based on the current preferences.
+func Set() {
+	h, err := os.Hostname()
+	if err == nil {
+		if !FullHostname {
+			h = strings.SplitN(h, ".", 2)[0]
+		}
+	} else {
+		h = "unknown"
+	}
+	Hostname = Clean(h)
+}
+
+func init() {
+	Set()
+}

--- a/docs/sink-configuration.md
+++ b/docs/sink-configuration.md
@@ -52,6 +52,19 @@ To use the InfluxDB sink add the following flag:
 
 This sink does not export any options!
 
+### Bosun
+This sink supports monitoring metrics only as of now.
+To use the Bosun sink add the following flag:
+```
+--sink=bosun:<BOSUN_URL>[?<BOSUN_OPTIONS>]
+```
+
+Example:
+```
+--sink=bosun:http://localhost:8070/
+```
+
+This sink does not export any options as of now!
 
 
 

--- a/sinks/api/decoder.go
+++ b/sinks/api/decoder.go
@@ -54,7 +54,10 @@ func (self *defaultDecoder) getPodLabels(pod *source_api.Pod) map[string]string 
 	labels[LabelPodId] = pod.ID
 	labels[LabelPodNamespace] = pod.Namespace
 	labels[LabelPodName] = pod.Name
-	labels[LabelLabels] = LabelsToString(pod.Labels, ",")
+	labelString := LabelsToString(pod.Labels, ",")
+	if labelString != "" {
+		labels[LabelLabels] = labelString
+	}
 	labels[LabelHostname] = pod.Hostname
 
 	return labels

--- a/sinks/bosun/client.go
+++ b/sinks/bosun/client.go
@@ -1,0 +1,112 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bosun
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
+	"bosun.org/metadata"
+	"bosun.org/opentsdb"
+
+	"github.com/golang/glog"
+)
+
+type bosunClient interface {
+	sendMetadata(ms []metadata.Metasend) error
+	sendBatch(batch []json.RawMessage) error
+}
+
+type bosunClientImpl struct {
+	metricsUrl *url.URL
+	metaUrl    *url.URL
+	client     *http.Client
+}
+
+func (bs *bosunClientImpl) sendMetadata(ms []metadata.Metasend) error {
+	b, err := json.Marshal(&ms)
+	if err != nil {
+		return err
+	}
+	resp, err := http.Post(bs.metaUrl.String(), "application/json", bytes.NewBuffer(b))
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != 204 {
+		return fmt.Errorf("Bosun Sink: bad metadata return:", resp.Status)
+	}
+	return nil
+}
+
+type sendError struct {
+	success int64 `json:"success,omitempty"`
+	failed  int64 `json:"failed,omitempty"`
+	errors  []struct {
+		datapoint opentsdb.DataPoint `json:"datapoint,omitempty"`
+		error     string             `json:"error,omitempty"`
+	} `json:"errors,omitempty"`
+}
+
+func (bs *bosunClientImpl) sendBatch(batch []json.RawMessage) error {
+	var buf bytes.Buffer
+	g := gzip.NewWriter(&buf)
+	if err := json.NewEncoder(g).Encode(batch); err != nil {
+		return err
+	}
+	if err := g.Close(); err != nil {
+		return err
+	}
+	q := bs.metricsUrl.Query()
+	q.Set("details", "")
+	bs.metricsUrl.RawQuery = q.Encode()
+	req, err := http.NewRequest("POST", bs.metricsUrl.String(), &buf)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Encoding", "gzip")
+	resp, err := bs.client.Do(req)
+	if err == nil {
+		defer resp.Body.Close()
+	}
+	// Some problem with connecting to the server; retry later.
+	if err != nil || resp.StatusCode != http.StatusNoContent {
+		if err != nil {
+			return err
+		} else if resp.StatusCode != http.StatusNoContent {
+			body, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				return fmt.Errorf("failed to parse response body: %v", err)
+			}
+			se := sendError{}
+			if err := json.Unmarshal(body, &se); err != nil {
+				return fmt.Errorf("failed to parse response body: %v", err)
+			}
+			if se.failed == 0 {
+				return nil
+			}
+			for _, error := range se.errors {
+				glog.Errorf("failed to push datapoint: %v\nError: %v", error.datapoint, error.error)
+			}
+			return fmt.Errorf("Bosun Sink: Failed to push %d data points", se.failed)
+		}
+	}
+	return nil
+}

--- a/sinks/bosun/driver.go
+++ b/sinks/bosun/driver.go
@@ -1,0 +1,161 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bosun
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"strings"
+	"time"
+
+	"bosun.org/metadata"
+	"bosun.org/opentsdb"
+
+	"github.com/GoogleCloudPlatform/heapster/extpoints"
+	sink_api "github.com/GoogleCloudPlatform/heapster/sinks/api"
+	kube_api "github.com/GoogleCloudPlatform/kubernetes/pkg/api"
+	"github.com/golang/glog"
+)
+
+const (
+	defaultBosunUrl = "http://monitoring-bosun:80"
+	defaultTags     = "name=heapster"
+	defaultRoot     = "kubernetes.io"
+)
+
+func init() {
+	extpoints.SinkFactories.Register(CreateBosun, "bosun")
+}
+
+func CreateBosun(uri string, options map[string][]string) ([]sink_api.ExternalSink, error) {
+	if len(uri) == 0 {
+		uri = defaultBosunUrl
+	}
+	parsedUrl, err := url.Parse(os.ExpandEnv(uri))
+	if err != nil {
+		return nil, err
+	}
+	metaUrl, err := parsedUrl.Parse("/api/metadata/put")
+	if err != nil {
+		return nil, err
+	}
+	metricsUrl, err := parsedUrl.Parse("/api/put")
+	if err != nil {
+		return nil, err
+	}
+	client := &bosunClientImpl{
+		metricsUrl: metricsUrl,
+		metaUrl:    metaUrl,
+		client: &http.Client{
+			Timeout: time.Minute,
+		},
+	}
+	glog.Infof("Created Bosun Sink - Metrics URL: %q, Metadata URL: %q", metricsUrl.String(), metaUrl.String())
+	return []sink_api.ExternalSink{&bosunSink{client}}, nil
+}
+
+type bosunSink struct {
+	client bosunClient
+}
+
+func (bs *bosunSink) Register(metrics []sink_api.MetricDescriptor) error {
+	ms := []metadata.Metasend{}
+	for _, metric := range metrics {
+		rate := ""
+		switch metric.Type {
+		case sink_api.MetricCumulative:
+			rate = "counter"
+			break
+		case sink_api.MetricGauge:
+			rate = "gauge"
+			break
+		}
+
+		ms = append(ms, metadata.Metasend{
+			Metric: bs.fullMetricName(metric.Name),
+			Name:   "rate",
+			Value:  rate,
+		})
+		ms = append(ms, metadata.Metasend{
+			Metric: bs.fullMetricName(metric.Name),
+			Name:   "unit",
+			Value:  metric.Units.String(),
+		})
+		ms = append(ms, metadata.Metasend{
+			Metric: bs.fullMetricName(metric.Name),
+			Name:   "desc",
+			Value:  metric.Description,
+		})
+	}
+	glog.Infof("Registering Metrics with Bosun: %v", ms)
+	return bs.client.sendMetadata(ms)
+}
+
+func (bs *bosunSink) fullMetricName(name string) string {
+	return strings.Replace(path.Join(defaultRoot, name), "/", "_", -1)
+}
+
+func (bs *bosunSink) getpoint(ts sink_api.Timeseries) (*opentsdb.DataPoint, error) {
+	tags := opentsdb.TagSet{}
+	for key, val := range ts.Point.Labels {
+		if key == sink_api.LabelLabels {
+			// TODO: Handle support for user specified labels.
+			continue
+		}
+		tag, err := opentsdb.ParseTags(fmt.Sprintf("%s=%s", key, val))
+		if err != nil {
+			glog.Errorf("failed to parse label [%v](%v) - %v", key, val, err)
+			return nil, err
+		}
+		tags.Merge(tag)
+	}
+	return &opentsdb.DataPoint{
+		Metric:    bs.fullMetricName(ts.Point.Name),
+		Timestamp: ts.Point.End.UnixNano() / int64(time.Millisecond),
+		Value:     ts.Point.Value,
+		Tags:      tags,
+	}, nil
+}
+
+func (bs *bosunSink) StoreTimeseries(timeseries []sink_api.Timeseries) error {
+	dps := []json.RawMessage{}
+	for _, ts := range timeseries {
+		point, err := bs.getpoint(ts)
+		if err != nil {
+			return err
+		}
+		m, err := json.Marshal(point)
+		if err != nil {
+			glog.V(2).Infof("failed to marshal datapoint %v - %v", point, err)
+			return err
+		}
+		dps = append(dps, m)
+	}
+	return bs.client.sendBatch(dps)
+}
+
+func (bs *bosunSink) StoreEvents(events []kube_api.Event) error {
+	return nil
+}
+
+func (bs *bosunSink) DebugInfo() string {
+	desc := "Sink Type: Bosun\n"
+	desc += "\n"
+	return desc
+}

--- a/sinks/modules.go
+++ b/sinks/modules.go
@@ -15,6 +15,7 @@
 package sinks
 
 import (
+	_ "github.com/GoogleCloudPlatform/heapster/sinks/bosun"
 	_ "github.com/GoogleCloudPlatform/heapster/sinks/gcl"
 	_ "github.com/GoogleCloudPlatform/heapster/sinks/gcm"
 	_ "github.com/GoogleCloudPlatform/heapster/sinks/influxdb"


### PR DESCRIPTION
Bosun will let users configure and generate alerts.
Bosun can store metrics in InfluxDB. 
The Sink now stores metrics only.

Next steps are to cook up a kube script for deploying Bosun alongside influxdb and post a guide for setting up alerts!

![screen shot 2015-05-03 at 7 53 29 pm](https://cloud.githubusercontent.com/assets/7063592/7448463/31c271fc-f1cf-11e4-8d1b-3715787ffca7.png)
