### PR TITLE
Launching the influxdb service in kube-system namespace

### DIFF
--- a/deploy/kube-config/influxdb/influxdb-service.json
+++ b/deploy/kube-config/influxdb/influxdb-service.json
@@ -3,7 +3,8 @@
     "kind": "Service",
     "metadata": {
 	"labels": null,
-	"name": "monitoring-influxdb"
+	  "name": "monitoring-influxdb",
+	  "namespace": "kube-system"  
     },
     "spec": {
 	"ports": [


### PR DESCRIPTION
This commit includes launching the influxdb service in kube system namespace so that heapster can push to influxdb. There was an error in the influxdb service spec file where default namespace was used.