### PR TITLE
Launching the influxdb service in kube-system namespace

### DIFF
--- a/deploy/kube-config/influxdb/influxdb-service.json
+++ b/deploy/kube-config/influxdb/influxdb-service.json
@@ -3,7 +3,8 @@
     "kind": "Service",
     "metadata": {
 	"labels": null,
-	"name": "monitoring-influxdb"
+	  "name": "monitoring-influxdb",
+	  "namespace": "kube-system"
     },
     "spec": {
 	"ports": [


### PR DESCRIPTION
monitoring-influxdb service was being launched in the default namespace and heapster was not able to connect to it. This commit moves the service to kube-system where the rest of the services and rc are being launched.