### PR TITLE
[Schema 2] Constructors and Getters

### DIFF
--- a/schema/impl.go
+++ b/schema/impl.go
@@ -88,5 +88,6 @@ func (rc *realCluster) GetAllPodData(namespace string, pod_name string) (*PodInf
 }
 
 func (rc *realCluster) Update(c *cache.Cache) error {
+	// TODO(afein): Unimplemented
 	return nil
 }

--- a/schema/impl.go
+++ b/schema/impl.go
@@ -57,7 +57,7 @@ func (rc *realCluster) GetAllNodeData(hostname string) (*NodeInfo, time.Time, er
 
 	res, ok := rc.Nodes[hostname]
 	if !ok {
-		return nil, zeroTime, fmt.Errorf("Unable to find node with hostname: %s", hostname)
+		return nil, zeroTime, fmt.Errorf("unable to find node with hostname: %s", hostname)
 	}
 
 	return res, rc.timestamp, nil
@@ -71,17 +71,17 @@ func (rc *realCluster) GetAllPodData(namespace string, pod_name string) (*PodInf
 	defer lock.RUnlock()
 
 	if len(rc.Namespaces) == 0 {
-		return nil, zeroTime, fmt.Errorf("Unable to find pod: no namespaces in cluster")
+		return nil, zeroTime, fmt.Errorf("unable to find pod: no namespaces in cluster")
 	}
 
 	ns, ok := rc.Namespaces[namespace]
 	if !ok {
-		return nil, zeroTime, fmt.Errorf("Unable to find namespace with name: %s", namespace)
+		return nil, zeroTime, fmt.Errorf("unable to find namespace with name: %s", namespace)
 	}
 
 	pod, ok := ns.Pods[pod_name]
 	if !ok {
-		return nil, zeroTime, fmt.Errorf("Unable to find pod with name: %s", pod_name)
+		return nil, zeroTime, fmt.Errorf("unable to find pod with name: %s", pod_name)
 	}
 
 	return pod, rc.timestamp, nil

--- a/schema/impl.go
+++ b/schema/impl.go
@@ -1,0 +1,99 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/GoogleCloudPlatform/heapster/sinks/cache"
+)
+
+func NewCluster() Cluster {
+	return NewRealCluster()
+}
+
+func NewRealCluster() *realCluster {
+	cinfo := ClusterInfo{
+		InfoType:   newInfoType(nil, nil),
+		Namespaces: make(map[string]*NamespaceInfo),
+		Nodes:      make(map[string]*NodeInfo),
+	}
+	cluster := &realCluster{
+		timestamp:   time.Time{},
+		lock:        new(sync.RWMutex),
+		ClusterInfo: cinfo,
+	}
+	return cluster
+}
+
+func (rc *realCluster) GetAllClusterData() (*ClusterInfo, time.Time, error) {
+	// Returns the entire ClusterInfo object
+	rc.lock.RLock()
+	defer rc.lock.RUnlock()
+	return &rc.ClusterInfo, rc.timestamp, nil
+}
+
+func (rc *realCluster) GetAllNodeData(hostname string) (*NodeInfo, time.Time, error) {
+	// Returns the corresponding NodeInfo object
+	rc.lock.RLock()
+	defer rc.lock.RUnlock()
+
+	var res *NodeInfo
+	var stamp time.Time
+	var err error
+
+	if val, ok := rc.Nodes[hostname]; ok {
+		res = val
+		stamp = rc.timestamp
+		err = nil
+	} else {
+		res = nil
+		err = errors.New("Unable to find node with hostname: " + hostname)
+	}
+	return res, stamp, err
+}
+
+func (rc *realCluster) GetAllPodData(namespace string, pod_name string) (*PodInfo, time.Time, error) {
+	// Returns the corresponding NodeInfo object
+	rc.lock.RLock()
+	defer rc.lock.RUnlock()
+
+	var res *PodInfo
+	var stamp time.Time
+	var err error
+
+	if len(rc.Namespaces) == 0 {
+		err = errors.New("Unable to find pod: no namespaces registered")
+	} else {
+		if ns, ok := rc.Namespaces[namespace]; ok {
+			if val, ok := ns.Pods[pod_name]; ok {
+				res = val
+				stamp = rc.timestamp
+				err = nil
+			} else {
+				err = errors.New("Unable to find pod with name: " + pod_name)
+			}
+		} else {
+			err = errors.New("Unable to find namespace with name: " + namespace)
+		}
+	}
+	return res, stamp, err
+}
+
+func (rc *realCluster) Update(c *cache.Cache) error {
+	return nil
+}

--- a/schema/impl.go
+++ b/schema/impl.go
@@ -22,11 +22,13 @@ import (
 	"github.com/GoogleCloudPlatform/heapster/sinks/cache"
 )
 
+var lock sync.RWMutex
+
 func NewCluster() Cluster {
-	return NewRealCluster()
+	return newRealCluster()
 }
 
-func NewRealCluster() *realCluster {
+func newRealCluster() *realCluster {
 	cinfo := ClusterInfo{
 		InfoType:   newInfoType(nil, nil),
 		Namespaces: make(map[string]*NamespaceInfo),
@@ -34,7 +36,6 @@ func NewRealCluster() *realCluster {
 	}
 	cluster := &realCluster{
 		timestamp:   time.Time{},
-		lock:        new(sync.RWMutex),
 		ClusterInfo: cinfo,
 	}
 	return cluster
@@ -42,15 +43,15 @@ func NewRealCluster() *realCluster {
 
 func (rc *realCluster) GetAllClusterData() (*ClusterInfo, time.Time, error) {
 	// Returns the entire ClusterInfo object
-	rc.lock.RLock()
-	defer rc.lock.RUnlock()
+	lock.RLock()
+	defer lock.RUnlock()
 	return &rc.ClusterInfo, rc.timestamp, nil
 }
 
 func (rc *realCluster) GetAllNodeData(hostname string) (*NodeInfo, time.Time, error) {
 	// Returns the corresponding NodeInfo object
-	rc.lock.RLock()
-	defer rc.lock.RUnlock()
+	lock.RLock()
+	defer lock.RUnlock()
 
 	var res *NodeInfo
 	var stamp time.Time
@@ -69,8 +70,8 @@ func (rc *realCluster) GetAllNodeData(hostname string) (*NodeInfo, time.Time, er
 
 func (rc *realCluster) GetAllPodData(namespace string, pod_name string) (*PodInfo, time.Time, error) {
 	// Returns the corresponding NodeInfo object
-	rc.lock.RLock()
-	defer rc.lock.RUnlock()
+	lock.RLock()
+	defer lock.RUnlock()
 
 	var res *PodInfo
 	var stamp time.Time

--- a/schema/types.go
+++ b/schema/types.go
@@ -26,14 +26,21 @@ type Cluster interface {
 	Update(*cache.Cache) error
 
 	// The Get operations extract internal types from the Cluster
+	// The returned Time value signifies the latest timestamp of all metrics on the cluster
+	// TODO(alex): Returning pointers is NOT safe, will be addressed in a later PR
+
 	GetAllClusterData() (*ClusterInfo, time.Time, error)
+	// Parameter: Internal Hostname of the node
 	GetAllNodeData(string) (*NodeInfo, time.Time, error)
+	// Parameters: Namespace, Pod Name
 	GetAllPodData(string, string) (*PodInfo, time.Time, error)
 }
 
 type realCluster struct {
-	// Implementation of Cluster
-	timestamp time.Time // Marks the last update from a cache.
+	// Implementation of Cluster.
+	// Timestamp signifies the latest timestamp of any metric
+	// that is currently present in the realCluster
+	timestamp time.Time
 	ClusterInfo
 }
 

--- a/schema/types.go
+++ b/schema/types.go
@@ -15,10 +15,10 @@
 package schema
 
 import (
+	"time"
+
 	"github.com/GoogleCloudPlatform/heapster/sinks/cache"
 	"github.com/GoogleCloudPlatform/heapster/store"
-	"sync"
-	"time"
 )
 
 type Cluster interface {
@@ -34,7 +34,6 @@ type Cluster interface {
 type realCluster struct {
 	// Implementation of Cluster
 	timestamp time.Time // Marks the last update from a cache.
-	lock      *sync.RWMutex
 	ClusterInfo
 }
 

--- a/schema/util.go
+++ b/schema/util.go
@@ -1,0 +1,43 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"time"
+
+	"github.com/GoogleCloudPlatform/heapster/store"
+)
+
+func maxTimestamp(first time.Time, second time.Time) time.Time {
+	if first.After(second) {
+		return first
+	} else {
+		return second
+	}
+}
+
+func newInfoType(metrics map[string]*store.TimeStore, labels map[string]string) InfoType {
+	// InfoType Constructor
+	if metrics == nil {
+		metrics = make(map[string]*store.TimeStore)
+	}
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	return InfoType{
+		Metrics: metrics,
+		Labels:  labels,
+	}
+}

--- a/schema/util.go
+++ b/schema/util.go
@@ -23,9 +23,8 @@ import (
 func maxTimestamp(first time.Time, second time.Time) time.Time {
 	if first.After(second) {
 		return first
-	} else {
-		return second
 	}
+	return second
 }
 
 func newInfoType(metrics map[string]*store.TimeStore, labels map[string]string) InfoType {


### PR DESCRIPTION
Part 2 of #342 
Added constructors and implementation for three basic "get" methods.

As this series of PRs is generated in order of dependencies, Part 3 will include the addPod, addNode, addNamespace and addContainer methods.
Unit tests for Part 2 will be provided in later parts (estimate: part 6)
