### PR TITLE
Changed behavior of StatStore Get and Last

### DIFF
--- a/store/daystore/day_store_test.go
+++ b/store/daystore/day_store_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package store
+package daystore
 
 import (
 	"testing"
@@ -287,7 +287,7 @@ func TestDayStore(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(nf, uint64(21000))
 
-	// Get Invocation, a full hour should be available
+	// Get Invocation, a full hour should be available plus the lastPut
 	res := ds.Hour.Get(time.Time{}, time.Time{})
-	assert.Len(res, 60)
+	assert.Len(res, 61)
 }


### PR DESCRIPTION
Part 1 of #478
 
This PR changes the behavior of the StatStore Get operation to also include one TimePoint that contains the Max of values stored in the current minute.
This behavior is needed to avoid metrics lagging behind after aggregation for abstract entities.

For example, if the latest timestamp is N minutes for all containers, then with the old behavior of Get the latest timestamp for pods would be N-1 and the latest timestamp for namespaces would be at N-2.

The behavior of Last has also changed to return values from LastPut.
- Last(true) now returns the Max value of the items represented in lastPut.
- Last(false) returns the average value of the items represented in lastPut

These two changes guarantee that the derived stats exposed by the heapster model are always sane, meaning that the last minute's Max cannot be larger that the hourly or daily max.

Bonuses: 
- changed the StatStore window size field to uint16, to support stores with more than 256 stored resolutions.
- allowed the DayStore to support Put operations at multiple hours in the future. Similarly to the StatStore, the missing resolutions are assumed to remain constant in value.

\cc @vishh @mvdan