### PR TITLE
Change model to use the new stores & Cleanup

### DIFF
--- a/api/v1/types/model_types.go
+++ b/api/v1/types/model_types.go
@@ -31,3 +31,9 @@ type MetricResult struct {
 type MetricResultList struct {
 	Items []MetricResult `json:"items"`
 }
+
+type ExternalEntityListEntry struct {
+	Name     string `json:"name"`
+	CPUUsage uint64 `json:"cpuUsage"`
+	MemUsage uint64 `json:"memUsage"`
+}

--- a/api/v1/types/model_types.go
+++ b/api/v1/types/model_types.go
@@ -32,6 +32,8 @@ type MetricResultList struct {
 	Items []MetricResult `json:"items"`
 }
 
+// An ExternalEntityListEntry represents the latest CPU and Memory usage of a model entity.
+// A model entity can be a Pod, a Container, a Namespace or a Node.
 type ExternalEntityListEntry struct {
 	Name     string `json:"name"`
 	CPUUsage uint64 `json:"cpuUsage"`

--- a/heapster.go
+++ b/heapster.go
@@ -40,7 +40,7 @@ var (
 	argSinkFrequency   = flag.Duration("sink_frequency", 10*time.Second, "Frequency at which data will be pushed to sinks")
 	argCacheDuration   = flag.Duration("cache_duration", 5*time.Minute, "The total duration of the historical data that will be cached by heapster.")
 	argUseModel        = flag.Bool("use_model", false, "When true, the internal model representation will be used")
-	argModelResolution = flag.Duration("model_resolution", 2*time.Minute, "The resolution of the timeseries stored in the model. Applies only if use_model is true")
+	argModelResolution = flag.Duration("model_resolution", 1*time.Minute, "The resolution of the timeseries stored in the model. Applies only if use_model is true")
 	argPort            = flag.Int("port", 8082, "port to listen to")
 	argIp              = flag.String("listen_ip", "", "IP to listen on, defaults to all IPs")
 	argMaxProcs        = flag.Int("max_procs", 0, "max number of CPUs that can be used simultaneously. Less than 1 for default (number of cores)")
@@ -106,7 +106,9 @@ func doWork() ([]source_api.Source, sinks.ExternalSinkManager, manager.Manager, 
 
 	// Spawn the Model Housekeeping goroutine even if the model is not enabled.
 	// This will allow the model to be activated/deactivated in runtime.
+	// Set the housekeeping period to 2 * argModelResolution + 25 sec
 	modelDuration := 2 * *argModelResolution
+	modelDuration = time.Time{}.Add(modelDuration).Add(25 * time.Second).Sub(time.Time{})
 	if (*argCacheDuration).Nanoseconds() < modelDuration.Nanoseconds() {
 		modelDuration = *argCacheDuration
 	}

--- a/model/aggregation.go
+++ b/model/aggregation.go
@@ -18,7 +18,8 @@ import (
 	"fmt"
 	"time"
 
-	"k8s.io/heapster/store"
+	"k8s.io/heapster/store/daystore"
+	"k8s.io/heapster/store/statstore"
 )
 
 // aggregationStep performs a Metric Aggregation step on the cluster.
@@ -26,17 +27,20 @@ import (
 // by Timeseries summation of the respective Metrics fields.
 // aggregationStep should be called after new data is present in the cluster,
 // but before the cluster timestamp is updated.
-func (rc *realCluster) aggregationStep() error {
+
+// The latestTime argument represents the latest time of metrics found in the model,
+// which should cause all aggregated metrics to remain constant up until that time.
+func (rc *realModel) aggregationStep(latestTime time.Time) error {
 	rc.lock.Lock()
 	defer rc.lock.Unlock()
 
 	// Perform Node Metric Aggregation
 	node_c := make(chan error)
-	go rc.aggregateNodeMetrics(node_c)
+	go rc.aggregateNodeMetrics(node_c, latestTime)
 
 	// Initiate bottom-up aggregation for Kubernetes stats
 	kube_c := make(chan error)
-	go rc.aggregateKubeMetrics(kube_c)
+	go rc.aggregateKubeMetrics(kube_c, latestTime)
 
 	errs := make([]error, 2)
 	errs[0] = <-node_c
@@ -54,7 +58,7 @@ func (rc *realCluster) aggregationStep() error {
 
 // aggregateNodeMetrics populates the Cluster.InfoType.Metrics field by adding up all node metrics.
 // Assumes an appropriate lock is already taken by the caller.
-func (rc *realCluster) aggregateNodeMetrics(c chan error) {
+func (rc *realModel) aggregateNodeMetrics(c chan error, latestTime time.Time) {
 	if len(rc.Nodes) == 0 {
 		// Fail silently if the cluster has no nodes
 		c <- nil
@@ -65,12 +69,12 @@ func (rc *realCluster) aggregateNodeMetrics(c chan error) {
 	for _, node := range rc.Nodes {
 		sources = append(sources, &(node.InfoType))
 	}
-	c <- rc.aggregateMetrics(&rc.ClusterInfo.InfoType, sources)
+	c <- rc.aggregateMetrics(&rc.ClusterInfo.InfoType, sources, latestTime)
 }
 
 // aggregateKubeMetrics initiates depth-first aggregation of Kubernetes metrics.
 // Assumes an appropriate lock is already taken by the caller.
-func (rc *realCluster) aggregateKubeMetrics(c chan error) {
+func (rc *realModel) aggregateKubeMetrics(c chan error, latestTime time.Time) {
 	if len(rc.Namespaces) == 0 {
 		// Fail silently if the cluster has no namespaces
 		c <- nil
@@ -81,7 +85,7 @@ func (rc *realCluster) aggregateKubeMetrics(c chan error) {
 	chans := make([]chan error, 0)
 	for _, namespace := range rc.Namespaces {
 		chans = append(chans, make(chan error))
-		go rc.aggregateNamespaceMetrics(namespace, chans[len(chans)-1])
+		go rc.aggregateNamespaceMetrics(namespace, chans[len(chans)-1], latestTime)
 	}
 
 	errs := make([]error, len(chans))
@@ -101,7 +105,7 @@ func (rc *realCluster) aggregateKubeMetrics(c chan error) {
 
 // aggregateNamespaceMetrics populates a NamespaceInfo.Metrics field by aggregating all PodInfo.
 // Assumes an appropriate lock is already taken by the caller.
-func (rc *realCluster) aggregateNamespaceMetrics(namespace *NamespaceInfo, c chan error) {
+func (rc *realModel) aggregateNamespaceMetrics(namespace *NamespaceInfo, c chan error, latestTime time.Time) {
 	if namespace == nil {
 		c <- fmt.Errorf("nil Namespace pointer passed for aggregation")
 		return
@@ -116,7 +120,7 @@ func (rc *realCluster) aggregateNamespaceMetrics(namespace *NamespaceInfo, c cha
 	chans := make([]chan error, 0)
 	for _, pod := range namespace.Pods {
 		chans = append(chans, make(chan error))
-		go rc.aggregatePodMetrics(pod, chans[len(chans)-1])
+		go rc.aggregatePodMetrics(pod, chans[len(chans)-1], latestTime)
 	}
 
 	errs := make([]error, len(chans))
@@ -136,12 +140,12 @@ func (rc *realCluster) aggregateNamespaceMetrics(namespace *NamespaceInfo, c cha
 	for _, pod := range namespace.Pods {
 		sources = append(sources, &(pod.InfoType))
 	}
-	c <- rc.aggregateMetrics(&namespace.InfoType, sources)
+	c <- rc.aggregateMetrics(&namespace.InfoType, sources, latestTime)
 }
 
 // aggregatePodMetrics populates a PodInfo.Metrics field by aggregating all ContainerInfo.
 // Assumes an appropriate lock is already taken by the caller.
-func (rc *realCluster) aggregatePodMetrics(pod *PodInfo, c chan error) {
+func (rc *realModel) aggregatePodMetrics(pod *PodInfo, c chan error, latestTime time.Time) {
 	if pod == nil {
 		c <- fmt.Errorf("nil Pod pointer passed for aggregation")
 		return
@@ -157,13 +161,13 @@ func (rc *realCluster) aggregatePodMetrics(pod *PodInfo, c chan error) {
 	for _, container := range pod.Containers {
 		sources = append(sources, &(container.InfoType))
 	}
-	c <- rc.aggregateMetrics(&pod.InfoType, sources)
+	c <- rc.aggregateMetrics(&pod.InfoType, sources, latestTime)
 }
 
 // aggregateMetrics populates an InfoType by adding metrics across a slice of InfoTypes.
 // Only metrics taken after the cluster timestamp are affected.
 // Assumes an appropriate lock is already taken by the caller.
-func (rc *realCluster) aggregateMetrics(target *InfoType, sources []*InfoType) error {
+func (rc *realModel) aggregateMetrics(target *InfoType, sources []*InfoType, latestTime time.Time) error {
 	zeroTime := time.Time{}
 
 	if target == nil {
@@ -181,34 +185,70 @@ func (rc *realCluster) aggregateMetrics(target *InfoType, sources []*InfoType) e
 		}
 	}
 
+	if latestTime.Equal(zeroTime) {
+		return fmt.Errorf("aggregateMetrics called with a zero latestTime argument")
+	}
+
 	// Create a map of []TimePoint as a timeseries accumulator per metric
-	newMetrics := make(map[string][]store.TimePoint)
+	newMetrics := make(map[string][]statstore.TimePoint)
 
 	// Reduce the sources slice with timeseries addition for each metric
 	for _, info := range sources {
-		for key, ts := range info.Metrics {
+		for key, ds := range info.Metrics {
 			_, ok := newMetrics[key]
 			if !ok {
 				// Metric does not exist on target map, create a new timeseries
-				newMetrics[key] = []store.TimePoint{}
+				newMetrics[key] = []statstore.TimePoint{}
 			}
 			// Perform timeseries addition between the accumulator and the current source
-			sourceTS := (*ts).Get(rc.timestamp, zeroTime)
-			newMetrics[key] = addMatchingTimeseries(newMetrics[key], sourceTS)
+			sourceDS := (*ds).Hour.Get(rc.timestamp, zeroTime)
+			newMetrics[key] = addMatchingTimeseries(newMetrics[key], sourceDS)
 		}
 	}
 
-	// Put all the new values in the TimeStores under target
+	// Put all the new values in the DayStores under target
 	for key, tpSlice := range newMetrics {
+		if len(tpSlice) == 0 {
+			continue
+		}
 		_, ok := target.Metrics[key]
 		if !ok {
-			// Metric does not exist on target InfoType, create TimeStore
-			newTS := rc.tsConstructor()
-			target.Metrics[key] = &newTS
+			// Metric does not exist on target InfoType, create DayStore
+			target.Metrics[key] = daystore.NewDayStore(epsilonFromMetric(key), rc.resolution)
 		}
-		for _, tp := range tpSlice {
-			(*target.Metrics[key]).Put(tp)
+
+		// Put the added TimeSeries in the corresponding DayStore, in time-ascending order
+		for i := len(tpSlice) - 1; i >= 0; i-- {
+			err := target.Metrics[key].Put(tpSlice[i])
+			if err != nil {
+				return fmt.Errorf("error while performing aggregation: %s", err)
+			}
+		}
+
+		// Put a TimePoint with the latest aggregated value at the latest model resolution.
+		// Causes the DayStore to assume the aggregated metric remained constant until the -
+		// next cluster timestamp.
+		newTP := statstore.TimePoint{
+			Timestamp: latestTime,
+			Value:     tpSlice[0].Value,
+		}
+		err := target.Metrics[key].Put(newTP)
+		if err != nil {
+			return fmt.Errorf("error while performing aggregation: %s", err)
+		}
+
+	}
+
+	// Set the creation time of the entity to the earliest one that we have found data for.
+	earliestCreation := sources[0].Creation
+	for _, info := range sources[1:] {
+		if info.Creation.Before(earliestCreation) && info.Creation.After(time.Time{}) {
+			earliestCreation = info.Creation
 		}
 	}
+	if earliestCreation.Before(target.Creation) || target.Creation.Equal(time.Time{}) {
+		target.Creation = earliestCreation
+	}
+
 	return nil
 }

--- a/model/getters.go
+++ b/model/getters.go
@@ -1,0 +1,427 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"k8s.io/heapster/store/daystore"
+	"k8s.io/heapster/store/statstore"
+)
+
+// Errors for the Getter methods
+var (
+	errModelEmpty      = errors.New("the model is not populated yet")
+	errNoEntityMetrics = errors.New("the requested entity does not have any metrics yet")
+	errInvalidNode     = errors.New("the requested node is not present in the cluster")
+	errNoSuchMetric    = errors.New("the requested metric is not present in the model")
+	errNoSuchNamespace = errors.New("the requested namespace is not present in the cluster")
+	errNoSuchPod       = errors.New("the requested pod is not present in the specified namespace")
+	errNoSuchContainer = errors.New("the requested container is not present in the model")
+)
+
+// GetClusterMetric returns a metric of the cluster entity, along with the latest timestamp.
+// GetClusterMetric returns a slice of TimePoints for that metric, with times starting AFTER the starting timestamp.
+func (rc *realModel) GetClusterMetric(req ClusterMetricRequest) ([]statstore.TimePoint, time.Time, error) {
+	var zeroTime time.Time
+	rc.lock.RLock()
+	defer rc.lock.RUnlock()
+
+	if len(rc.Metrics) == 0 {
+		return nil, zeroTime, errNoEntityMetrics
+	}
+
+	ts, ok := rc.Metrics[req.MetricName]
+	if !ok {
+		return nil, zeroTime, errNoSuchMetric
+	}
+	res := (*ts).Hour.Get(req.Start, req.End)
+	return res, rc.timestamp, nil
+}
+
+// GetNodeMetric returns a metric of a node entity, along with the latest timestamp.
+// GetNodeMetric returns a slice of TimePoints for that metric, with times starting AFTER the starting timestamp.
+func (rc *realModel) GetNodeMetric(req NodeMetricRequest) ([]statstore.TimePoint, time.Time, error) {
+	var zeroTime time.Time
+	rc.lock.RLock()
+	defer rc.lock.RUnlock()
+
+	if len(rc.Nodes) == 0 {
+		return nil, zeroTime, errModelEmpty
+	}
+	if _, ok := rc.Nodes[req.NodeName]; !ok {
+		return nil, zeroTime, errInvalidNode
+	}
+	if len(rc.Nodes[req.NodeName].Metrics) == 0 {
+		return nil, zeroTime, errNoEntityMetrics
+	}
+	ts, ok := rc.Nodes[req.NodeName].Metrics[req.MetricName]
+	if !ok {
+		return nil, zeroTime, errNoSuchMetric
+	}
+
+	res := (*ts).Hour.Get(req.Start, req.End)
+	return res, rc.timestamp, nil
+}
+
+// GetNamespaceMetric returns a metric of a namespace entity, along with the latest timestamp.
+// GetNamespaceMetric receives as arguments the namespace, the metric name and a start time.
+// GetNamespaceMetric returns a slice of TimePoints for that metric, with times starting AFTER the starting timestamp.
+func (rc *realModel) GetNamespaceMetric(req NamespaceMetricRequest) ([]statstore.TimePoint, time.Time, error) {
+	var zeroTime time.Time
+	rc.lock.RLock()
+	defer rc.lock.RUnlock()
+
+	if len(rc.Namespaces) == 0 {
+		return nil, zeroTime, errModelEmpty
+	}
+	ns, ok := rc.Namespaces[req.NamespaceName]
+	if !ok {
+		return nil, zeroTime, errNoSuchNamespace
+	}
+	if len(ns.Metrics) == 0 {
+		return nil, zeroTime, errNoEntityMetrics
+	}
+	ts, ok := ns.Metrics[req.MetricName]
+	if !ok {
+		return nil, zeroTime, errNoSuchMetric
+	}
+
+	res := (*ts).Hour.Get(req.Start, req.End)
+	return res, rc.timestamp, nil
+}
+
+// GetPodMetric returns a metric of a Pod entity, along with the latest timestamp.
+// GetPodMetric receives as arguments the namespace, the pod name, the metric name and a start time.
+// GetPodMetric returns a slice of TimePoints for that metric, with times starting AFTER the starting timestamp.
+func (rc *realModel) GetPodMetric(req PodMetricRequest) ([]statstore.TimePoint, time.Time, error) {
+	var zeroTime time.Time
+	rc.lock.RLock()
+	defer rc.lock.RUnlock()
+
+	if len(rc.Namespaces) == 0 {
+		return nil, zeroTime, errModelEmpty
+	}
+	ns, ok := rc.Namespaces[req.NamespaceName]
+	if !ok {
+		return nil, zeroTime, errNoSuchNamespace
+	}
+	pod, ok := ns.Pods[req.PodName]
+	if !ok {
+		return nil, zeroTime, errNoSuchPod
+	}
+	if len(pod.Metrics) == 0 {
+		return nil, zeroTime, errNoEntityMetrics
+	}
+	ts, ok := pod.Metrics[req.MetricName]
+	if !ok {
+		return nil, zeroTime, errNoSuchMetric
+	}
+
+	res := (*ts).Hour.Get(req.Start, req.End)
+	return res, rc.timestamp, nil
+}
+
+// GetBatchPodMetric returns metrics of a batch of Pod entities, along with the latest timestamp.
+// GetBatchPodMetric receives as arguments the namespace, the pod names, the metric name and a start time.
+// GetBatchPodMetric returns, for ach of the pods, slice of TimePoints for that metric, with times starting AFTER the starting timestamp
+// (possibly empty if )
+func (rc *realModel) GetBatchPodMetric(req BatchPodRequest) ([][]statstore.TimePoint, time.Time, error) {
+	var zeroTime time.Time
+	rc.lock.RLock()
+	defer rc.lock.RUnlock()
+
+	if len(rc.Namespaces) == 0 {
+		return nil, zeroTime, fmt.Errorf("the model is not populated yet")
+	}
+	ns, ok := rc.Namespaces[req.NamespaceName]
+	if !ok {
+		return nil, zeroTime, fmt.Errorf("the specified namespace is not present in the cluster")
+	}
+	result := make([][]statstore.TimePoint, len(req.PodNames))
+	for i, podName := range req.PodNames {
+		pod, ok := ns.Pods[podName]
+		if !ok {
+			result[i] = []statstore.TimePoint{}
+			continue
+		}
+		if len(pod.Metrics) == 0 {
+			result[i] = []statstore.TimePoint{}
+			continue
+		}
+		ts, ok := pod.Metrics[req.MetricName]
+		if !ok {
+			result[i] = []statstore.TimePoint{}
+			continue
+		}
+		res := (*ts).Hour.Get(req.Start, req.End)
+		result[i] = res
+	}
+	return result, rc.timestamp, nil
+}
+
+// GetPodContainerMetric returns a metric of a container entity that belongs in a Pod, along with the latest timestamp.
+// GetPodContainerMetric receives as arguments the namespace, the pod name, the container name, the metric name and a start time.
+// GetPodContainerMetric returns a slice of TimePoints for that metric, with times starting AFTER the starting timestamp.
+func (rc *realModel) GetPodContainerMetric(req PodContainerMetricRequest) ([]statstore.TimePoint, time.Time, error) {
+	var zeroTime time.Time
+	rc.lock.RLock()
+	defer rc.lock.RUnlock()
+
+	if len(rc.Namespaces) == 0 {
+		return nil, zeroTime, errModelEmpty
+	}
+	ns, ok := rc.Namespaces[req.NamespaceName]
+	if !ok {
+		return nil, zeroTime, errNoSuchNamespace
+	}
+	pod, ok := ns.Pods[req.PodName]
+	if !ok {
+		return nil, zeroTime, errNoSuchPod
+	}
+	ctr, ok := pod.Containers[req.ContainerName]
+	if !ok {
+		return nil, zeroTime, errNoSuchContainer
+	}
+	ts, ok := ctr.Metrics[req.MetricName]
+	if !ok {
+		return nil, zeroTime, errNoSuchMetric
+	}
+
+	res := (*ts).Hour.Get(req.Start, req.End)
+	return res, rc.timestamp, nil
+}
+
+// GetFreeContainerMetric returns a metric of a free container entity, along with the latest timestamp.
+// GetFreeContainerMetric receives as arguments the host name, the container name, the metric name and a start time.
+// GetFreeContainerMetric returns a slice of TimePoints for that metric, with times starting AFTER the starting timestamp.
+func (rc *realModel) GetFreeContainerMetric(req FreeContainerMetricRequest) ([]statstore.TimePoint, time.Time, error) {
+	var zeroTime time.Time
+	rc.lock.RLock()
+	defer rc.lock.RUnlock()
+	if len(rc.Nodes) == 0 {
+		return nil, zeroTime, errModelEmpty
+	}
+	node, ok := rc.Nodes[req.NodeName]
+	if !ok {
+		return nil, zeroTime, errInvalidNode
+	}
+	ctr, ok := node.FreeContainers[req.ContainerName]
+	if !ok {
+		return nil, zeroTime, errNoSuchContainer
+	}
+	ts, ok := ctr.Metrics[req.MetricName]
+	if !ok {
+		return nil, zeroTime, errNoSuchMetric
+	}
+
+	res := (*ts).Hour.Get(req.Start, req.End)
+	return res, rc.timestamp, nil
+}
+
+// makeEntityList creates an EntityListEntry from a map of metrics.
+func makeEntityListEntry(name string, entities map[string]*daystore.DayStore) EntityListEntry {
+	newListEntry := EntityListEntry{}
+	cpu, ok := entities[cpuUsage]
+	if !ok {
+		newListEntry.CPUUsage = uint64(0)
+	} else {
+		_, lastHourMaxCPU, err := cpu.Hour.Last()
+		if err != nil {
+			newListEntry.CPUUsage = uint64(0)
+		} else {
+			newListEntry.CPUUsage = lastHourMaxCPU
+		}
+	}
+
+	mem, ok := entities[memWorking]
+	if !ok {
+		newListEntry.MemUsage = uint64(0)
+	} else {
+		_, lastHourMaxMem, err := mem.Hour.Last()
+		if err != nil {
+			newListEntry.MemUsage = uint64(0)
+		} else {
+			newListEntry.MemUsage = lastHourMaxMem
+		}
+	}
+	newListEntry.Name = name
+
+	return newListEntry
+}
+
+// GetNodes returns a slice of EntityListEntry for all the nodes that are available on the cluster.
+func (rc *realModel) GetNodes() []EntityListEntry {
+	rc.lock.RLock()
+	defer rc.lock.RUnlock()
+
+	res := make([]EntityListEntry, 0)
+	for key, val := range rc.Nodes {
+		newEntity := makeEntityListEntry(key, val.Metrics)
+		// Ignore entities with no name populated (errors)
+		if newEntity.Name == "" {
+			continue
+		}
+		res = append(res, newEntity)
+	}
+	return res
+}
+
+// findPodNamespace finds the namespace name that a given PodInfo belongs to
+// assumes cluster lock is taken by the caller.
+func (rc *realModel) findPodNamespace(target *PodInfo) (string, error) {
+	for namespace, nsref := range rc.Namespaces {
+		for _, pod := range nsref.Pods {
+			if pod == target {
+				return namespace, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("the specified pod does not belong under a namespace")
+}
+
+// GetNodePods returns the names and latest usage values of all the pods
+// under a specific node.
+func (rc *realModel) GetNodePods(hostname string) []EntityListEntry {
+	rc.lock.RLock()
+	defer rc.lock.RUnlock()
+
+	res := make([]EntityListEntry, 0)
+	noderef, ok := rc.Nodes[hostname]
+	if !ok {
+		return res
+	}
+
+	for podname, val := range noderef.Pods {
+		// Set the Pod name as <namespace> / <podname>
+		namespace, err := rc.findPodNamespace(val)
+		if err != nil {
+			break
+		}
+		newEntity := makeEntityListEntry(namespace+"/"+podname, val.Metrics)
+		if newEntity.Name == "" {
+			continue
+		}
+		res = append(res, newEntity)
+	}
+	return res
+}
+
+// GetNamespaces returns the names and latest usage values of all the namespaces
+// that are available in the model.
+func (rc *realModel) GetNamespaces() []EntityListEntry {
+	rc.lock.RLock()
+	defer rc.lock.RUnlock()
+
+	res := make([]EntityListEntry, 0)
+	for key, val := range rc.Namespaces {
+		newEntity := makeEntityListEntry(key, val.Metrics)
+		if newEntity.Name == "" {
+			continue
+		}
+		res = append(res, newEntity)
+	}
+	return res
+}
+
+// GetPods returns the names and latest usage values of all the pods that are
+// available in the model under a specific namespace.
+func (rc *realModel) GetPods(namespace string) []EntityListEntry {
+	rc.lock.RLock()
+	defer rc.lock.RUnlock()
+
+	res := make([]EntityListEntry, 0)
+	ns, ok := rc.Namespaces[namespace]
+	if !ok {
+		return res
+	}
+
+	for key, val := range ns.Pods {
+		newEntity := makeEntityListEntry(key, val.Metrics)
+		if newEntity.Name == "" {
+			continue
+		}
+		res = append(res, newEntity)
+	}
+	return res
+}
+
+// GetPodContainers returns the names and latest usage values of all the containers
+// that are available in the model under a specific namespace and pod.
+func (rc *realModel) GetPodContainers(namespace string, pod string) []EntityListEntry {
+	rc.lock.RLock()
+	defer rc.lock.RUnlock()
+
+	res := make([]EntityListEntry, 0)
+	ns, ok := rc.Namespaces[namespace]
+	if !ok {
+		return res
+	}
+
+	podref, ok := ns.Pods[pod]
+	if !ok {
+		return res
+	}
+	for key, val := range podref.Containers {
+		newEntity := makeEntityListEntry(key, val.Metrics)
+		if newEntity.Name == "" {
+			continue
+		}
+		res = append(res, newEntity)
+	}
+	return res
+}
+
+// GetFreeContainers returns the names and latest usage values of all the containers
+// that are available in the model under a specific node.
+func (rc *realModel) GetFreeContainers(node string) []EntityListEntry {
+	rc.lock.RLock()
+	defer rc.lock.RUnlock()
+
+	res := make([]EntityListEntry, 0)
+	noderef, ok := rc.Nodes[node]
+	if !ok {
+		return res
+	}
+
+	for key, val := range noderef.FreeContainers {
+		newEntity := makeEntityListEntry(key, val.Metrics)
+		if newEntity.Name == "" {
+			continue
+		}
+		res = append(res, newEntity)
+	}
+	return res
+}
+
+// GetAvailableMetrics returns the names of all metrics that are available on the cluster.
+// Due to metric propagation, all entities of the cluster have the same metrics.
+func (rc *realModel) GetAvailableMetrics() []string {
+	rc.lock.RLock()
+	defer rc.lock.RUnlock()
+
+	res := make([]string, 0)
+	for key := range rc.Metrics {
+		res = append(res, key)
+	}
+	return res
+}
+
+// uptime returns the uptime of an entity, given its InfoType
+func (rc *realModel) uptime(infotype *InfoType) time.Duration {
+	return rc.timestamp.Sub(infotype.Creation)
+}

--- a/model/getters_test.go
+++ b/model/getters_test.go
@@ -1,0 +1,647 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestGetClusterMetric tests all flows of GetClusterMetric.
+func TestGetClusterMetric(t *testing.T) {
+	var (
+		model        = newRealModel(time.Minute)
+		source_cache = cacheFactory()
+		assert       = assert.New(t)
+		zeroTime     = time.Time{}
+		dummyRequest = MetricRequest{
+			MetricName: cpuUsage,
+			Start:      zeroTime,
+			End:        zeroTime,
+		}
+	)
+	// Invocation with no cluster metrics
+	res, stamp, err := model.GetClusterMetric(ClusterMetricRequest{
+		MetricRequest: dummyRequest,
+	})
+	assert.Error(err)
+	assert.Equal(stamp, zeroTime)
+	assert.Nil(res)
+
+	// Populate model
+	assert.NoError(model.Update(source_cache))
+
+	// Invocation with non-existant metric
+	dummyRequest.MetricName = "doesnotexist"
+	res, stamp, err = model.GetClusterMetric(ClusterMetricRequest{
+		MetricRequest: dummyRequest,
+	})
+	assert.Error(err)
+	assert.Equal(stamp, zeroTime)
+	assert.Nil(res)
+
+	// Normal Invocation - memoryUsage
+	dummyRequest.MetricName = memUsage
+	res, stamp, err = model.GetClusterMetric(ClusterMetricRequest{
+		MetricRequest: dummyRequest,
+	})
+	assert.NoError(err)
+	assert.NotEqual(stamp, zeroTime)
+	assert.NotNil(res)
+}
+
+// TestGetNodeMetric tests all flows of GetNodeMetric.
+func TestGetNodeMetric(t *testing.T) {
+	var (
+		zeroTime     = time.Time{}
+		model        = newRealModel(time.Minute)
+		source_cache = cacheFactory()
+		assert       = assert.New(t)
+		hostname     = "hostname3"
+		dummyRequest = MetricRequest{
+			MetricName: cpuUsage,
+			Start:      zeroTime,
+			End:        zeroTime,
+		}
+	)
+	// Invocation with no nodes in model
+	res, stamp, err := model.GetNodeMetric(NodeMetricRequest{
+		NodeName:      hostname,
+		MetricRequest: dummyRequest,
+	})
+	assert.Error(err)
+	assert.Equal(stamp, zeroTime)
+	assert.Nil(res)
+
+	// Populate model
+	assert.NoError(model.Update(source_cache))
+
+	// Invocation with non-existant node
+	res, stamp, err = model.GetNodeMetric(NodeMetricRequest{
+		NodeName:      "doesnotexist",
+		MetricRequest: dummyRequest,
+	})
+	assert.Error(err)
+	assert.Equal(stamp, zeroTime)
+	assert.Nil(res)
+
+	// Invocation with new node - no metrics
+	model.addNode("newnode")
+	res, stamp, err = model.GetNodeMetric(NodeMetricRequest{
+		NodeName:      "newnode",
+		MetricRequest: dummyRequest,
+	})
+	assert.Error(err)
+	assert.Equal(stamp, zeroTime)
+	assert.Nil(res)
+
+	// Invocation with non-existant metric
+	dummyRequest.MetricName = "doesnotexist"
+	res, stamp, err = model.GetNodeMetric(NodeMetricRequest{
+		NodeName:      hostname,
+		MetricRequest: dummyRequest,
+	})
+	assert.Error(err)
+	assert.Equal(stamp, zeroTime)
+	assert.Nil(res)
+
+	// Normal Invocation - memoryUsage
+	dummyRequest.MetricName = memUsage
+	res, stamp, err = model.GetNodeMetric(NodeMetricRequest{
+		NodeName:      hostname,
+		MetricRequest: dummyRequest,
+	})
+	assert.NoError(err)
+	assert.NotEqual(stamp, zeroTime)
+	assert.NotNil(res)
+}
+
+// TestGetNamespaceMetric tests all flows of GetNamespaceMetric.
+func TestGetNamespaceMetric(t *testing.T) {
+	var (
+		zeroTime     = time.Time{}
+		model        = newRealModel(time.Minute)
+		source_cache = cacheFactory()
+		assert       = assert.New(t)
+		namespace    = "test"
+		dummyRequest = MetricRequest{
+			MetricName: cpuUsage,
+			Start:      zeroTime,
+			End:        zeroTime,
+		}
+	)
+	// Invocation with no namespaces in model
+	res, stamp, err := model.GetNamespaceMetric(NamespaceMetricRequest{
+		NamespaceName: namespace,
+		MetricRequest: dummyRequest,
+	})
+	assert.Error(err)
+	assert.Equal(stamp, zeroTime)
+	assert.Nil(res)
+
+	// Populate model
+	assert.NoError(model.Update(source_cache))
+
+	// Invocation with non-existant namespace
+	res, stamp, err = model.GetNamespaceMetric(NamespaceMetricRequest{
+		NamespaceName: "doesnotexist",
+		MetricRequest: dummyRequest,
+	})
+	assert.Error(err)
+	assert.Equal(stamp, zeroTime)
+	assert.Nil(res)
+
+	// Invocation with new namespace - no metrics
+	model.addNamespace("newns")
+	res, stamp, err = model.GetNamespaceMetric(NamespaceMetricRequest{
+		NamespaceName: "newns",
+		MetricRequest: dummyRequest,
+	})
+	assert.Error(err)
+	assert.Equal(stamp, zeroTime)
+	assert.Nil(res)
+
+	// Invocation with non-existant metric
+	dummyRequest.MetricName = "doesnotexist"
+	res, stamp, err = model.GetNamespaceMetric(NamespaceMetricRequest{
+		NamespaceName: namespace,
+		MetricRequest: dummyRequest,
+	})
+	assert.Error(err)
+	assert.Equal(stamp, zeroTime)
+	assert.Nil(res)
+
+	// Normal Invocation - memoryUsage
+	dummyRequest.MetricName = memUsage
+	res, stamp, err = model.GetNamespaceMetric(NamespaceMetricRequest{
+		NamespaceName: namespace,
+		MetricRequest: dummyRequest,
+	})
+	assert.NoError(err)
+	assert.NotEqual(stamp, zeroTime)
+	assert.NotNil(res)
+}
+
+// TestGetPodMetric tests all flows of GetPodMetric.
+func TestGetPodMetric(t *testing.T) {
+	var (
+		zeroTime     = time.Time{}
+		model        = newRealModel(time.Minute)
+		source_cache = cacheFactory()
+		assert       = assert.New(t)
+		namespace    = "test"
+		pod          = "pod1"
+		dummyRequest = MetricRequest{
+			MetricName: cpuUsage,
+			Start:      zeroTime,
+			End:        zeroTime,
+		}
+	)
+	// Invocation with no namespaces in model
+	res, stamp, err := model.GetPodMetric(PodMetricRequest{
+		NamespaceName: namespace,
+		PodName:       pod,
+		MetricRequest: dummyRequest,
+	})
+	assert.Error(err)
+	assert.Equal(stamp, zeroTime)
+	assert.Nil(res)
+
+	// Populate model
+	assert.NoError(model.Update(source_cache))
+
+	// Invocation with non-existant namespace
+	res, stamp, err = model.GetPodMetric(PodMetricRequest{
+		NamespaceName: "doesnotexist",
+		PodName:       pod,
+		MetricRequest: dummyRequest,
+	})
+	assert.Error(err)
+	assert.Equal(stamp, zeroTime)
+	assert.Nil(res)
+
+	// Invocation with non-existant pod
+	res, stamp, err = model.GetPodMetric(PodMetricRequest{
+		NamespaceName: namespace,
+		PodName:       "otherpod",
+		MetricRequest: dummyRequest,
+	})
+	assert.Error(err)
+	assert.Equal(stamp, zeroTime)
+	assert.Nil(res)
+
+	// Invocation with non-existant metric
+	dummyRequest.MetricName = "doesnotexist"
+	res, stamp, err = model.GetPodMetric(PodMetricRequest{
+		NamespaceName: namespace,
+		PodName:       pod,
+		MetricRequest: dummyRequest,
+	})
+	assert.Error(err)
+	assert.Equal(stamp, zeroTime)
+	assert.Nil(res)
+
+	// Normal Invocation - memoryUsage
+	dummyRequest.MetricName = memUsage
+	res, stamp, err = model.GetPodMetric(PodMetricRequest{
+		NamespaceName: namespace,
+		PodName:       pod,
+		MetricRequest: dummyRequest,
+	})
+	assert.NoError(err)
+	assert.NotEqual(stamp, zeroTime)
+	assert.NotNil(res)
+}
+
+// TestGetBatchPodMetric tests all flows of GetBatchPodMetric.
+func TestGetBatchPodMetric(t *testing.T) {
+	var (
+		zeroTime     = time.Time{}
+		model        = newRealModel(time.Minute)
+		source_cache = cacheFactory()
+		assert       = assert.New(t)
+		namespace    = "test"
+		pod          = "pod1"
+	)
+
+	// Invocation with no namespaces in model
+	res, stamp, err := model.GetBatchPodMetric(BatchPodRequest{namespace, []string{pod}, cpuUsage, zeroTime, zeroTime})
+	assert.Error(err)
+	assert.Equal(stamp, zeroTime)
+	assert.Nil(res)
+
+	// Populate model
+	assert.NoError(model.Update(source_cache))
+
+	// Invocation with non-existant namespace
+	res, stamp, err = model.GetBatchPodMetric(BatchPodRequest{"doesnotexist", []string{pod}, cpuUsage, zeroTime, zeroTime})
+	assert.Error(err)
+	assert.Equal(stamp, zeroTime)
+	assert.Nil(res)
+
+	// Invocation with non-existant pod
+	res, stamp, err = model.GetBatchPodMetric(BatchPodRequest{namespace, []string{"otherpod"}, cpuUsage, zeroTime, zeroTime})
+	assert.NoError(err)
+	assert.NotEqual(stamp, zeroTime)
+	assert.NotNil(res)
+	assert.Equal(len(res[0]), 0)
+
+	// Invocation with non-existant metric
+	res, stamp, err = model.GetBatchPodMetric(BatchPodRequest{namespace, []string{pod}, "doesnotexist", zeroTime, zeroTime})
+	assert.NoError(err)
+	assert.NotEqual(stamp, zeroTime)
+	assert.NotNil(res)
+	assert.Equal(len(res[0]), 0)
+
+	// Normal Invocation - memoryUsage
+	res, stamp, err = model.GetBatchPodMetric(BatchPodRequest{namespace, []string{pod}, memUsage, zeroTime, zeroTime})
+	assert.NoError(err)
+	assert.NotEqual(stamp, zeroTime)
+	assert.NotNil(res)
+	assert.Equal(len(res[0]), 8)
+}
+
+// TestGetPodContainerMetric tests all flows of GetPodContainerMetric.
+func TestGetPodContainerMetric(t *testing.T) {
+	var (
+		zeroTime     = time.Time{}
+		model        = newRealModel(time.Minute)
+		source_cache = cacheFactory()
+		assert       = assert.New(t)
+		namespace    = "test"
+		pod          = "pod1"
+		container    = "container1"
+		dummyRequest = MetricRequest{
+			MetricName: cpuUsage,
+			Start:      zeroTime,
+			End:        zeroTime,
+		}
+	)
+	// Invocation with no namespaces in model
+	res, stamp, err := model.GetPodContainerMetric(PodContainerMetricRequest{
+		NamespaceName: namespace,
+		PodName:       pod,
+		ContainerName: container,
+		MetricRequest: dummyRequest,
+	})
+	assert.Error(err)
+	assert.Equal(stamp, zeroTime)
+	assert.Nil(res)
+
+	// Populate model
+	assert.NoError(model.Update(source_cache))
+
+	// Invocation with non-existant namespace
+	res, stamp, err = model.GetPodContainerMetric(PodContainerMetricRequest{
+		NamespaceName: "doesnotexist",
+		PodName:       pod,
+		ContainerName: container,
+		MetricRequest: dummyRequest,
+	})
+	assert.Error(err)
+	assert.Equal(stamp, zeroTime)
+	assert.Nil(res)
+
+	// Invocation with new namespace - no metrics
+	model.addNamespace("newns")
+	res, stamp, err = model.GetPodContainerMetric(PodContainerMetricRequest{
+		NamespaceName: "newns",
+		PodName:       pod,
+		ContainerName: container,
+		MetricRequest: dummyRequest,
+	})
+	assert.Error(err)
+	assert.Equal(stamp, zeroTime)
+	assert.Nil(res)
+
+	// Invocation with non-existant pod
+	res, stamp, err = model.GetPodContainerMetric(PodContainerMetricRequest{
+		NamespaceName: namespace,
+		PodName:       "otherpod",
+		ContainerName: container,
+		MetricRequest: dummyRequest,
+	})
+	assert.Error(err)
+	assert.Equal(stamp, zeroTime)
+	assert.Nil(res)
+
+	// Invocation with non-existant container
+	res, stamp, err = model.GetPodContainerMetric(PodContainerMetricRequest{
+		NamespaceName: namespace,
+		PodName:       pod,
+		ContainerName: "doesnotexist",
+		MetricRequest: dummyRequest,
+	})
+	assert.Error(err)
+	assert.Equal(stamp, zeroTime)
+	assert.Nil(res)
+
+	// Invocation with non-existant metric
+	dummyRequest.MetricName = "doesnotexist"
+	res, stamp, err = model.GetPodContainerMetric(PodContainerMetricRequest{
+		NamespaceName: namespace,
+		PodName:       pod,
+		ContainerName: container,
+		MetricRequest: dummyRequest,
+	})
+	assert.Error(err)
+	assert.Equal(stamp, zeroTime)
+	assert.Nil(res)
+
+	// Normal Invocation - memoryUsage
+	dummyRequest.MetricName = memUsage
+	res, stamp, err = model.GetPodContainerMetric(PodContainerMetricRequest{
+		NamespaceName: namespace,
+		PodName:       pod,
+		ContainerName: container,
+		MetricRequest: dummyRequest,
+	})
+	assert.NoError(err)
+	assert.NotEqual(stamp, zeroTime)
+	assert.NotNil(res)
+}
+
+// TestGetFreeContainerMetric tests all flows of GetFreeContainerMetric.
+func TestGetFreeContainerMetric(t *testing.T) {
+	var (
+		zeroTime     = time.Time{}
+		model        = newRealModel(time.Minute)
+		source_cache = cacheFactory()
+		assert       = assert.New(t)
+		node         = "hostname2"
+		container    = "free_container1"
+		dummyRequest = MetricRequest{
+			MetricName: cpuUsage,
+			Start:      zeroTime,
+			End:        zeroTime,
+		}
+	)
+	// Invocation with no nodes in model
+	res, stamp, err := model.GetFreeContainerMetric(FreeContainerMetricRequest{
+		NodeName:      node,
+		ContainerName: container,
+		MetricRequest: dummyRequest,
+	})
+	assert.Error(err)
+	assert.Equal(stamp, zeroTime)
+	assert.Nil(res)
+
+	// Populate model
+	assert.NoError(model.Update(source_cache))
+
+	// Invocation with non-existant node
+	res, stamp, err = model.GetFreeContainerMetric(FreeContainerMetricRequest{
+		NodeName:      "doesnotexist",
+		ContainerName: container,
+		MetricRequest: dummyRequest,
+	})
+	assert.Error(err)
+	assert.Equal(stamp, zeroTime)
+	assert.Nil(res)
+
+	// Invocation with new node - no metrics
+	model.addNode("newnode")
+	res, stamp, err = model.GetFreeContainerMetric(FreeContainerMetricRequest{
+		NodeName:      "newnode",
+		ContainerName: container,
+		MetricRequest: dummyRequest,
+	})
+	assert.Error(err)
+	assert.Equal(stamp, zeroTime)
+	assert.Nil(res)
+
+	// Invocation with non-existant container
+	res, stamp, err = model.GetFreeContainerMetric(FreeContainerMetricRequest{
+		NodeName:      node,
+		ContainerName: "not_actual_ctr",
+		MetricRequest: dummyRequest,
+	})
+	assert.Error(err)
+	assert.Equal(stamp, zeroTime)
+	assert.Nil(res)
+
+	// Invocation with non-existant metric
+	dummyRequest.MetricName = "doesnotexist"
+	res, stamp, err = model.GetFreeContainerMetric(FreeContainerMetricRequest{
+		NodeName:      node,
+		ContainerName: container,
+		MetricRequest: dummyRequest,
+	})
+	assert.Error(err)
+	assert.Equal(stamp, zeroTime)
+	assert.Nil(res)
+
+	// Normal Invocation - memoryUsage
+	dummyRequest.MetricName = memUsage
+	res, stamp, err = model.GetFreeContainerMetric(FreeContainerMetricRequest{
+		NodeName:      node,
+		ContainerName: container,
+		MetricRequest: dummyRequest,
+	})
+	assert.NoError(err)
+	assert.NotEqual(stamp, zeroTime)
+	assert.NotNil(res)
+}
+
+//TestGetNodes tests the flow of GetNodes.
+func TestGetNodes(t *testing.T) {
+	var (
+		model        = newRealModel(time.Minute)
+		source_cache = cacheFactory()
+		assert       = assert.New(t)
+	)
+	// Invocation with empty model
+	res := model.GetNodes()
+	assert.Len(res, 0)
+
+	// Populate model
+	assert.NoError(model.Update(source_cache))
+
+	// Normal Invocation
+	res = model.GetNodes()
+	assert.Len(res, 2)
+}
+
+//TestGetNodePods tests the flow of GetNodePods.
+func TestGetNodePods(t *testing.T) {
+	var (
+		model        = newRealModel(time.Minute)
+		source_cache = cacheFactory()
+		assert       = assert.New(t)
+	)
+	// Populate model
+	assert.NoError(model.Update(source_cache))
+
+	// Invocation with nonexistant node
+	res := model.GetNodePods("nonexistant")
+	assert.Len(res, 0)
+
+	// Normal Invocation
+	res = model.GetNodePods("hostname2")
+	assert.Len(res, 1)
+}
+
+//TestGetNamespaces tests the flow of GetNamespaces.
+func TestGetNamespaces(t *testing.T) {
+	var (
+		model        = newRealModel(time.Minute)
+		source_cache = cacheFactory()
+		assert       = assert.New(t)
+	)
+	// Invocation with empty model
+	res := model.GetNamespaces()
+	assert.Len(res, 0)
+
+	// Populate model
+	assert.NoError(model.Update(source_cache))
+
+	// Normal Invocation
+	res = model.GetNamespaces()
+	assert.Len(res, 1)
+}
+
+//TestGetPods tests the flow of GetPods.
+func TestGetPods(t *testing.T) {
+	var (
+		model        = newRealModel(time.Minute)
+		source_cache = cacheFactory()
+		assert       = assert.New(t)
+	)
+	// Invocation with empty model
+	res := model.GetPods("test")
+	assert.Len(res, 0)
+
+	// Populate model
+	assert.NoError(model.Update(source_cache))
+
+	// Normal Invocation
+	res = model.GetPods("test")
+	assert.Len(res, 2)
+
+	// Invocation with non-existant namespace
+	res = model.GetPods("fakenamespace")
+	assert.Len(res, 0)
+}
+
+//TestGetPodContainers tests the flow of GetPodContainers.
+func TestGetPodContainers(t *testing.T) {
+	var (
+		model        = newRealModel(time.Minute)
+		source_cache = cacheFactory()
+		assert       = assert.New(t)
+	)
+	// Invocation with empty model
+	res := model.GetPodContainers("test", "pod1")
+	assert.Len(res, 0)
+
+	// Populate model
+	assert.NoError(model.Update(source_cache))
+
+	// Normal Invocation
+	res = model.GetPodContainers("test", "pod1")
+	assert.Len(res, 2)
+
+	// Invocation with non-existant namespace
+	res = model.GetPodContainers("fail", "pod1")
+	assert.Len(res, 0)
+
+	// Invocation with non-existant pod
+	res = model.GetPodContainers("test", "pod5")
+	assert.Len(res, 0)
+}
+
+//TestGetFreeContainers tests the flow of GetFreeContainers.
+func TestGetFreeContainers(t *testing.T) {
+	var (
+		model        = newRealModel(time.Minute)
+		source_cache = cacheFactory()
+		assert       = assert.New(t)
+	)
+	// Invocation with empty model
+	res := model.GetFreeContainers("hostname2")
+	assert.Len(res, 0)
+
+	// Populate model
+	assert.NoError(model.Update(source_cache))
+
+	// Normal Invocation
+	res = model.GetFreeContainers("hostname2")
+	assert.Len(res, 1)
+
+	// Invocation with non-existant node
+	res = model.GetFreeContainers("hostname9")
+	assert.Len(res, 0)
+}
+
+// TestGetAvailableMetrics tests the flow of GetAvailableMetrics.
+func TestGetAvailableMetrics(t *testing.T) {
+	var (
+		model        = newRealModel(time.Minute)
+		source_cache = cacheFactory()
+		assert       = assert.New(t)
+	)
+	// Invocation with no model metrics
+	res := model.GetAvailableMetrics()
+	assert.Len(res, 0)
+
+	// Populate model
+	assert.NoError(model.Update(source_cache))
+
+	// Normal Invocation
+	res = model.GetAvailableMetrics()
+	assert.Len(res, 7)
+}

--- a/model/impl.go
+++ b/model/impl.go
@@ -22,327 +22,33 @@ import (
 	"github.com/golang/glog"
 
 	"k8s.io/heapster/sinks/cache"
-	"k8s.io/heapster/store"
+	"k8s.io/heapster/store/daystore"
+	"k8s.io/heapster/store/statstore"
 )
 
-// NewCluster returns a new Cluster.
-// Receives a TimeStore constructor function and a Duration resolution for stored data.
-func NewCluster(tsConstructor func() store.TimeStore, resolution time.Duration) Cluster {
-	return newRealCluster(tsConstructor, resolution)
+// NewModel returns a new Model.
+// Receives a DayStore constructor function and a Duration resolution for stored data.
+func NewModel(resolution time.Duration) Model {
+	return newRealModel(resolution)
 }
 
-// newRealCluster returns a realCluster, given a TimeStore constructor and a Duration resolution.
-func newRealCluster(tsConstructor func() store.TimeStore, resolution time.Duration) *realCluster {
+// newRealModel returns a realModel, given a DayStore constructor and a Duration resolution.
+func newRealModel(resolution time.Duration) *realModel {
 	cinfo := ClusterInfo{
 		InfoType:   newInfoType(nil, nil, nil),
 		Namespaces: make(map[string]*NamespaceInfo),
 		Nodes:      make(map[string]*NodeInfo),
 	}
-	cluster := &realCluster{
-		timestamp:     time.Time{},
-		ClusterInfo:   cinfo,
-		tsConstructor: tsConstructor,
-		resolution:    resolution,
+	model := &realModel{
+		timestamp:   time.Time{},
+		ClusterInfo: cinfo,
+		resolution:  resolution,
 	}
-	return cluster
+	return model
 }
 
-// GetClusterMetric returns a metric of the cluster entity, along with the latest timestamp.
-// GetClusterMetric returns a slice of TimePoints for that metric, with times starting AFTER the starting timestamp.
-func (rc *realCluster) GetClusterMetric(req ClusterRequest) ([]store.TimePoint, time.Time, error) {
-	var zeroTime time.Time
-	rc.lock.RLock()
-	defer rc.lock.RUnlock()
-
-	if len(rc.Metrics) == 0 {
-		return nil, zeroTime, fmt.Errorf("cluster metrics are not populated yet")
-	}
-
-	ts, ok := rc.Metrics[req.MetricName]
-	if !ok {
-		return nil, zeroTime, fmt.Errorf("the requested metric is not present")
-	}
-	res := (*ts).Get(req.Start, req.End)
-	return res, rc.timestamp, nil
-}
-
-// GetNodeMetric returns a metric of a node entity, along with the latest timestamp.
-// GetNodeMetric returns a slice of TimePoints for that metric, with times starting AFTER the starting timestamp.
-func (rc *realCluster) GetNodeMetric(req NodeRequest) ([]store.TimePoint, time.Time, error) {
-	var zeroTime time.Time
-	rc.lock.RLock()
-	defer rc.lock.RUnlock()
-
-	if len(rc.Nodes) == 0 {
-		return nil, zeroTime, fmt.Errorf("the model is not populated yet")
-	}
-	if _, ok := rc.Nodes[req.NodeName]; !ok {
-		return nil, zeroTime, fmt.Errorf("the requested node is not present in the cluster")
-	}
-	if len(rc.Nodes[req.NodeName].Metrics) == 0 {
-		return nil, zeroTime, fmt.Errorf("the requested node is not populated with metrics yet")
-	}
-	ts, ok := rc.Nodes[req.NodeName].Metrics[req.MetricName]
-	if !ok {
-		return nil, zeroTime, fmt.Errorf("the requested node metric is not present in the model")
-	}
-
-	res := (*ts).Get(req.Start, req.End)
-	return res, rc.timestamp, nil
-}
-
-// GetNamespaceMetric returns a metric of a namespace entity, along with the latest timestamp.
-// GetNamespaceMetric receives as arguments the namespace, the metric name and a start time.
-// GetNamespaceMetric returns a slice of TimePoints for that metric, with times starting AFTER the starting timestamp.
-func (rc *realCluster) GetNamespaceMetric(req NamespaceRequest) ([]store.TimePoint, time.Time, error) {
-	var zeroTime time.Time
-	rc.lock.RLock()
-	defer rc.lock.RUnlock()
-
-	if len(rc.Namespaces) == 0 {
-		return nil, zeroTime, fmt.Errorf("the model is not populated yet")
-	}
-	ns, ok := rc.Namespaces[req.NamespaceName]
-	if !ok {
-		return nil, zeroTime, fmt.Errorf("the requested namespace is not present in the cluster")
-	}
-	if len(ns.Metrics) == 0 {
-		return nil, zeroTime, fmt.Errorf("the requested namespace is not populated with metrics yet")
-	}
-	ts, ok := ns.Metrics[req.MetricName]
-	if !ok {
-		return nil, zeroTime, fmt.Errorf("the requested namespace metric is not present in the model")
-	}
-
-	res := (*ts).Get(req.Start, req.End)
-	return res, rc.timestamp, nil
-}
-
-// GetPodMetric returns a metric of a Pod entity, along with the latest timestamp.
-// GetPodMetric receives as arguments the namespace, the pod name, the metric name and a start time.
-// GetPodMetric returns a slice of TimePoints for that metric, with times starting AFTER the starting timestamp.
-func (rc *realCluster) GetPodMetric(req PodRequest) ([]store.TimePoint, time.Time, error) {
-	var zeroTime time.Time
-	rc.lock.RLock()
-	defer rc.lock.RUnlock()
-
-	if len(rc.Namespaces) == 0 {
-		return nil, zeroTime, fmt.Errorf("the model is not populated yet")
-	}
-	ns, ok := rc.Namespaces[req.NamespaceName]
-	if !ok {
-		return nil, zeroTime, fmt.Errorf("the specified namespace is not present in the cluster")
-	}
-	pod, ok := ns.Pods[req.PodName]
-	if !ok {
-		return nil, zeroTime, fmt.Errorf("the requested pod is not present in the specified namespace")
-	}
-	if len(pod.Metrics) == 0 {
-		return nil, zeroTime, fmt.Errorf("the requested pod is not populated with metrics yet")
-	}
-	ts, ok := pod.Metrics[req.MetricName]
-	if !ok {
-		return nil, zeroTime, fmt.Errorf("the requested pod metric is not present in the model")
-	}
-
-	res := (*ts).Get(req.Start, req.End)
-	return res, rc.timestamp, nil
-}
-
-// GetPodMetric returns metrics of a batch of Pod entities, along with the latest timestamp.
-// GetPodMetric receives as arguments the namespace, the pod names, the metric name and a start time.
-// GetPodMetric returns, for ach of the pods, slice of TimePoints for that metric, with times starting AFTER the starting timestamp
-// (possibly empty if )
-func (rc *realCluster) GetBatchPodMetric(req BatchPodRequest) ([][]store.TimePoint, time.Time, error) {
-	var zeroTime time.Time
-	rc.lock.RLock()
-	defer rc.lock.RUnlock()
-
-	if len(rc.Namespaces) == 0 {
-		return nil, zeroTime, fmt.Errorf("the model is not populated yet")
-	}
-	ns, ok := rc.Namespaces[req.NamespaceName]
-	if !ok {
-		return nil, zeroTime, fmt.Errorf("the specified namespace is not present in the cluster")
-	}
-	result := make([][]store.TimePoint, len(req.PodNames))
-	for i, podName := range req.PodNames {
-		pod, ok := ns.Pods[podName]
-		if !ok {
-			result[i] = []store.TimePoint{}
-			continue
-		}
-		if len(pod.Metrics) == 0 {
-			result[i] = []store.TimePoint{}
-			continue
-		}
-		ts, ok := pod.Metrics[req.MetricName]
-		if !ok {
-			result[i] = []store.TimePoint{}
-			continue
-		}
-		res := (*ts).Get(req.Start, req.End)
-		result[i] = res
-	}
-	return result, rc.timestamp, nil
-}
-
-// GetPodContainerMetric returns a metric of a container entity that belongs in a Pod, along with the latest timestamp.
-// GetPodContainerMetric receives as arguments the namespace, the pod name, the container name, the metric name and a start time.
-// GetPodContainerMetric returns a slice of TimePoints for that metric, with times starting AFTER the starting timestamp.
-func (rc *realCluster) GetPodContainerMetric(req PodContainerRequest) ([]store.TimePoint, time.Time, error) {
-	var zeroTime time.Time
-	rc.lock.RLock()
-	defer rc.lock.RUnlock()
-
-	if len(rc.Namespaces) == 0 {
-		return nil, zeroTime, fmt.Errorf("the model is not populated yet")
-	}
-	ns, ok := rc.Namespaces[req.NamespaceName]
-	if !ok {
-		return nil, zeroTime, fmt.Errorf("the specified namespace is not present in the cluster")
-	}
-	pod, ok := ns.Pods[req.PodName]
-	if !ok {
-		return nil, zeroTime, fmt.Errorf("the specified pod is not present in the specified namespace")
-	}
-	ctr, ok := pod.Containers[req.ContainerName]
-	if !ok {
-		return nil, zeroTime, fmt.Errorf("the requested container is not present under the specified pod")
-	}
-	ts, ok := ctr.Metrics[req.MetricName]
-	if !ok {
-		return nil, zeroTime, fmt.Errorf("the requested container metric is not present in the model")
-	}
-
-	res := (*ts).Get(req.Start, req.End)
-	return res, rc.timestamp, nil
-}
-
-// GetFreeContainerMetric returns a metric of a free container entity, along with the latest timestamp.
-// GetFreeContainerMetric receives as arguments the host name, the container name, the metric name and a start time.
-// GetFreeContainerMetric returns a slice of TimePoints for that metric, with times starting AFTER the starting timestamp.
-func (rc *realCluster) GetFreeContainerMetric(req FreeContainerRequest) ([]store.TimePoint, time.Time, error) {
-	var zeroTime time.Time
-	rc.lock.RLock()
-	defer rc.lock.RUnlock()
-	if len(rc.Nodes) == 0 {
-		return nil, zeroTime, fmt.Errorf("the model is not populated yet")
-	}
-	node, ok := rc.Nodes[req.NodeName]
-	if !ok {
-		return nil, zeroTime, fmt.Errorf("the requested node is not present in the cluster")
-	}
-	ctr, ok := node.FreeContainers[req.ContainerName]
-	if !ok {
-		return nil, zeroTime, fmt.Errorf("the requested container is not present under the specified node")
-	}
-	ts, ok := ctr.Metrics[req.MetricName]
-	if !ok {
-		return nil, zeroTime, fmt.Errorf("the requested container metric is not present in the model")
-	}
-
-	res := (*ts).Get(req.Start, req.End)
-	return res, rc.timestamp, nil
-}
-
-// GetNodes returns the names (hostnames) of all the nodes that are available on the cluster.
-func (rc *realCluster) GetNodes() []string {
-	rc.lock.RLock()
-	defer rc.lock.RUnlock()
-
-	res := make([]string, 0)
-	for key := range rc.Nodes {
-		res = append(res, key)
-	}
-	return res
-}
-
-// GetNamespaces returns the names of all the namespaces that are available on the cluster.
-func (rc *realCluster) GetNamespaces() []string {
-	rc.lock.RLock()
-	defer rc.lock.RUnlock()
-
-	res := make([]string, 0)
-	for key := range rc.Namespaces {
-		res = append(res, key)
-	}
-	return res
-}
-
-// GetPods returns the names of all the pods that are available on the cluster, under a specific namespace.
-func (rc *realCluster) GetPods(namespace string) []string {
-	rc.lock.RLock()
-	defer rc.lock.RUnlock()
-
-	res := make([]string, 0)
-	ns, ok := rc.Namespaces[namespace]
-	if !ok {
-		return res
-	}
-
-	for key := range ns.Pods {
-		res = append(res, key)
-	}
-	return res
-}
-
-// GetPodContainers returns the names of all the containers that are available on the cluster,
-// under a specific namespace and pod.
-func (rc *realCluster) GetPodContainers(namespace string, pod string) []string {
-	rc.lock.RLock()
-	defer rc.lock.RUnlock()
-
-	res := make([]string, 0)
-	ns, ok := rc.Namespaces[namespace]
-	if !ok {
-		return res
-	}
-
-	podref, ok := ns.Pods[pod]
-	if !ok {
-		return res
-	}
-
-	for key := range podref.Containers {
-		res = append(res, key)
-	}
-	return res
-}
-
-// GetFreeContainers returns the names of all the containers that are available on the cluster,
-// under a specific node.
-func (rc *realCluster) GetFreeContainers(node string) []string {
-	rc.lock.RLock()
-	defer rc.lock.RUnlock()
-
-	res := make([]string, 0)
-	noderef, ok := rc.Nodes[node]
-	if !ok {
-		return res
-	}
-
-	for key := range noderef.FreeContainers {
-		res = append(res, key)
-	}
-	return res
-}
-
-// GetAvailableMetrics returns the names of all metrics that are available on the cluster.
-// Due to metric propagation, all entities of the cluster have the same metrics.
-func (rc *realCluster) GetAvailableMetrics() []string {
-	rc.lock.RLock()
-	defer rc.lock.RUnlock()
-
-	res := make([]string, 0)
-	for key := range rc.Metrics {
-		res = append(res, key)
-	}
-	return res
-}
-
-// updateTime updates the Cluster timestamp to the specified time.
-func (rc *realCluster) updateTime(new_time time.Time) {
+// updateTime updates the Model timestamp to the specified time.
+func (rc *realModel) updateTime(new_time time.Time) {
 	if new_time.Equal(time.Time{}) {
 		return
 	}
@@ -354,7 +60,7 @@ func (rc *realCluster) updateTime(new_time time.Time) {
 // addNode creates or finds a NodeInfo element for the provided (internal) hostname.
 // addNode returns a pointer to the NodeInfo element that was created or found.
 // addNode assumes an appropriate lock is already taken by the caller.
-func (rc *realCluster) addNode(hostname string) *NodeInfo {
+func (rc *realModel) addNode(hostname string) *NodeInfo {
 	var node_ptr *NodeInfo
 
 	if val, ok := rc.Nodes[hostname]; ok {
@@ -377,7 +83,7 @@ func (rc *realCluster) addNode(hostname string) *NodeInfo {
 // addNamespace creates or finds a NamespaceInfo element for the provided namespace.
 // addNamespace returns a pointer to the NamespaceInfo element that was created or found.
 // addNamespace assumes an appropriate lock is already taken by the caller.
-func (rc *realCluster) addNamespace(name string) *NamespaceInfo {
+func (rc *realModel) addNamespace(name string) *NamespaceInfo {
 	var namespace_ptr *NamespaceInfo
 
 	if val, ok := rc.Namespaces[name]; ok {
@@ -398,7 +104,7 @@ func (rc *realCluster) addNamespace(name string) *NamespaceInfo {
 // addPod creates or finds a PodInfo element under the provided NodeInfo and NamespaceInfo.
 // addPod returns a pointer to the PodInfo element that was created or found.
 // addPod assumes an appropriate lock is already taken by the caller.
-func (rc *realCluster) addPod(pod_name string, pod_uid string, namespace *NamespaceInfo, node *NodeInfo) *PodInfo {
+func (rc *realModel) addPod(pod_name string, pod_uid string, namespace *NamespaceInfo, node *NodeInfo) *PodInfo {
 	var pod_ptr *PodInfo
 	var in_ns bool
 	var in_node bool
@@ -440,35 +146,51 @@ func (rc *realCluster) addPod(pod_name string, pod_uid string, namespace *Namesp
 }
 
 // updateInfoType updates the metrics of an InfoType from a ContainerElement.
-// updateInfoType returns the latest timestamp in the resulting TimeStore.
+// updateInfoType returns the latest timestamp in the resulting DayStore.
 // updateInfoType does not fail if a single ContainerMetricElement cannot be parsed.
-func (rc *realCluster) updateInfoType(info *InfoType, ce *cache.ContainerElement) (time.Time, error) {
-	var latest_time time.Time
+func (rc *realModel) updateInfoType(info *InfoType, ce *cache.ContainerElement) (time.Time, error) {
+	var latestTime time.Time
+	var err error
 
 	if ce == nil {
-		return latest_time, fmt.Errorf("cannot update InfoType from nil ContainerElement")
+		return latestTime, fmt.Errorf("cannot update InfoType from nil ContainerElement")
 	}
 	if info == nil {
-		return latest_time, fmt.Errorf("cannot update a nil InfoType")
+		return latestTime, fmt.Errorf("cannot update a nil InfoType")
 	}
 
 	// call parseMetric in a time-ascending order
+	parsed := 0
 	for i := len(ce.Metrics) - 1; i >= 0; i-- {
-		stamp, err := rc.parseMetric(ce.Metrics[i], info.Metrics, info.Context)
+		cme := ce.Metrics[i]
+		if cme == nil {
+			continue
+		}
+		stamp, err := rc.parseMetric(cme, info.Metrics, info.Context)
 		if err != nil {
 			glog.Warningf("failed to parse ContainerMetricElement: %s", err)
 			continue
 		}
-		latest_time = latestTimestamp(latest_time, stamp)
+		parsed += 1
+		latestTime = latestTimestamp(latestTime, stamp)
+
+		if info.Creation.Equal(time.Time{}) || cme.Spec.CreationTime.Before(info.Creation) {
+			info.Creation = cme.Spec.CreationTime
+		}
 	}
-	return latest_time, nil
+
+	// Return the latest error if we were unable to process any CME completely
+	if parsed == 0 {
+		return latestTime, err
+	}
+	return latestTime, nil
 }
 
-// addMetricToMap adds a new metric (time-value pair) to a map of TimeStores.
-// addMetricToMap accepts as arguments the metric name, timestamp, value and the TimeStore map.
+// addMetricToMap adds a new metric (time-value pair) to a map of DayStore.
+// addMetricToMap accepts as arguments the metric name, timestamp, value and the DayStore map.
 // The timestamp argument needs to be already rounded to the cluster resolution.
-func (rc *realCluster) addMetricToMap(metric string, timestamp time.Time, value uint64, dict map[string]*store.TimeStore) error {
-	point := store.TimePoint{
+func (rc *realModel) addMetricToMap(metric string, timestamp time.Time, value uint64, dict map[string]*daystore.DayStore) error {
+	point := statstore.TimePoint{
 		Timestamp: timestamp,
 		Value:     value,
 	}
@@ -476,22 +198,23 @@ func (rc *realCluster) addMetricToMap(metric string, timestamp time.Time, value 
 		ts := *val
 		err := ts.Put(point)
 		if err != nil {
-			return fmt.Errorf("failed to add metric to TimeStore: %s", err)
+			return fmt.Errorf("failed to add metric to DayStore: %s", err)
 		}
 	} else {
-		new_ts := rc.tsConstructor()
+		new_ts := daystore.NewDayStore(epsilonFromMetric(metric), rc.resolution)
 		err := new_ts.Put(point)
 		if err != nil {
-			return fmt.Errorf("failed to add metric to TimeStore: %s", err)
+			return fmt.Errorf("failed to add metric to DayStore: %s", err)
 		}
-		dict[metric] = &new_ts
+		dict[metric] = new_ts
 	}
 	return nil
 }
 
-// parseMetric populates a map[string]*TimeStore from a ContainerMetricElement.
+// parseMetric populates a map[string]*DayStore from a ContainerMetricElement.
 // parseMetric returns the ContainerMetricElement timestamp, iff successful.
-func (rc *realCluster) parseMetric(cme *cache.ContainerMetricElement, dict map[string]*store.TimeStore, context map[string]*store.TimePoint) (time.Time, error) {
+// TODO(afein): handle limits as constants
+func (rc *realModel) parseMetric(cme *cache.ContainerMetricElement, dict map[string]*daystore.DayStore, context map[string]*statstore.TimePoint) (time.Time, error) {
 	zeroTime := time.Time{}
 	if cme == nil {
 		return zeroTime, fmt.Errorf("cannot parse nil ContainerMetricElement")
@@ -507,10 +230,10 @@ func (rc *realCluster) parseMetric(cme *cache.ContainerMetricElement, dict map[s
 	timestamp := cme.Stats.Timestamp
 	roundedStamp := timestamp.Truncate(rc.resolution)
 
-	// TODO(alex): refactor to avoid repetition
+	// TODO: refactor for readability
 	if cme.Spec.HasCpu {
 		// Append to CPU Limit metric
-		cpu_limit := cme.Spec.Cpu.Limit
+		cpu_limit := cme.Spec.Cpu.Limit * 1000 / 1024 // convert to millicores
 		err := rc.addMetricToMap(cpuLimit, roundedStamp, cpu_limit, dict)
 		if err != nil {
 			return zeroTime, fmt.Errorf("failed to add %s metric: %s", cpuLimit, err)
@@ -523,18 +246,17 @@ func (rc *realCluster) parseMetric(cme *cache.ContainerMetricElement, dict map[s
 		prevTP, ok := context[cpuUsage]
 		if !ok && cpu_usage != 0 {
 			// Context is empty, add the first TimePoint for cumulative cpuUsage.
-			context[cpuUsage] = &store.TimePoint{
+			context[cpuUsage] = &statstore.TimePoint{
 				Timestamp: timestamp,
 				Value:     cpu_usage,
 			}
 		} else {
 			prevRoundedStamp := prevTP.Timestamp.Truncate(rc.resolution)
 
-			// check if the container was restarted since the last context timestamp
 			if cme.Spec.CreationTime.After(prevTP.Timestamp) {
-				// TODO(afein): mark as a container crash event
+				// check if the container was restarted since the last context timestamp
 				// Reset the context
-				context[cpuUsage] = &store.TimePoint{
+				context[cpuUsage] = &statstore.TimePoint{
 					Timestamp: timestamp,
 					Value:     cpu_usage,
 				}
@@ -550,8 +272,6 @@ func (rc *realCluster) parseMetric(cme *cache.ContainerMetricElement, dict map[s
 				if err != nil {
 					return zeroTime, fmt.Errorf("failed to add %s metric: %s", cpuUsage, err)
 				}
-			} else {
-				glog.Warningf("Internal Error: reached unreachable CPU Usage parsing flow")
 			}
 		}
 	}
@@ -603,17 +323,15 @@ func (rc *realCluster) parseMetric(cme *cache.ContainerMetricElement, dict map[s
 }
 
 // Update populates the data structure from a cache.
-func (rc *realCluster) Update(c cache.Cache) error {
+func (rc *realModel) Update(c cache.Cache) error {
 	var zero time.Time
 	latest_time := rc.timestamp
-	glog.V(2).Infoln("Schema Update operation started")
+	glog.V(2).Infoln("Model Update operation started")
 
-	// Invoke cache methods using the Cluster timestamp
-	// Iterate through the results in time-ascending order to maintain the context for cumulative metrics
-
+	// Invoke cache methods using the Model timestamp
 	nodes := c.GetNodes(rc.timestamp, zero)
-	for i := len(nodes) - 1; i >= 0; i-- {
-		timestamp, err := rc.updateNode(nodes[i])
+	for _, node := range nodes {
+		timestamp, err := rc.updateNode(node)
 		if err != nil {
 			return fmt.Errorf("Failed to Update Node Information: %s", err)
 		}
@@ -639,9 +357,9 @@ func (rc *realCluster) Update(c cache.Cache) error {
 	}
 
 	// Perform metrics aggregation
-	rc.aggregationStep()
+	rc.aggregationStep(latest_time)
 
-	// Update the Cluster timestamp to the latest time found in the new metrics
+	// Update the Model timestamp to the latest time found in the new metrics
 	rc.updateTime(latest_time)
 
 	glog.V(2).Infoln("Schema Update operation completed")
@@ -649,7 +367,7 @@ func (rc *realCluster) Update(c cache.Cache) error {
 }
 
 // updateNode updates Node-level information from a "machine"-tagged ContainerElement.
-func (rc *realCluster) updateNode(node_container *cache.ContainerElement) (time.Time, error) {
+func (rc *realModel) updateNode(node_container *cache.ContainerElement) (time.Time, error) {
 	if node_container.Name != "machine" {
 		return time.Time{}, fmt.Errorf("Received node-level container with unexpected name: %s", node_container.Name)
 	}
@@ -664,7 +382,7 @@ func (rc *realCluster) updateNode(node_container *cache.ContainerElement) (time.
 }
 
 // updatePod updates Pod-level information from a PodElement.
-func (rc *realCluster) updatePod(pod *cache.PodElement) (time.Time, error) {
+func (rc *realModel) updatePod(pod *cache.PodElement) (time.Time, error) {
 	if pod == nil {
 		return time.Time{}, fmt.Errorf("nil PodElement provided to updatePod")
 	}
@@ -697,8 +415,8 @@ func (rc *realCluster) updatePod(pod *cache.PodElement) (time.Time, error) {
 
 // updatePodContainer updates a Pod's Container-level information from a ContainerElement.
 // updatePodContainer receives a PodInfo pointer and a ContainerElement pointer.
-// Assumes Cluster lock is already taken.
-func (rc *realCluster) updatePodContainer(pod_info *PodInfo, ce *cache.ContainerElement) (time.Time, error) {
+// Assumes Model lock is already taken.
+func (rc *realModel) updatePodContainer(pod_info *PodInfo, ce *cache.ContainerElement) (time.Time, error) {
 	// Get Container pointer and update its InfoType
 	cinfo := addContainerToMap(ce.Name, pod_info.Containers)
 	latest_time, err := rc.updateInfoType(&cinfo.InfoType, ce)
@@ -706,7 +424,7 @@ func (rc *realCluster) updatePodContainer(pod_info *PodInfo, ce *cache.Container
 }
 
 // updateFreeContainer updates Free Container-level information from a ContainerElement
-func (rc *realCluster) updateFreeContainer(ce *cache.ContainerElement) (time.Time, error) {
+func (rc *realModel) updateFreeContainer(ce *cache.ContainerElement) (time.Time, error) {
 	rc.lock.Lock()
 	defer rc.lock.Unlock()
 

--- a/model/impl_test.go
+++ b/model/impl_test.go
@@ -27,25 +27,25 @@ import (
 
 	"k8s.io/heapster/sinks/cache"
 	source_api "k8s.io/heapster/sources/api"
-	"k8s.io/heapster/store"
+
+	"k8s.io/heapster/store/daystore"
+	"k8s.io/heapster/store/statstore"
 )
 
-// newTimeStore creates a new GCStore and returns it as a TimeStore.
-// Meant to be passed to newRealCluster calls in all unit tests.
-func newTimeStore() store.TimeStore {
-	return store.NewGCStore(store.NewCMAStore(), 24*time.Hour)
+func newDayStore() *daystore.DayStore {
+	return daystore.NewDayStore(defaultEpsilon, time.Minute)
 }
 
 // TestNewCluster tests the sanity of NewCluster
 func TestNewCluster(t *testing.T) {
-	cluster := NewCluster(newTimeStore, time.Minute)
+	cluster := NewModel(time.Minute)
 	assert.NotNil(t, cluster)
 }
 
 // TestAddNamespace tests all flows of addNamespace.
 func TestAddNamespace(t *testing.T) {
 	var (
-		cluster        = newRealCluster(newTimeStore, time.Minute)
+		cluster        = newRealModel(time.Minute)
 		namespace_name = "default"
 		assert         = assert.New(t)
 	)
@@ -67,7 +67,7 @@ func TestAddNamespace(t *testing.T) {
 // TestAddNode tests all flows of addNode.
 func TestAddNode(t *testing.T) {
 	var (
-		cluster  = newRealCluster(newTimeStore, time.Minute)
+		cluster  = newRealModel(time.Minute)
 		hostname = "kubernetes-minion-xkhz"
 		assert   = assert.New(t)
 	)
@@ -90,7 +90,7 @@ func TestAddNode(t *testing.T) {
 // TestAddPod tests all flows of addPod.
 func TestAddPod(t *testing.T) {
 	var (
-		cluster   = newRealCluster(newTimeStore, time.Minute)
+		cluster   = newRealModel(time.Minute)
 		pod_name  = "podname-xkhz"
 		pod_uid   = "123124-124124-124124124124"
 		namespace = cluster.addNamespace("default")
@@ -126,7 +126,7 @@ func TestAddPod(t *testing.T) {
 // TestUpdateTime tests the sanity of updateTime.
 func TestUpdateTime(t *testing.T) {
 	var (
-		cluster = newRealCluster(newTimeStore, time.Minute)
+		cluster = newRealModel(time.Minute)
 		stamp   = time.Now()
 	)
 
@@ -142,55 +142,79 @@ func TestUpdateTime(t *testing.T) {
 // Tests the flow of AddMetricToMap where the metric name is present in the map
 func TestAddMetricToMapExistingKey(t *testing.T) {
 	var (
-		cluster         = newRealCluster(newTimeStore, time.Minute)
-		metrics         = make(map[string]*store.TimeStore)
+		cluster         = newRealModel(time.Minute)
+		metrics         = make(map[string]*daystore.DayStore)
 		new_metric_name = "name_already_in_map"
 		value           = uint64(1234567890)
 		zeroTime        = time.Time{}
 		stamp           = time.Now().Round(time.Minute)
 		assert          = assert.New(t)
+		require         = require.New(t)
 	)
 
 	// Fist Call: addMetricToMap for a new metric
 	assert.NoError(cluster.addMetricToMap(new_metric_name, stamp, value, metrics))
 
 	ts := *metrics[new_metric_name]
-	results := ts.Get(zeroTime, zeroTime)
-	assert.Len(results, 1)
-	assert.Equal(results[0].Timestamp, stamp)
-	assert.Equal(results[0].Value, value)
+	results := ts.Hour.Get(zeroTime, zeroTime)
+	require.Len(results, 1)
 
 	// Second Call: addMetricToMap for an existing key, same time
-	new_value := uint64(102)
+	new_value := uint64(1234567890)
 	assert.NoError(cluster.addMetricToMap(new_metric_name, stamp, new_value, metrics))
 
-	ts = *metrics[new_metric_name]
-	results = ts.Get(zeroTime, zeroTime)
-	assert.Len(results, 1)
-	assert.Equal(results[0].Timestamp, stamp)
-	assert.Equal(results[0].Value, uint64(617283996))
+	require.Len(results, 1)
 
 	// Second Call: addMetricToMap for an existing key, new time
-	later_stamp := stamp.Add(2 * time.Hour)
+	new_value = uint64(617283996)
+	later_stamp := stamp.Add(20 * time.Minute)
 	assert.NoError(cluster.addMetricToMap(new_metric_name, later_stamp, new_value, metrics))
 
 	ts = *metrics[new_metric_name]
-	results = ts.Get(zeroTime, zeroTime)
-	assert.Len(results, 2)
-	assert.Equal(results[0].Timestamp, later_stamp)
-	assert.Equal(results[0].Value, uint64(102))
-	assert.Equal(results[1].Timestamp, stamp)
-	assert.Equal(results[1].Value, uint64(617283996))
+	results = ts.Hour.Get(zeroTime, zeroTime)
+	require.Len(results, 21)
+	assert.Equal(results[0].Timestamp, stamp.Add(20*time.Minute))
+	assert.Equal(roundToEpsilon(results[0].Value, defaultEpsilon), roundToEpsilon(new_value, defaultEpsilon))
+	assert.Equal(results[20].Timestamp, stamp)
+	assert.Equal(roundToEpsilon(results[20].Value, defaultEpsilon), roundToEpsilon(1234567890, defaultEpsilon))
 
-	// Third Call: addMetricToMap for an existing key, overwrites previous data
-	later_stamp = stamp.Add(48 * time.Hour)
+	// Second Call: addMetricToMap for an existing key, same time
 	assert.NoError(cluster.addMetricToMap(new_metric_name, later_stamp, new_value, metrics))
 
 	ts = *metrics[new_metric_name]
-	results = ts.Get(zeroTime, zeroTime)
-	assert.Len(results, 1)
-	assert.Equal(results[0].Timestamp, later_stamp)
-	assert.Equal(results[0].Value, uint64(102))
+	results = ts.Hour.Get(zeroTime, zeroTime)
+	require.Len(results, 21)
+	assert.Equal(results[0].Timestamp, stamp.Add(20*time.Minute))
+	resVal := roundToEpsilon(results[0].Value, defaultEpsilon)
+	assert.Equal(resVal, roundToEpsilon(new_value, defaultEpsilon))
+
+	assert.Equal(results[1].Timestamp, stamp.Add(19*time.Minute))
+	resVal = roundToEpsilon(results[1].Value, defaultEpsilon)
+	assert.Equal(resVal, roundToEpsilon(1234567890, defaultEpsilon))
+
+	assert.Equal(results[20].Timestamp, stamp)
+	resVal = roundToEpsilon(results[20].Value, defaultEpsilon)
+	assert.Equal(resVal, roundToEpsilon(1234567890, defaultEpsilon))
+
+	// Third Call: addMetricToMap for an existing key in the distant future
+	stamp = later_stamp
+	later_stamp = stamp.Add(14 * time.Hour)
+	new_value = uint64(1234567890)
+	assert.NoError(cluster.addMetricToMap(new_metric_name, later_stamp, new_value, metrics))
+
+	ts = *metrics[new_metric_name]
+	results = ts.Hour.Get(zeroTime, zeroTime)
+	require.Len(results, 61) // One full hour of data
+	assert.Equal(results[0].Timestamp, stamp.Add(14*time.Hour))
+	resVal = roundToEpsilon(results[0].Value, defaultEpsilon)
+	assert.Equal(resVal, roundToEpsilon(1234567890, defaultEpsilon))
+
+	assert.Equal(results[1].Timestamp, stamp.Add(13*time.Hour).Add(59*time.Minute))
+	resVal = roundToEpsilon(results[1].Value, defaultEpsilon)
+	assert.Equal(resVal, roundToEpsilon(617283996, defaultEpsilon))
+
+	assert.Equal(results[60].Timestamp, stamp.Add(13*time.Hour))
+	assert.Equal(results[60].Value, uint64(roundToEpsilon(617283996, defaultEpsilon)))
 
 	// Fourth Call: addMetricToMap for an existing key, cause TimeStore failure
 	assert.Error(cluster.addMetricToMap(new_metric_name, zeroTime, new_value, metrics))
@@ -199,33 +223,40 @@ func TestAddMetricToMapExistingKey(t *testing.T) {
 // Tests the flow of AddMetricToMap where the metric name is not present in the map
 func TestAddMetricToMapNewKey(t *testing.T) {
 	var (
-		cluster         = newRealCluster(newTimeStore, time.Minute)
-		metrics         = make(map[string]*store.TimeStore)
+		cluster         = newRealModel(time.Minute)
+		metrics         = make(map[string]*daystore.DayStore)
 		new_metric_name = "name_not_in_map"
-		stamp           = time.Now()
+		stamp           = time.Now().Round(cluster.resolution)
 		zeroTime        = time.Time{}
 		value           = uint64(1234567890)
 		assert          = assert.New(t)
+		require         = require.New(t)
 	)
 
 	// First Call: Add a new metric to the map
 	assert.NoError(cluster.addMetricToMap(new_metric_name, stamp, value, metrics))
+
+	// Second Call: Add a second metric to the map on a later time. Flushes previous metric.
+	assert.NoError(cluster.addMetricToMap(new_metric_name, stamp.Add(time.Minute), value, metrics))
 	new_ts := *metrics[new_metric_name]
-	results := new_ts.Get(zeroTime, zeroTime)
-	assert.Len(results, 1)
-	assert.Equal(results[0].Timestamp, stamp)
-	assert.Equal(results[0].Value, value)
+	results := new_ts.Hour.Get(zeroTime, zeroTime)
+	require.Len(results, 2)
+	assert.Equal(results[0].Timestamp, stamp.Add(time.Minute))
+	assert.Equal(roundToEpsilon(results[0].Value, defaultEpsilon), roundToEpsilon(value, defaultEpsilon))
+	assert.Equal(results[1].Timestamp, stamp)
+	assert.Equal(roundToEpsilon(results[1].Value, defaultEpsilon), roundToEpsilon(value, defaultEpsilon))
 
 	// Second Call: addMetricToMap for a new key, cause TimeStore failure
-	assert.Error(cluster.addMetricToMap("other_metric", zeroTime, value, metrics))
+	assert.NoError(cluster.addMetricToMap("other_metric", stamp, value, metrics))
+	assert.Error(cluster.addMetricToMap("other_metric", stamp.Add(-time.Minute), value, metrics))
 }
 
 // TestParseMetricError tests the error flows of ParseMetric
 func TestParseMetricError(t *testing.T) {
 	var (
-		cluster = newRealCluster(newTimeStore, time.Minute)
-		context = make(map[string]*store.TimePoint)
-		dict    = make(map[string]*store.TimeStore)
+		cluster = newRealModel(time.Minute)
+		context = make(map[string]*statstore.TimePoint)
+		dict    = make(map[string]*daystore.DayStore)
 		cme     = cmeFactory()
 		assert  = assert.New(t)
 	)
@@ -246,75 +277,114 @@ func TestParseMetricError(t *testing.T) {
 	assert.Equal(stamp, time.Time{})
 }
 
+// roundToEpsilon is a helper function that rounds a value based on a given epsilon.
+func roundToEpsilon(value, epsilon uint64) uint64 {
+	res := (value / epsilon) * epsilon
+	if value%epsilon != 0 {
+		res += epsilon
+	}
+	return res
+}
+
 // TestParseMetricNormal tests the normal flow of ParseMetric
 func TestParseMetricNormal(t *testing.T) {
 	var (
-		cluster    = newRealCluster(newTimeStore, time.Minute)
+		cluster    = newRealModel(time.Minute)
 		zeroTime   = time.Time{}
-		metrics    = make(map[string]*store.TimeStore)
-		context    = make(map[string]*store.TimePoint)
+		metrics    = make(map[string]*daystore.DayStore)
+		context    = make(map[string]*statstore.TimePoint)
 		normal_cme = cmeFactory()
 		other_cme  = cmeFactory()
+		flush_cme  = cmeFactory()
 		assert     = assert.New(t)
+		require    = require.New(t)
 	)
-	normal_stamp := normal_cme.Stats.Timestamp.Round(time.Minute)
+	normal_stamp := normal_cme.Stats.Timestamp.Truncate(time.Minute)
 	normal_cme.Stats.Cpu.Usage.Total = uint64(1000)
 
 	other_cme.Stats.Timestamp = normal_stamp.Add(3 * time.Minute)
 	other_cme.Stats.Cpu.Usage.Total = uint64(360000001000) // 2 stable over 3 minutes in NS
-	other_stamp := other_cme.Stats.Timestamp.Round(time.Minute)
+	other_stamp := other_cme.Stats.Timestamp.Truncate(time.Minute)
 
-	// Normal Invocation with a regular CME, passed twice
+	// Create a CME that will flush other_cme to the store
+	flush_cme.Stats.Timestamp = normal_stamp.Add(4 * time.Minute)
+	flush_cme.Stats.Cpu.Usage.Total = uint64(760000001000)
+	flush_stamp := flush_cme.Stats.Timestamp.Truncate(time.Minute)
+
+	// Three Normal Invocations
 	stamp, err := cluster.parseMetric(normal_cme, metrics, context)
 	assert.NoError(err)
 	assert.Equal(stamp, normal_stamp)
 	stamp, err = cluster.parseMetric(other_cme, metrics, context)
 	assert.NoError(err)
 	assert.Equal(stamp, other_stamp)
+	stamp, err = cluster.parseMetric(flush_cme, metrics, context)
+	assert.NoError(err)
+	assert.Equal(stamp, flush_stamp)
 	for key, ts := range metrics {
 		actual_ts := *ts
-		pointSlice := actual_ts.Get(zeroTime, zeroTime)
-		metric := pointSlice[0]
+		pointSlice := actual_ts.Hour.Get(zeroTime, zeroTime)
+		require.True(len(pointSlice) >= 1)
 		switch key {
 		case cpuLimit:
-			assert.Len(pointSlice, 2)
-			assert.Equal(metric.Timestamp, other_stamp)
-			assert.Equal(metric.Value, other_cme.Spec.Cpu.Limit)
-			metric = pointSlice[1]
-			assert.Equal(metric.Timestamp, normal_stamp)
-			assert.Equal(metric.Value, normal_cme.Spec.Cpu.Limit)
+			require.Len(pointSlice, 5)
+			assert.Equal(pointSlice[1].Timestamp, other_stamp)
+			assert.Equal(pointSlice[0].Value, other_cme.Spec.Cpu.Limit*1000/1024)
+			for i := 1; i <= 3; i++ {
+				assert.Equal(pointSlice[i+1].Timestamp, normal_stamp.Add(time.Duration(3-i)*time.Minute))
+				assert.Equal(pointSlice[i+1].Value, normal_cme.Spec.Cpu.Limit*1000/1024)
+			}
 		case memLimit:
-			assert.Len(pointSlice, 2)
-			assert.Equal(metric.Timestamp, other_stamp)
-			assert.Equal(metric.Value, other_cme.Spec.Memory.Limit)
-			metric = pointSlice[1]
-			assert.Equal(metric.Timestamp, normal_stamp)
-			assert.Equal(metric.Value, normal_cme.Spec.Memory.Limit)
+			require.Len(pointSlice, 5)
+			assert.Equal(pointSlice[1].Timestamp, other_stamp)
+			actualML := roundToEpsilon(pointSlice[0].Value, memLimitEpsilon)
+			expectedML := roundToEpsilon(other_cme.Spec.Memory.Limit, memLimitEpsilon)
+			assert.Equal(actualML, expectedML)
+			for i := 1; i <= 3; i++ {
+				assert.Equal(pointSlice[i+1].Timestamp, normal_stamp.Add(time.Duration(3-i)*time.Minute))
+				actualML = roundToEpsilon(pointSlice[i+1].Value, memLimitEpsilon)
+				expectedML = roundToEpsilon(normal_cme.Spec.Memory.Limit, memLimitEpsilon)
+				assert.Equal(actualML, expectedML)
+			}
 		case cpuUsage:
-			assert.Len(pointSlice, 1)
-			assert.Equal(metric.Timestamp, other_stamp)
-			assert.Equal(metric.Value.(uint64), 2*other_cme.Spec.Cpu.Limit)
+			require.Len(pointSlice, 2)
+			assert.Equal(pointSlice[1].Timestamp, other_stamp)
+			assert.Equal(pointSlice[1].Value, 2000) //Two full cores
 		case memUsage:
-			assert.Len(pointSlice, 2)
-			assert.Equal(metric.Timestamp, other_stamp)
-			assert.Equal(metric.Value, other_cme.Stats.Memory.Usage)
-			metric = pointSlice[1]
-			assert.Equal(metric.Timestamp, normal_stamp)
-			assert.Equal(metric.Value, normal_cme.Stats.Memory.Usage)
+			require.Len(pointSlice, 5)
+			assert.Equal(pointSlice[1].Timestamp, other_stamp)
+			actualMU := roundToEpsilon(pointSlice[0].Value, memUsageEpsilon)
+			expectedMU := roundToEpsilon(other_cme.Stats.Memory.Usage, memUsageEpsilon)
+			assert.Equal(actualMU, expectedMU)
+			for i := 1; i <= 3; i++ {
+				assert.Equal(pointSlice[i+1].Timestamp, normal_stamp.Add(time.Duration(3-i)*time.Minute))
+				actualMU := roundToEpsilon(pointSlice[i+1].Value, memUsageEpsilon)
+				expectedMU := roundToEpsilon(normal_cme.Stats.Memory.Usage, memUsageEpsilon)
+				assert.Equal(actualMU, expectedMU)
+			}
 		case memWorking:
-			assert.Len(pointSlice, 2)
-			assert.Equal(metric.Timestamp, other_stamp)
-			assert.Equal(metric.Value, other_cme.Stats.Memory.WorkingSet)
-			metric = pointSlice[1]
-			assert.Equal(metric.Timestamp, normal_stamp)
-			assert.Equal(metric.Value, normal_cme.Stats.Memory.WorkingSet)
+			require.Len(pointSlice, 5)
+			assert.Equal(pointSlice[1].Timestamp, other_stamp)
+			actualMWS := roundToEpsilon(pointSlice[0].Value, memWorkingEpsilon)
+			expectedMWS := roundToEpsilon(other_cme.Stats.Memory.WorkingSet, memWorkingEpsilon)
+			assert.Equal(actualMWS, expectedMWS)
+			for i := 1; i <= 3; i++ {
+				assert.Equal(pointSlice[i+1].Timestamp, normal_stamp.Add(time.Duration(3-i)*time.Minute))
+				actualMWS = roundToEpsilon(pointSlice[i+1].Value, memWorkingEpsilon)
+				expectedMWS = roundToEpsilon(normal_cme.Stats.Memory.WorkingSet, memWorkingEpsilon)
+				assert.Equal(actualMWS, expectedMWS)
+			}
 		default:
 			// Filesystem or error
-			assert.Len(pointSlice, 2)
+			require.Len(pointSlice, 5)
 			if strings.Contains(key, "limit") {
-				assert.Equal(metric.Value, other_cme.Stats.Filesystem[0].Limit)
+				actualFSL := roundToEpsilon(pointSlice[0].Value, fsLimitEpsilon)
+				expectedFSL := roundToEpsilon(other_cme.Stats.Filesystem[0].Limit, fsLimitEpsilon)
+				assert.Equal(actualFSL, expectedFSL)
 			} else if strings.Contains(key, "usage") {
-				assert.Equal(metric.Value, other_cme.Stats.Filesystem[0].Usage)
+				actualFSU := roundToEpsilon(pointSlice[0].Value, fsUsageEpsilon)
+				expectedFSU := roundToEpsilon(other_cme.Stats.Filesystem[0].Usage, fsUsageEpsilon)
+				assert.Equal(actualFSU, expectedFSU)
 			} else {
 				assert.True(false, "Unknown key in resulting metrics slice")
 			}
@@ -325,7 +395,7 @@ func TestParseMetricNormal(t *testing.T) {
 // TestUpdateInfoTypeError Tests the error flows of updateInfoType.
 func TestUpdateInfoTypeError(t *testing.T) {
 	var (
-		cluster      = newRealCluster(newTimeStore, time.Minute)
+		cluster      = newRealModel(time.Minute)
 		new_infotype = newInfoType(nil, nil, nil)
 		full_ce      = containerElementFactory(nil)
 		assert       = assert.New(t)
@@ -346,13 +416,14 @@ func TestUpdateInfoTypeError(t *testing.T) {
 // TestUpdateInfoTypeNormal tests the normal flows of UpdateInfoType.
 func TestUpdateInfoTypeNormal(t *testing.T) {
 	var (
-		cluster      = newRealCluster(newTimeStore, time.Minute)
+		cluster      = newRealModel(time.Minute)
 		new_cme      = cmeFactory()
 		empty_ce     = containerElementFactory([]*cache.ContainerMetricElement{})
 		nil_ce       = containerElementFactory([]*cache.ContainerMetricElement{new_cme, nil})
 		new_infotype = newInfoType(nil, nil, nil)
 		zeroTime     = time.Time{}
 		assert       = assert.New(t)
+		require      = require.New(t)
 	)
 
 	// Invocation with a ContainerElement argument with no CMEs
@@ -366,52 +437,59 @@ func TestUpdateInfoTypeNormal(t *testing.T) {
 	assert.NoError(err)
 	assert.NotEmpty(new_infotype.Metrics)
 	assert.NotEqual(stamp, time.Time{})
-	assert.Len(new_infotype.Metrics, 6) // 6 stats in total - no CPU Usage yet
+	require.Len(new_infotype.Metrics, 6) // 6 stats in total - no CPU Usage yet
 	for _, metricStore := range new_infotype.Metrics {
-		metricSlice := (*metricStore).Get(zeroTime, zeroTime)
-		assert.Len(metricSlice, 1) // 1 Metric per stat
+		metricSlice := (*metricStore).Hour.Get(zeroTime, zeroTime)
+		assert.Len(metricSlice, 1) // One value in the store
 	}
 
 	// Invocation with an empty InfoType argument
 	// The new ContainerElement adds one TimePoint to each of 7 Metrics
 	newer_cme := cmeFactory()
-	newer_cme.Stats.Timestamp = new_cme.Stats.Timestamp.Add(time.Hour)
-	newer_cme.Stats.Cpu.Usage.Total = new_cme.Stats.Cpu.Usage.Total + uint64(3600000000)
+	newer_cme.Stats.Timestamp = new_cme.Stats.Timestamp.Add(10 * time.Minute)
+	newer_cme.Stats.Cpu.Usage.Total = new_cme.Stats.Cpu.Usage.Total + uint64(600000000000)
 	new_ce := containerElementFactory([]*cache.ContainerMetricElement{newer_cme})
 	stamp, err = cluster.updateInfoType(&new_infotype, new_ce)
 	assert.NoError(err)
 	assert.Empty(new_infotype.Labels)
 	assert.NotEqual(stamp, time.Time{})
-	assert.Len(new_infotype.Metrics, 7) // 7 stats in total
+	require.Len(new_infotype.Metrics, 7) // 7 stats in total
 	for key, metricStore := range new_infotype.Metrics {
-		metricSlice := (*metricStore).Get(zeroTime, zeroTime)
+		metricSlice := (*metricStore).Hour.Get(zeroTime, zeroTime)
 		if key == cpuUsage {
-			assert.Len(metricSlice, 1) // cpuUsage has n-1 values.
+			// cpuUsage has 1 value at the newer_cme timestamp
+			// That value has not been flushed yet into the DayStore
+			assert.Len(metricSlice, 1)
 		} else {
-			assert.Len(metricSlice, 2) // 2 Metrics per stat
+			assert.Len(metricSlice, 11) // All other metrics have 11 values, one per elapsed minute
 		}
 	}
 
 	// Invocation with an existing infotype as argument
 	// The new ContainerElement adds two TimePoints to each Metric
 	newer_cme2 := cmeFactory()
-	newer_cme2.Stats.Timestamp = newer_cme.Stats.Timestamp.Add(time.Hour)
-	newer_cme2.Stats.Cpu.Usage.Total = newer_cme.Stats.Cpu.Usage.Total + uint64(3600000000)
+	newer_cme2.Stats.Timestamp = newer_cme.Stats.Timestamp.Add(10 * time.Minute)
+	newer_cme2.Stats.Cpu.Usage.Total = newer_cme.Stats.Cpu.Usage.Total + uint64(3600000000000)
 	newer_cme3 := cmeFactory()
-	newer_cme3.Stats.Timestamp = newer_cme2.Stats.Timestamp.Add(time.Hour)
-	newer_cme3.Stats.Cpu.Usage.Total = newer_cme2.Stats.Cpu.Usage.Total + uint64(360000000)
+	newer_cme3.Stats.Timestamp = newer_cme2.Stats.Timestamp.Add(10 * time.Minute)
+	newer_cme3.Stats.Cpu.Usage.Total = newer_cme2.Stats.Cpu.Usage.Total + uint64(600000000000)
 	new_ce = containerElementFactory([]*cache.ContainerMetricElement{newer_cme3, newer_cme2})
 	stamp, err = cluster.updateInfoType(&new_infotype, new_ce)
 	assert.NoError(err)
 	assert.Empty(new_infotype.Labels)
 	assert.NotEqual(stamp, time.Time{})
-	assert.Len(new_infotype.Metrics, 7) // 7 stats total
+	require.Len(new_infotype.Metrics, 7) // 7 stats total
 	for key, metricStore := range new_infotype.Metrics {
-		metricSlice := (*metricStore).Get(zeroTime, zeroTime)
+		metricSlice := (*metricStore).Hour.Get(zeroTime, zeroTime)
 		if key == cpuUsage {
-			assert.Len(metricSlice, 3) // cpuUsage consists of n-1 values.
+			require.Len(metricSlice, 21) // cpuUsage consists of 1+10+10 values.
+			assert.Equal(metricSlice[0].Value, 1000)
+			assert.Equal(metricSlice[1].Value, 6000)
+			assert.Equal(metricSlice[10].Value, 6000)
+			assert.Equal(metricSlice[11].Value, 1000)
+			assert.Equal(metricSlice[20].Value, 1000)
 		} else {
-			assert.Len(metricSlice, 4) // 4 Metrics per stat
+			assert.Len(metricSlice, 31) // All other metrics have 31 values, one per minute
 		}
 	}
 }
@@ -419,7 +497,7 @@ func TestUpdateInfoTypeNormal(t *testing.T) {
 // TestUpdateFreeContainer tests the flow of updateFreeContainer
 func TestUpdateFreeContainer(t *testing.T) {
 	var (
-		cluster = newRealCluster(newTimeStore, time.Minute)
+		cluster = newRealModel(time.Minute)
 		ce      = containerElementFactory(nil)
 		assert  = assert.New(t)
 	)
@@ -439,7 +517,7 @@ func TestUpdateFreeContainer(t *testing.T) {
 // TestUpdatePodContainer tests the flow of updatePodContainer
 func TestUpdatePodContainer(t *testing.T) {
 	var (
-		cluster   = newRealCluster(newTimeStore, time.Minute)
+		cluster   = newRealModel(time.Minute)
 		namespace = cluster.addNamespace("default")
 		node      = cluster.addNode("new_node_xyz")
 		pod_ptr   = cluster.addPod("new_pod", "1234-1245-235235", namespace, node)
@@ -457,7 +535,7 @@ func TestUpdatePodContainer(t *testing.T) {
 // TestUpdatePodNormal tests the normal flow of updatePod.
 func TestUpdatePodNormal(t *testing.T) {
 	var (
-		cluster  = newRealCluster(newTimeStore, time.Minute)
+		cluster  = newRealModel(time.Minute)
 		pod_elem = podElementFactory()
 		assert   = assert.New(t)
 	)
@@ -475,7 +553,7 @@ func TestUpdatePodNormal(t *testing.T) {
 // TestUpdatePodError tests the error flow of updatePod.
 func TestUpdatePodError(t *testing.T) {
 	var (
-		cluster = newRealCluster(newTimeStore, time.Minute)
+		cluster = newRealModel(time.Minute)
 		assert  = assert.New(t)
 	)
 	// Invocation with a nil parameter
@@ -487,7 +565,7 @@ func TestUpdatePodError(t *testing.T) {
 // TestUpdateNodeInvalid tests the error flow of updateNode.
 func TestUpdateNodeInvalid(t *testing.T) {
 	var (
-		cluster = newRealCluster(newTimeStore, time.Minute)
+		cluster = newRealModel(time.Minute)
 		ce      = containerElementFactory(nil)
 		assert  = assert.New(t)
 	)
@@ -501,7 +579,7 @@ func TestUpdateNodeInvalid(t *testing.T) {
 // TestUpdateNodeNormal tests the normal flow of updateNode.
 func TestUpdateNodeNormal(t *testing.T) {
 	var (
-		cluster = newRealCluster(newTimeStore, time.Minute)
+		cluster = newRealModel(time.Minute)
 		ce      = containerElementFactory(nil)
 		assert  = assert.New(t)
 	)
@@ -518,11 +596,12 @@ func TestUpdateNodeNormal(t *testing.T) {
 // TestUpdate performs consecutive calls to Update with both empty and non-empty caches
 func TestUpdate(t *testing.T) {
 	var (
-		cluster      = newRealCluster(newTimeStore, time.Minute)
+		cluster      = newRealModel(time.Minute)
 		source_cache = cacheFactory()
-		assert       = assert.New(t)
 		empty_cache  = cache.NewCache(24*time.Hour, time.Hour)
 		zeroTime     = time.Time{}
+		assert       = assert.New(t)
+		require      = require.New(t)
 	)
 
 	// Invocation with empty cache
@@ -536,32 +615,33 @@ func TestUpdate(t *testing.T) {
 	verifyCacheFactoryCluster(&cluster.ClusterInfo, t)
 
 	// Assert Node Metric aggregation
-	assert.NotEmpty(cluster.Nodes)
-	assert.NotEmpty(cluster.Metrics)
-	assert.NotNil(cluster.Metrics[memWorking])
+	require.NotEmpty(cluster.Nodes)
+	require.NotEmpty(cluster.Metrics)
+	require.NotNil(cluster.Metrics[memWorking])
 	mem_work_ts := *(cluster.Metrics[memWorking])
-	actual := mem_work_ts.Get(zeroTime, zeroTime)
-	assert.Len(actual, 2)
-	// Datapoint present in both nodes, added up to 1024
-	assert.Equal(actual[1].Value.(uint64), uint64(1204))
-	// Datapoint present in only one node
-	assert.Equal(actual[0].Value.(uint64), uint64(602))
+	actual := mem_work_ts.Hour.Get(zeroTime, zeroTime)
+	require.Len(actual, 6)
+	// Datapoint present in both nodes,
 
-	assert.NotNil(cluster.Metrics[memUsage])
+	assert.Equal(actual[0].Value, uint64(602+602))
+	assert.Equal(actual[1].Value, 2*memWorkingEpsilon)
+	assert.Equal(actual[5].Value, 2*memWorkingEpsilon)
+
+	require.NotNil(cluster.Metrics[memUsage])
 	mem_usage_ts := *(cluster.Metrics[memUsage])
-	actual = mem_usage_ts.Get(zeroTime, zeroTime)
-	assert.Len(actual, 2)
+	actual = mem_usage_ts.Hour.Get(zeroTime, zeroTime)
+	require.Len(actual, 6)
+	// Datapoint present in only one node, second node's metric is extended
+	assert.Equal(actual[0].Value, uint64(10000))
 	// Datapoint present in both nodes, added up to 10000
-	assert.Equal(actual[1].Value.(uint64), uint64(10000))
-	// Datapoint present in only one node
-	assert.Equal(actual[0].Value.(uint64), uint64(5000))
+	assert.Equal(actual[1].Value, 2*memWorkingEpsilon)
 
 	// Assert Kubernetes Metric aggregation up to namespaces
 	ns := cluster.Namespaces["test"]
 	mem_work_ts = *(ns.Metrics[memWorking])
-	actual = mem_work_ts.Get(zeroTime, zeroTime)
-	assert.Len(actual, 1)
-	assert.Equal(actual[0].Value.(uint64), uint64(2408))
+	actual = mem_work_ts.Hour.Get(zeroTime, zeroTime)
+	require.Len(actual, 8)
+	assert.Equal(actual[0].Value, uint64(2408))
 
 	// Invocation with no fresh data - expect no change in cluster
 	assert.NoError(cluster.Update(source_cache))
@@ -570,472 +650,6 @@ func TestUpdate(t *testing.T) {
 	// Invocation with empty cache - expect no change in cluster
 	assert.NoError(cluster.Update(empty_cache))
 	verifyCacheFactoryCluster(&cluster.ClusterInfo, t)
-}
-
-// TestGetClusterMetric tests all flows of GetClusterMetric.
-func TestGetClusterMetric(t *testing.T) {
-	var (
-		cluster      = newRealCluster(newTimeStore, time.Minute)
-		source_cache = cacheFactory()
-		assert       = assert.New(t)
-		zeroTime     = time.Time{}
-	)
-	// Invocation with no cluster metrics
-	res, stamp, err := cluster.GetClusterMetric(ClusterRequest{cpuUsage, zeroTime, zeroTime})
-	assert.Error(err)
-	assert.Equal(stamp, zeroTime)
-	assert.Nil(res)
-
-	// Populate cluster
-	assert.NoError(cluster.Update(source_cache))
-
-	// Invocation with non-existant metric
-	res, stamp, err = cluster.GetClusterMetric(ClusterRequest{"doesnotexist", zeroTime, zeroTime})
-	assert.Error(err)
-	assert.Equal(stamp, zeroTime)
-	assert.Nil(res)
-
-	// Normal Invocation - memoryUsage
-	res, stamp, err = cluster.GetClusterMetric(ClusterRequest{memUsage, zeroTime, zeroTime})
-	assert.NoError(err)
-	assert.NotEqual(stamp, zeroTime)
-	assert.NotNil(res)
-}
-
-// TestGetNodeMetric tests all flows of GetNodeMetric.
-func TestGetNodeMetric(t *testing.T) {
-	var (
-		zeroTime     = time.Time{}
-		cluster      = newRealCluster(newTimeStore, time.Minute)
-		source_cache = cacheFactory()
-		assert       = assert.New(t)
-		hostname     = "hostname3"
-	)
-	// Invocation with no nodes in cluster
-	res, stamp, err := cluster.GetNodeMetric(NodeRequest{hostname, cpuUsage, zeroTime, zeroTime})
-	assert.Error(err)
-	assert.Equal(stamp, zeroTime)
-	assert.Nil(res)
-
-	// Populate cluster
-	assert.NoError(cluster.Update(source_cache))
-
-	// Invocation with non-existant node
-	res, stamp, err = cluster.GetNodeMetric(NodeRequest{"doesnotexist", cpuUsage, zeroTime, zeroTime})
-	assert.Error(err)
-	assert.Equal(stamp, zeroTime)
-	assert.Nil(res)
-
-	// Invocation with new node - no metrics
-	cluster.addNode("newnode")
-	res, stamp, err = cluster.GetNodeMetric(NodeRequest{"newnode", cpuUsage, zeroTime, zeroTime})
-	assert.Error(err)
-	assert.Equal(stamp, zeroTime)
-	assert.Nil(res)
-
-	// Invocation with non-existant metric
-	res, stamp, err = cluster.GetNodeMetric(NodeRequest{hostname, "doesnotexist", zeroTime, zeroTime})
-	assert.Error(err)
-	assert.Equal(stamp, zeroTime)
-	assert.Nil(res)
-
-	// Normal Invocation - memoryUsage
-	res, stamp, err = cluster.GetNodeMetric(NodeRequest{hostname, memUsage, zeroTime, zeroTime})
-	assert.NoError(err)
-	assert.NotEqual(stamp, zeroTime)
-	assert.NotNil(res)
-}
-
-// TestGetNamespaceMetric tests all flows of GetNamespaceMetric.
-func TestGetNamespaceMetric(t *testing.T) {
-	var (
-		zeroTime     = time.Time{}
-		cluster      = newRealCluster(newTimeStore, time.Minute)
-		source_cache = cacheFactory()
-		assert       = assert.New(t)
-		namespace    = "test"
-	)
-	// Invocation with no namespaces in cluster
-	res, stamp, err := cluster.GetNamespaceMetric(NamespaceRequest{namespace, cpuUsage, zeroTime, zeroTime})
-	assert.Error(err)
-	assert.Equal(stamp, zeroTime)
-	assert.Nil(res)
-
-	// Populate cluster
-	assert.NoError(cluster.Update(source_cache))
-
-	// Invocation with non-existant namespace
-	res, stamp, err = cluster.GetNamespaceMetric(NamespaceRequest{"doesnotexist", cpuUsage, zeroTime, zeroTime})
-	assert.Error(err)
-	assert.Equal(stamp, zeroTime)
-	assert.Nil(res)
-
-	// Invocation with new namespace - no metrics
-	cluster.addNamespace("newnode")
-	res, stamp, err = cluster.GetNamespaceMetric(NamespaceRequest{"newnode", cpuUsage, zeroTime, zeroTime})
-	assert.Error(err)
-	assert.Equal(stamp, zeroTime)
-	assert.Nil(res)
-
-	// Invocation with non-existant metric
-	res, stamp, err = cluster.GetNamespaceMetric(NamespaceRequest{namespace, "doesnotexist", zeroTime, zeroTime})
-	assert.Error(err)
-	assert.Equal(stamp, zeroTime)
-	assert.Nil(res)
-
-	// Normal Invocation - memoryUsage
-	res, stamp, err = cluster.GetNamespaceMetric(NamespaceRequest{namespace, memUsage, zeroTime, zeroTime})
-	assert.NoError(err)
-	assert.NotEqual(stamp, zeroTime)
-	assert.NotNil(res)
-}
-
-// TestGetPodMetric tests all flows of GetPodMetric.
-func TestGetPodMetric(t *testing.T) {
-	var (
-		zeroTime     = time.Time{}
-		cluster      = newRealCluster(newTimeStore, time.Minute)
-		source_cache = cacheFactory()
-		assert       = assert.New(t)
-		namespace    = "test"
-		pod          = "pod1"
-		node         = "hostname2"
-	)
-	// Invocation with no namespaces in cluster
-	res, stamp, err := cluster.GetPodMetric(PodRequest{namespace, pod, cpuUsage, zeroTime, zeroTime})
-	assert.Error(err)
-	assert.Equal(stamp, zeroTime)
-	assert.Nil(res)
-
-	// Populate cluster
-	assert.NoError(cluster.Update(source_cache))
-
-	// Invocation with non-existant namespace
-	res, stamp, err = cluster.GetPodMetric(PodRequest{"doesnotexist", pod, cpuUsage, zeroTime, zeroTime})
-	assert.Error(err)
-	assert.Equal(stamp, zeroTime)
-	assert.Nil(res)
-
-	// Invocation with non-existant pod
-	res, stamp, err = cluster.GetPodMetric(PodRequest{namespace, "otherpod", cpuUsage, zeroTime, zeroTime})
-	assert.Error(err)
-	assert.Equal(stamp, zeroTime)
-	assert.Nil(res)
-
-	// Invocation with new pod - no metrics
-	cluster.addPod(pod, "1234", cluster.Namespaces[namespace], cluster.Nodes[node])
-	res, stamp, err = cluster.GetPodMetric(PodRequest{namespace, pod, cpuUsage, zeroTime, zeroTime})
-	assert.Error(err)
-	assert.Equal(stamp, zeroTime)
-	assert.Nil(res)
-
-	// Invocation with non-existant metric
-	res, stamp, err = cluster.GetPodMetric(PodRequest{namespace, pod, "doesnotexist", zeroTime, zeroTime})
-	assert.Error(err)
-	assert.Equal(stamp, zeroTime)
-	assert.Nil(res)
-
-	// Normal Invocation - memoryUsage
-	res, stamp, err = cluster.GetPodMetric(PodRequest{namespace, pod, memUsage, zeroTime, zeroTime})
-	assert.NoError(err)
-	assert.NotEqual(stamp, zeroTime)
-	assert.NotNil(res)
-}
-
-// TestGetPodMetric tests all flows of GetPodMetric.
-func TestGetBatchPodMetric(t *testing.T) {
-	var (
-		zeroTime     = time.Time{}
-		cluster      = newRealCluster(newTimeStore, time.Minute)
-		source_cache = cacheFactory()
-		assert       = assert.New(t)
-		namespace    = "test"
-		pod          = "pod1"
-		node         = "hostname2"
-	)
-
-	// Invocation with no namespaces in cluster
-	res, stamp, err := cluster.GetBatchPodMetric(BatchPodRequest{namespace, []string{pod}, cpuUsage, zeroTime, zeroTime})
-	assert.Error(err)
-	assert.Equal(stamp, zeroTime)
-	assert.Nil(res)
-
-	// Populate cluster
-	assert.NoError(cluster.Update(source_cache))
-
-	// Invocation with non-existant namespace
-	res, stamp, err = cluster.GetBatchPodMetric(BatchPodRequest{"doesnotexist", []string{pod}, cpuUsage, zeroTime, zeroTime})
-	assert.Error(err)
-	assert.Equal(stamp, zeroTime)
-	assert.Nil(res)
-
-	// Invocation with non-existant pod
-	res, stamp, err = cluster.GetBatchPodMetric(BatchPodRequest{namespace, []string{"otherpod"}, cpuUsage, zeroTime, zeroTime})
-	assert.NoError(err)
-	assert.NotEqual(stamp, zeroTime)
-	assert.NotNil(res)
-	assert.Equal(len(res[0]), 0)
-
-	// Invocation with new pod - no metrics
-	cluster.addPod(pod, "1234", cluster.Namespaces[namespace], cluster.Nodes[node])
-	res, stamp, err = cluster.GetBatchPodMetric(BatchPodRequest{namespace, []string{pod}, cpuUsage, zeroTime, zeroTime})
-	assert.NoError(err)
-	assert.NotEqual(stamp, zeroTime)
-	assert.NotNil(res)
-	assert.Equal(len(res[0]), 0)
-
-	// Invocation with non-existant metric
-	res, stamp, err = cluster.GetBatchPodMetric(BatchPodRequest{namespace, []string{pod}, "doesnotexist", zeroTime, zeroTime})
-	assert.NoError(err)
-	assert.NotEqual(stamp, zeroTime)
-	assert.NotNil(res)
-	assert.Equal(len(res[0]), 0)
-
-	// Normal Invocation - memoryUsage
-	res, stamp, err = cluster.GetBatchPodMetric(BatchPodRequest{namespace, []string{pod}, memUsage, zeroTime, zeroTime})
-	assert.NoError(err)
-	assert.NotEqual(stamp, zeroTime)
-	assert.NotNil(res)
-	assert.Equal(len(res[0]), 1)
-}
-
-// TestGetPodContainerMetric tests all flows of GetPodContainerMetric.
-func TestGetPodContainerMetric(t *testing.T) {
-	var (
-		zeroTime     = time.Time{}
-		cluster      = newRealCluster(newTimeStore, time.Minute)
-		source_cache = cacheFactory()
-		assert       = assert.New(t)
-		namespace    = "test"
-		pod          = "pod1"
-		container    = "container1"
-	)
-	// Invocation with no namespaces in cluster
-	res, stamp, err := cluster.GetPodContainerMetric(PodContainerRequest{namespace, pod, container, cpuUsage, zeroTime, zeroTime})
-	assert.Error(err)
-	assert.Equal(stamp, zeroTime)
-	assert.Nil(res)
-
-	// Populate cluster
-	assert.NoError(cluster.Update(source_cache))
-
-	// Invocation with non-existant namespace
-	res, stamp, err = cluster.GetPodContainerMetric(PodContainerRequest{"doesnotexist", pod, container, cpuUsage, zeroTime, zeroTime})
-	assert.Error(err)
-	assert.Equal(stamp, zeroTime)
-	assert.Nil(res)
-
-	// Invocation with new namespace - no metrics
-	cluster.addNamespace("newnode")
-	res, stamp, err = cluster.GetPodContainerMetric(PodContainerRequest{"newnode", pod, container, cpuUsage, zeroTime, zeroTime})
-	assert.Error(err)
-	assert.Equal(stamp, zeroTime)
-	assert.Nil(res)
-
-	// Invocation with non-existant pod
-	res, stamp, err = cluster.GetPodContainerMetric(PodContainerRequest{namespace, "otherpod", container, cpuUsage, zeroTime, zeroTime})
-	assert.Error(err)
-	assert.Equal(stamp, zeroTime)
-	assert.Nil(res)
-
-	// Invocation with non-existant container
-	res, stamp, err = cluster.GetPodContainerMetric(PodContainerRequest{namespace, pod, "doesnotexist", cpuUsage, zeroTime, zeroTime})
-	assert.Error(err)
-	assert.Equal(stamp, zeroTime)
-	assert.Nil(res)
-
-	// Invocation with non-existant metric
-	res, stamp, err = cluster.GetPodContainerMetric(PodContainerRequest{namespace, pod, container, "doesnotexist", zeroTime, zeroTime})
-	assert.Error(err)
-	assert.Equal(stamp, zeroTime)
-	assert.Nil(res)
-
-	// Normal Invocation - memoryUsage
-	res, stamp, err = cluster.GetPodContainerMetric(PodContainerRequest{namespace, pod, container, memUsage, zeroTime, zeroTime})
-	assert.NoError(err)
-	assert.NotEqual(stamp, zeroTime)
-	assert.NotNil(res)
-}
-
-// TestGetFreeContainerMetric tests all flows of GetFreeContainerMetric.
-func TestGetFreeContainerMetric(t *testing.T) {
-	var (
-		zeroTime     = time.Time{}
-		cluster      = newRealCluster(newTimeStore, time.Minute)
-		source_cache = cacheFactory()
-		assert       = assert.New(t)
-		node         = "hostname2"
-		container    = "free_container1"
-	)
-	// Invocation with no nodes in cluster
-	res, stamp, err := cluster.GetFreeContainerMetric(FreeContainerRequest{node, container, cpuUsage, zeroTime, zeroTime})
-	assert.Error(err)
-	assert.Equal(stamp, zeroTime)
-	assert.Nil(res)
-
-	// Populate cluster
-	assert.NoError(cluster.Update(source_cache))
-
-	// Invocation with non-existant node
-	res, stamp, err = cluster.GetFreeContainerMetric(FreeContainerRequest{"doesnotexist", container, cpuUsage, zeroTime, zeroTime})
-	assert.Error(err)
-	assert.Equal(stamp, zeroTime)
-	assert.Nil(res)
-
-	// Invocation with new node - no metrics
-	cluster.addNode("newnode")
-	res, stamp, err = cluster.GetFreeContainerMetric(FreeContainerRequest{"newnode", container, cpuUsage, zeroTime, zeroTime})
-	assert.Error(err)
-	assert.Equal(stamp, zeroTime)
-	assert.Nil(res)
-
-	// Invocation with non-existant container
-	res, stamp, err = cluster.GetFreeContainerMetric(FreeContainerRequest{node, "not_actual_ctr", cpuUsage, zeroTime, zeroTime})
-	assert.Error(err)
-	assert.Equal(stamp, zeroTime)
-	assert.Nil(res)
-
-	// Invocation with non-existant metric
-	res, stamp, err = cluster.GetFreeContainerMetric(FreeContainerRequest{node, container, "doesnotexist", zeroTime, zeroTime})
-	assert.Error(err)
-	assert.Equal(stamp, zeroTime)
-	assert.Nil(res)
-
-	// Normal Invocation - memoryUsage
-	res, stamp, err = cluster.GetFreeContainerMetric(FreeContainerRequest{node, container, memUsage, zeroTime, zeroTime})
-	assert.NoError(err)
-	assert.NotEqual(stamp, zeroTime)
-	assert.NotNil(res)
-}
-
-//TestGetNodes tests the flow of GetNodes.
-func TestGetNodes(t *testing.T) {
-	var (
-		cluster      = newRealCluster(newTimeStore, time.Minute)
-		source_cache = cacheFactory()
-		assert       = assert.New(t)
-	)
-	// Invocation with empty cluster
-	res := cluster.GetNodes()
-	assert.Len(res, 0)
-
-	// Populate cluster
-	assert.NoError(cluster.Update(source_cache))
-
-	// Normal Invocation
-	res = cluster.GetNodes()
-	assert.Len(res, 2)
-}
-
-//TestGetNamespaces tests the flow of GetNamespaces.
-func TestGetNamespaces(t *testing.T) {
-	var (
-		cluster      = newRealCluster(newTimeStore, time.Minute)
-		source_cache = cacheFactory()
-		assert       = assert.New(t)
-	)
-	// Invocation with empty cluster
-	res := cluster.GetNamespaces()
-	assert.Len(res, 0)
-
-	// Populate cluster
-	assert.NoError(cluster.Update(source_cache))
-
-	// Normal Invocation
-	res = cluster.GetNamespaces()
-	assert.Len(res, 1)
-}
-
-//TestGetPods tests the flow of GetPods.
-func TestGetPods(t *testing.T) {
-	var (
-		cluster      = newRealCluster(newTimeStore, time.Minute)
-		source_cache = cacheFactory()
-		assert       = assert.New(t)
-	)
-	// Invocation with empty cluster
-	res := cluster.GetPods("test")
-	assert.Len(res, 0)
-
-	// Populate cluster
-	assert.NoError(cluster.Update(source_cache))
-
-	// Normal Invocation
-	res = cluster.GetPods("test")
-	assert.Len(res, 2)
-
-	// Invocation with non-existant namespace
-	res = cluster.GetPods("fakenamespace")
-	assert.Len(res, 0)
-}
-
-//TestGetPodContainers tests the flow of GetPodContainers.
-func TestGetPodContainers(t *testing.T) {
-	var (
-		cluster      = newRealCluster(newTimeStore, time.Minute)
-		source_cache = cacheFactory()
-		assert       = assert.New(t)
-	)
-	// Invocation with empty cluster
-	res := cluster.GetPodContainers("test", "pod1")
-	assert.Len(res, 0)
-
-	// Populate cluster
-	assert.NoError(cluster.Update(source_cache))
-
-	// Normal Invocation
-	res = cluster.GetPodContainers("test", "pod1")
-	assert.Len(res, 2)
-
-	// Invocation with non-existant namespace
-	res = cluster.GetPodContainers("fail", "pod1")
-	assert.Len(res, 0)
-
-	// Invocation with non-existant pod
-	res = cluster.GetPodContainers("test", "pod5")
-	assert.Len(res, 0)
-}
-
-//TestGetFreeContainers tests the flow of GetFreeContainers.
-func TestGetFreeContainers(t *testing.T) {
-	var (
-		cluster      = newRealCluster(newTimeStore, time.Minute)
-		source_cache = cacheFactory()
-		assert       = assert.New(t)
-	)
-	// Invocation with empty cluster
-	res := cluster.GetFreeContainers("hostname2")
-	assert.Len(res, 0)
-
-	// Populate cluster
-	assert.NoError(cluster.Update(source_cache))
-
-	// Normal Invocation
-	res = cluster.GetFreeContainers("hostname2")
-	assert.Len(res, 1)
-
-	// Invocation with non-existant node
-	res = cluster.GetFreeContainers("hostname9")
-	assert.Len(res, 0)
-}
-
-// TestGetAvailableMetrics tests the flow of GetAvailableMetrics.
-func TestGetAvailableMetrics(t *testing.T) {
-	var (
-		cluster      = newRealCluster(newTimeStore, time.Minute)
-		source_cache = cacheFactory()
-		assert       = assert.New(t)
-	)
-	// Invocation with no cluster metrics
-	res := cluster.GetAvailableMetrics()
-	assert.Len(res, 0)
-
-	// Populate cluster
-	assert.NoError(cluster.Update(source_cache))
-
-	// Normal Invocation
-	res = cluster.GetAvailableMetrics()
-	assert.Len(res, 7)
 }
 
 // verifyCacheFactoryCluster performs assertions over a ClusterInfo structure,
@@ -1081,7 +695,7 @@ func cmeFactory() *cache.ContainerMetricElement {
 		HasFilesystem: true,
 		HasDiskIo:     true,
 	}
-	containerSpec.Cpu.Limit = 1000
+	containerSpec.Cpu.Limit = 1024
 	containerSpec.Memory.Limit = 10000000
 
 	// Create a fuzzed ContainerStats struct
@@ -1092,18 +706,21 @@ func cmeFactory() *cache.ContainerMetricElement {
 	now_time := time.Now().Round(time.Minute)
 	new_time := now_time
 	for new_time == now_time {
-		new_time = now_time.Add(time.Duration(rand.Intn(10)) * time.Hour)
+		new_time = now_time.Add(time.Duration(rand.Intn(10)) * 5 * time.Minute)
 	}
 	containerStats.Timestamp = new_time
+	containerSpec.CreationTime = new_time.Add(-time.Hour)
 
 	// Standardize memory usage and limit to test aggregation
 	containerStats.Memory.Usage = uint64(5000)
 	containerStats.Memory.WorkingSet = uint64(602)
 
-	// Standardize the device name
+	// Standardize the device name, usage and limit
 	new_fs := cadvisor.FsStats{}
 	f.Fuzz(&new_fs)
 	new_fs.Device = "/dev/device1"
+	new_fs.Usage = 50000
+	new_fs.Limit = 100000
 	containerStats.Filesystem = []cadvisor.FsStats{new_fs}
 
 	return &cache.ContainerMetricElement{
@@ -1201,37 +818,56 @@ func podElementFactory() *cache.PodElement {
 }
 
 // cacheFactory generates a cache with a predetermined structure.
-// The cache contains two pods, one with two containers and one without any containers.
+// The cache contains 2 pods, one with two containers and one without any containers.
 // The cache also contains a free container and a "machine"-tagged container.
 func cacheFactory() cache.Cache {
-	source_cache := cache.NewCache(24*time.Hour, time.Hour)
+	source_cache := cache.NewCache(10*time.Minute, time.Minute)
 
 	// Generate Container CMEs - same timestamp for aggregation
 	cme_1 := cmeFactory()
 	cme_2 := cmeFactory()
 	cme_2.Stats.Timestamp = cme_1.Stats.Timestamp
+	cme_2.Stats.Cpu.Usage.Total = cme_1.Stats.Cpu.Usage.Total
+
+	// Generate a flush CME for cme_1 and cme_2
+	cme_2flush := cmeFactory()
+	cme_2flush.Stats.Timestamp = cme_1.Stats.Timestamp.Add(time.Minute)
 
 	// Genete Machine CMEs - same timestamp for aggregation
 	cme_3 := cmeFactory()
 	cme_4 := cmeFactory()
+	cme_3.Stats.Timestamp = cme_1.Stats.Timestamp.Add(2 * time.Minute)
 	cme_4.Stats.Timestamp = cme_3.Stats.Timestamp
+	cme_3.Stats.Memory.WorkingSet = 602
+	cme_4.Stats.Memory.WorkingSet = 1062
 
+	// Generate a flush CME for cme_3 and cme_4
+	cme_4flush := cmeFactory()
+	cme_4flush.Stats.Timestamp = cme_4.Stats.Timestamp.Add(time.Minute)
+	cme_4flush.Stats.Cpu.Usage.Total = cme_4.Stats.Cpu.Usage.Total + uint64(360000000000)
+
+	// Genete a generic container further than one resolution in the future
 	cme_5 := cmeFactory()
-	cme_5.Stats.Timestamp = cme_4.Stats.Timestamp.Add(time.Hour)
-	cme_5.Stats.Cpu.Usage.Total = cme_4.Stats.Cpu.Usage.Total + uint64(3600000000000)
+	cme_5.Stats.Timestamp = cme_4.Stats.Timestamp.Add(4 * time.Minute)
+	cme_5.Stats.Cpu.Usage.Total = cme_4.Stats.Cpu.Usage.Total + uint64(4*360000000000)
+
+	// Generate a flush CME for cme_5 and cme_4
+	cme_5flush := cmeFactory()
+	cme_5flush.Stats.Timestamp = cme_5.Stats.Timestamp.Add(time.Minute)
+	cme_5flush.Stats.Cpu.Usage.Total = cme_5.Stats.Cpu.Usage.Total + uint64(360000000000)
 
 	// Generate a pod with two containers, and a pod without any containers
 	container1 := source_api.Container{
 		Name:     "container1",
 		Hostname: "hostname2",
 		Spec:     *cme_1.Spec,
-		Stats:    []*cadvisor.ContainerStats{cme_1.Stats},
+		Stats:    []*cadvisor.ContainerStats{cme_2flush.Stats, cme_1.Stats},
 	}
 	container2 := source_api.Container{
 		Name:     "container2",
 		Hostname: "hostname3",
 		Spec:     *cme_2.Spec,
-		Stats:    []*cadvisor.ContainerStats{cme_2.Stats},
+		Stats:    []*cadvisor.ContainerStats{cme_2flush.Stats, cme_2.Stats},
 	}
 
 	containers := []source_api.Container{container1, container2}
@@ -1263,20 +899,20 @@ func cacheFactory() cache.Cache {
 		Name:     "/",
 		Hostname: "hostname2",
 		Spec:     *cme_3.Spec,
-		Stats:    []*cadvisor.ContainerStats{cme_3.Stats},
+		Stats:    []*cadvisor.ContainerStats{cme_4flush.Stats, cme_3.Stats},
 	}
 	machine_container2 := source_api.Container{
 		Name:     "/",
 		Hostname: "hostname3",
 		Spec:     *cme_4.Spec,
-		Stats:    []*cadvisor.ContainerStats{cme_5.Stats, cme_4.Stats},
+		Stats:    []*cadvisor.ContainerStats{cme_5flush.Stats, cme_5.Stats, cme_4.Stats},
 	}
 	// Generate a free container
 	free_container := source_api.Container{
 		Name:     "free_container1",
 		Hostname: "hostname2",
 		Spec:     *cme_5.Spec,
-		Stats:    []*cadvisor.ContainerStats{cme_5.Stats},
+		Stats:    []*cadvisor.ContainerStats{cme_5flush.Stats, cme_5.Stats},
 	}
 
 	other_containers := []source_api.Container{

--- a/model/types.go
+++ b/model/types.go
@@ -67,14 +67,19 @@ const fsLimit = "fs-limit"
 const fsUsage = "fs-usage"
 
 // epsilon values for the underlying in-memory stores
-const cpuLimitEpsilon = 10
-const cpuUsageEpsilon = 10
+// Epsilon values for CPU metrics are expressed in millicores
+const cpuLimitEpsilon = 10 // 10 millicores
+const cpuUsageEpsilon = 10 // 10 millicores
+
+// Epsilon values for memory and filesystem metrics are expressed in bytes
 const memLimitEpsilon = 4194304   // 4 MB
 const memUsageEpsilon = 4194304   // 4 MB
 const memWorkingEpsilon = 4194304 // 4 MB
 const fsLimitEpsilon = 10485760   // 10 MB
 const fsUsageEpsilon = 10485760   // 10 MB
-const defaultEpsilon = 100        // used for testing
+
+// TODO(afein): move defaultEpsilon to impl_test after handling FS epsilon
+const defaultEpsilon = 100 // used for testing
 
 // Simple Request Types.
 type MetricRequest struct {

--- a/model/types.go
+++ b/model/types.go
@@ -19,44 +19,45 @@ import (
 	"time"
 
 	"k8s.io/heapster/sinks/cache"
-	"k8s.io/heapster/store"
+	"k8s.io/heapster/store/daystore"
+	"k8s.io/heapster/store/statstore"
 )
 
-type Cluster interface {
-	// The Update operation populates the Cluster from a cache.
+type Model interface {
+	// The Update operation populates the Model from a cache.
 	Update(cache.Cache) error
 
-	// The GetXMetric operations extract timeseries from the Cluster.
-	// The returned time.Time values signify the latest metric timestamp in the cluster.
-	GetClusterMetric(ClusterRequest) ([]store.TimePoint, time.Time, error)
-	GetNodeMetric(NodeRequest) ([]store.TimePoint, time.Time, error)
-	GetNamespaceMetric(NamespaceRequest) ([]store.TimePoint, time.Time, error)
-	GetPodMetric(PodRequest) ([]store.TimePoint, time.Time, error)
-	GetBatchPodMetric(req BatchPodRequest) ([][]store.TimePoint, time.Time, error)
-	GetPodContainerMetric(PodContainerRequest) ([]store.TimePoint, time.Time, error)
-	GetFreeContainerMetric(FreeContainerRequest) ([]store.TimePoint, time.Time, error)
-
-	// The normal Get operations extract information from the Cluster structure.
+	// The simple Get operations extract structural information from the Model.
 	GetAvailableMetrics() []string
-	GetNodes() []string
-	GetNamespaces() []string
-	GetPods(string) []string
-	GetPodContainers(string, string) []string
-	GetFreeContainers(string) []string
+	GetNodes() []EntityListEntry
+	GetNamespaces() []EntityListEntry
+	GetPods(string) []EntityListEntry
+	GetPodContainers(string, string) []EntityListEntry
+	GetNodePods(string) []EntityListEntry
+	GetFreeContainers(string) []EntityListEntry
+
+	// The GetXMetric operations extract timeseries from the Model.
+	// The returned time.Time values signify the latest metric timestamp in the cluster.
+	GetClusterMetric(ClusterMetricRequest) ([]statstore.TimePoint, time.Time, error)
+	GetNodeMetric(NodeMetricRequest) ([]statstore.TimePoint, time.Time, error)
+	GetNamespaceMetric(NamespaceMetricRequest) ([]statstore.TimePoint, time.Time, error)
+	GetPodMetric(PodMetricRequest) ([]statstore.TimePoint, time.Time, error)
+	GetBatchPodMetric(req BatchPodRequest) ([][]statstore.TimePoint, time.Time, error)
+	GetPodContainerMetric(PodContainerMetricRequest) ([]statstore.TimePoint, time.Time, error)
+	GetFreeContainerMetric(FreeContainerMetricRequest) ([]statstore.TimePoint, time.Time, error)
 }
 
-// realCluster is an implementation of the Cluster interface.
-// timestamp marks the latest timestamp of any metric present in the realCluster.
+// realModel is an implementation of the Model interface.
+// timestamp marks the latest timestamp of any metric present in the realModel.
 // tsConstructor generates a new empty TimeStore, used for storing historical data.
-type realCluster struct {
-	timestamp     time.Time
-	lock          sync.RWMutex
-	tsConstructor func() store.TimeStore
-	resolution    time.Duration
+type realModel struct {
+	timestamp  time.Time
+	lock       sync.RWMutex
+	resolution time.Duration
 	ClusterInfo
 }
 
-// Supported metric names, used as keys for all map[string]*store.TimeStore
+// Supported metric names, used as keys for all map[string]*daystore.DayStore
 const cpuLimit = "cpu-limit"
 const cpuUsage = "cpu-usage"
 const memLimit = "memory-limit"
@@ -65,34 +66,34 @@ const memWorking = "memory-working"
 const fsLimit = "fs-limit"
 const fsUsage = "fs-usage"
 
-// Request Types.
-// Used as parameters to all the Get methods of the model.
-type ClusterRequest struct {
+// epsilon values for the underlying in-memory stores
+const cpuLimitEpsilon = 10
+const cpuUsageEpsilon = 10
+const memLimitEpsilon = 4194304   // 4 MB
+const memUsageEpsilon = 4194304   // 4 MB
+const memWorkingEpsilon = 4194304 // 4 MB
+const fsLimitEpsilon = 10485760   // 10 MB
+const fsUsageEpsilon = 10485760   // 10 MB
+const defaultEpsilon = 100        // used for testing
+
+// Simple Request Types.
+type MetricRequest struct {
 	MetricName string
 	Start      time.Time
 	End        time.Time
 }
 
 type NodeRequest struct {
-	NodeName   string
-	MetricName string
-	Start      time.Time
-	End        time.Time
+	NodeName string
 }
 
 type NamespaceRequest struct {
 	NamespaceName string
-	MetricName    string
-	Start         time.Time
-	End           time.Time
 }
 
 type PodRequest struct {
 	NamespaceName string
 	PodName       string
-	MetricName    string
-	Start         time.Time
-	End           time.Time
 }
 
 type BatchPodRequest struct {
@@ -107,26 +108,62 @@ type PodContainerRequest struct {
 	NamespaceName string
 	PodName       string
 	ContainerName string
-	MetricName    string
-	Start         time.Time
-	End           time.Time
 }
 
 type FreeContainerRequest struct {
 	NodeName      string
 	ContainerName string
-	MetricName    string
-	Start         time.Time
-	End           time.Time
+}
+
+// Metric Request Types
+type ClusterMetricRequest struct {
+	MetricRequest
+}
+
+type NodeMetricRequest struct {
+	NodeName string
+	MetricRequest
+}
+
+type NamespaceMetricRequest struct {
+	NamespaceName string
+	MetricRequest
+}
+
+type PodMetricRequest struct {
+	NamespaceName string
+	PodName       string
+	MetricRequest
+}
+
+type PodContainerMetricRequest struct {
+	NamespaceName string
+	PodName       string
+	ContainerName string
+	MetricRequest
+}
+
+type FreeContainerMetricRequest struct {
+	NodeName      string
+	ContainerName string
+	MetricRequest
+}
+
+// Listing Types
+type EntityListEntry struct {
+	Name     string
+	CPUUsage uint64
+	MemUsage uint64
 }
 
 // Internal Types
 type InfoType struct {
-	Metrics map[string]*store.TimeStore // key: Metric Name
-	Labels  map[string]string           // key: Label
+	Creation time.Time
+	Metrics  map[string]*daystore.DayStore // key: Metric Name
+	Labels   map[string]string             // key: Label
 	// Context retains instantaneous state for a specific InfoType.
 	// Currently used for calculating instantaneous metrics from cumulative counterparts.
-	Context map[string]*store.TimePoint // key: metric name
+	Context map[string]*statstore.TimePoint // key: metric name
 }
 
 type ClusterInfo struct {

--- a/model/util.go
+++ b/model/util.go
@@ -18,7 +18,8 @@ import (
 	"fmt"
 	"time"
 
-	"k8s.io/heapster/store"
+	"k8s.io/heapster/store/daystore"
+	"k8s.io/heapster/store/statstore"
 )
 
 // latestTimestamp returns its largest time.Time argument
@@ -32,20 +33,21 @@ func latestTimestamp(first time.Time, second time.Time) time.Time {
 // newInfoType is an InfoType Constructor, which returns a new InfoType.
 // Initial fields for the new InfoType can be provided as arguments.
 // A nil argument results in a newly-allocated map for that field.
-func newInfoType(metrics map[string]*store.TimeStore, labels map[string]string, context map[string]*store.TimePoint) InfoType {
+func newInfoType(metrics map[string]*daystore.DayStore, labels map[string]string, context map[string]*statstore.TimePoint) InfoType {
 	if metrics == nil {
-		metrics = make(map[string]*store.TimeStore)
+		metrics = make(map[string]*daystore.DayStore)
 	}
 	if labels == nil {
 		labels = make(map[string]string)
 	}
 	if context == nil {
-		context = make(map[string]*store.TimePoint)
+		context = make(map[string]*statstore.TimePoint)
 	}
 	return InfoType{
-		Metrics: metrics,
-		Labels:  labels,
-		Context: context,
+		Creation: time.Time{},
+		Metrics:  metrics,
+		Labels:   labels,
+		Context:  context,
 	}
 }
 
@@ -68,16 +70,20 @@ func addContainerToMap(container_name string, dict map[string]*ContainerInfo) *C
 // addTimePoints adds the values of two TimePoints as uint64.
 // addTimePoints returns a new TimePoint with the added Value fields
 // and the Timestamp of the first TimePoint.
-func addTimePoints(tp1 store.TimePoint, tp2 store.TimePoint) store.TimePoint {
-	return store.TimePoint{
-		Timestamp: tp1.Timestamp,
-		Value:     tp1.Value.(uint64) + tp2.Value.(uint64),
+func addTimePoints(tp1 statstore.TimePoint, tp2 statstore.TimePoint) statstore.TimePoint {
+	maxTS := tp1.Timestamp
+	if maxTS.Before(tp2.Timestamp) {
+		maxTS = tp2.Timestamp
+	}
+	return statstore.TimePoint{
+		Timestamp: maxTS,
+		Value:     tp1.Value + tp2.Value,
 	}
 }
 
 // popTPSlice pops the first element of a TimePoint Slice, removing it from the slice.
 // popTPSlice receives a *[]TimePoint and returns its first element.
-func popTPSlice(tps_ptr *[]store.TimePoint) *store.TimePoint {
+func popTPSlice(tps_ptr *[]statstore.TimePoint) *statstore.TimePoint {
 	if tps_ptr == nil {
 		return nil
 	}
@@ -96,24 +102,22 @@ func popTPSlice(tps_ptr *[]store.TimePoint) *store.TimePoint {
 // addMatchingTimeseries performs addition over two timeseries with unique timestamps.
 // addMatchingTimeseries returns a []TimePoint of the resulting aggregated timeseries.
 // Assumes time-descending order of both []TimePoint parameters and the return slice.
-func addMatchingTimeseries(left []store.TimePoint, right []store.TimePoint) []store.TimePoint {
-	var cur_left *store.TimePoint
-	var cur_right *store.TimePoint
-	result := []store.TimePoint{}
+func addMatchingTimeseries(left []statstore.TimePoint, right []statstore.TimePoint) []statstore.TimePoint {
+	var cur_left *statstore.TimePoint
+	var cur_right *statstore.TimePoint
+	result := []statstore.TimePoint{}
 
 	// Merge timeseries into result until either one is empty
 	cur_left = popTPSlice(&left)
 	cur_right = popTPSlice(&right)
 	for cur_left != nil && cur_right != nil {
+		result = append(result, addTimePoints(*cur_left, *cur_right))
 		if cur_left.Timestamp.Equal(cur_right.Timestamp) {
-			result = append(result, addTimePoints(*cur_left, *cur_right))
 			cur_left = popTPSlice(&left)
 			cur_right = popTPSlice(&right)
 		} else if cur_left.Timestamp.After(cur_right.Timestamp) {
-			result = append(result, *cur_left)
 			cur_left = popTPSlice(&left)
 		} else {
-			result = append(result, *cur_right)
 			cur_right = popTPSlice(&right)
 		}
 	}
@@ -137,7 +141,7 @@ func addMatchingTimeseries(left []store.TimePoint, right []store.TimePoint) []st
 // points of a cumulative metric, such as cpu/usage.
 // The inputs are the value and timestamp of the newer cumulative datapoint,
 // and a pointer to a TimePoint holding the previous cumulative datapoint.
-func instantFromCumulativeMetric(value uint64, stamp time.Time, prev *store.TimePoint) (uint64, error) {
+func instantFromCumulativeMetric(value uint64, stamp time.Time, prev *statstore.TimePoint) (uint64, error) {
 	if prev == nil {
 		return uint64(0), fmt.Errorf("unable to calculate instant metric with nil previous TimePoint")
 	}
@@ -146,13 +150,33 @@ func instantFromCumulativeMetric(value uint64, stamp time.Time, prev *store.Time
 	}
 	tdelta := uint64(stamp.Sub(prev.Timestamp).Nanoseconds())
 	// Divide metric by nanoseconds that have elapsed, multiply by 1000 to get an unsigned metric
-	if value < prev.Value.(uint64) {
-		return uint64(0), fmt.Errorf("the provided value %d is less than the previous one %d", value, prev.Value.(uint64))
+	if value < prev.Value {
+		return uint64(0), fmt.Errorf("the provided value %d is less than the previous one %d", value, prev.Value)
 	}
-	vdelta := (value - prev.Value.(uint64)) * 1000
+	// Divide metric by nanoseconds that have elapsed, multiply by 1000 to get an unsigned metric
+	vdelta := (value - prev.Value) * 1000
 
 	instaVal := vdelta / tdelta
 	prev.Value = value
 	prev.Timestamp = stamp
 	return instaVal, nil
+}
+
+func epsilonFromMetric(metric string) uint64 {
+	// TODO: dynamic epsilon configuration, instead of statically allocating it during init
+	// TODO(afein): handle FS epsilon
+	switch metric {
+	case cpuLimit:
+		return cpuLimitEpsilon
+	case cpuUsage:
+		return cpuUsageEpsilon
+	case memLimit:
+		return memLimitEpsilon
+	case memUsage:
+		return memUsageEpsilon
+	case memWorking:
+		return memWorkingEpsilon
+	default:
+		return defaultEpsilon
+	}
 }

--- a/model/util_test.go
+++ b/model/util_test.go
@@ -20,16 +20,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"k8s.io/heapster/store"
+	"k8s.io/heapster/store/daystore"
+	"k8s.io/heapster/store/statstore"
 )
-
-// newTimePoint is a helper function that constructs TimePoints for other unit tests.
-func newTimePoint(stamp time.Time, val interface{}) store.TimePoint {
-	return store.TimePoint{
-		Timestamp: stamp,
-		Value:     val,
-	}
-}
 
 // TestLatestsTimestamp tests all flows of latestTimeStamp.
 func TestLatestTimestamp(t *testing.T) {
@@ -44,12 +37,11 @@ func TestLatestTimestamp(t *testing.T) {
 // TestNewInfoType tests both flows of the InfoType constructor.
 func TestNewInfoType(t *testing.T) {
 	var (
-		metrics = make(map[string]*store.TimeStore)
+		metrics = make(map[string]*daystore.DayStore)
 		labels  = make(map[string]string)
-		context = make(map[string]*store.TimePoint)
+		context = make(map[string]*statstore.TimePoint)
 	)
-	new_store := newTimeStore()
-	metrics["test"] = &new_store
+	metrics["test"] = newDayStore()
 	labels["name"] = "test"
 	assert := assert.New(t)
 
@@ -87,29 +79,29 @@ func TestAddContainerToMap(t *testing.T) {
 // TestAddTimePoints tests all flows of addTimePoints.
 func TestAddTimePoints(t *testing.T) {
 	var (
-		tp1 = store.TimePoint{
+		tp1 = statstore.TimePoint{
 			Timestamp: time.Unix(1434212800, 0),
 			Value:     uint64(500),
 		}
-		tp2 = store.TimePoint{
+		tp2 = statstore.TimePoint{
 			Timestamp: time.Unix(1434212805, 0),
 			Value:     uint64(700),
 		}
 		assert = assert.New(t)
 	)
 	new_tp := addTimePoints(tp1, tp2)
-	assert.Equal(new_tp.Timestamp, tp1.Timestamp)
-	assert.Equal(new_tp.Value.(uint64), tp1.Value.(uint64)+tp2.Value.(uint64))
+	assert.Equal(new_tp.Timestamp, tp2.Timestamp)
+	assert.Equal(new_tp.Value, tp1.Value+tp2.Value)
 }
 
 // TestPopTPSlice tests all flows of PopTPSlice.
 func TestPopTPSlice(t *testing.T) {
 	var (
-		tp1 = store.TimePoint{
+		tp1 = statstore.TimePoint{
 			Timestamp: time.Now(),
 			Value:     uint64(3),
 		}
-		tp2 = store.TimePoint{
+		tp2 = statstore.TimePoint{
 			Timestamp: time.Now(),
 			Value:     uint64(4),
 		}
@@ -118,16 +110,16 @@ func TestPopTPSlice(t *testing.T) {
 
 	// Invocations with no popped element
 	assert.Nil(popTPSlice(nil))
-	assert.Nil(popTPSlice(&[]store.TimePoint{}))
+	assert.Nil(popTPSlice(&[]statstore.TimePoint{}))
 
 	// Invocation with one element
-	tps := []store.TimePoint{tp1}
+	tps := []statstore.TimePoint{tp1}
 	res := popTPSlice(&tps)
 	assert.Equal(*res, tp1)
 	assert.Empty(tps)
 
 	// Invocation with two elements
-	tps = []store.TimePoint{tp1, tp2}
+	tps = []statstore.TimePoint{tp1, tp2}
 	res = popTPSlice(&tps)
 	assert.Equal(*res, tp1)
 	assert.Len(tps, 1)
@@ -137,99 +129,112 @@ func TestPopTPSlice(t *testing.T) {
 // TestAddMatchingTimeseries tests the normal flow of addMatchingTimeseries.
 func TestAddMatchingTimeseries(t *testing.T) {
 	var (
-		tp11 = store.TimePoint{
+		tp11 = statstore.TimePoint{
 			Timestamp: time.Unix(1434212800, 0),
 			Value:     uint64(4),
 		}
-		tp21 = store.TimePoint{
+		tp21 = statstore.TimePoint{
 			Timestamp: time.Unix(1434212805, 0),
 			Value:     uint64(9),
 		}
-		tp31 = store.TimePoint{
+		tp31 = statstore.TimePoint{
 			Timestamp: time.Unix(1434212807, 0),
 			Value:     uint64(10),
 		}
-		tp41 = store.TimePoint{
+		tp41 = statstore.TimePoint{
 			Timestamp: time.Unix(1434212850, 0),
 			Value:     uint64(533),
 		}
 
-		tp12 = store.TimePoint{
+		tp12 = statstore.TimePoint{
 			Timestamp: time.Unix(1434212800, 0),
 			Value:     uint64(4),
 		}
-		tp22 = store.TimePoint{
+		tp22 = statstore.TimePoint{
 			Timestamp: time.Unix(1434212806, 0),
 			Value:     uint64(8),
 		}
-		tp32 = store.TimePoint{
+		tp32 = statstore.TimePoint{
 			Timestamp: time.Unix(1434212807, 0),
 			Value:     uint64(11),
 		}
-		tp42 = store.TimePoint{
+		tp42 = statstore.TimePoint{
 			Timestamp: time.Unix(1434212851, 0),
 			Value:     uint64(534),
 		}
-		tp52 = store.TimePoint{
+		tp52 = statstore.TimePoint{
 			Timestamp: time.Unix(1434212859, 0),
 			Value:     uint64(538),
 		}
 		assert = assert.New(t)
 	)
 	// Invocation with 1+1 data points
-	tps1 := []store.TimePoint{tp11}
-	tps2 := []store.TimePoint{tp12}
+	tps1 := []statstore.TimePoint{tp11}
+	tps2 := []statstore.TimePoint{tp12}
 	new_ts := addMatchingTimeseries(tps1, tps2)
 	assert.Len(new_ts, 1)
 	assert.Equal(new_ts[0].Timestamp, tp11.Timestamp)
 	assert.Equal(new_ts[0].Value, uint64(8))
 
 	// Invocation with 3+1 data points
-	tps1 = []store.TimePoint{tp52, tp42, tp11}
-	tps2 = []store.TimePoint{tp12}
+	tps1 = []statstore.TimePoint{tp52, tp42, tp11}
+	tps2 = []statstore.TimePoint{tp12}
 	new_ts = addMatchingTimeseries(tps1, tps2)
 	assert.Len(new_ts, 3)
-	assert.Equal(new_ts[0], tp52)
-	assert.Equal(new_ts[1], tp42)
+	assert.Equal(new_ts[0].Timestamp, tp52.Timestamp)
+	assert.Equal(new_ts[0].Value, tp52.Value+tp12.Value)
+	assert.Equal(new_ts[1].Timestamp, tp42.Timestamp)
+	assert.Equal(new_ts[1].Value, tp42.Value+tp12.Value)
 	assert.Equal(new_ts[2].Timestamp, tp11.Timestamp)
-	assert.Equal(new_ts[2].Value, tp11.Value.(uint64)+tp12.Value.(uint64))
+	assert.Equal(new_ts[2].Value, tp11.Value+tp12.Value)
 
 	// Invocation with 4+5 data points
-	tps1 = []store.TimePoint{tp41, tp31, tp21, tp11}
-	tps2 = []store.TimePoint{tp52, tp42, tp32, tp22, tp12}
+	tps1 = []statstore.TimePoint{tp41, tp31, tp21, tp11}
+	tps2 = []statstore.TimePoint{tp52, tp42, tp32, tp22, tp12}
 	new_ts = addMatchingTimeseries(tps1, tps2)
 	assert.Len(new_ts, 7)
-	assert.Equal(new_ts[0], tp52)
-	assert.Equal(new_ts[1], tp42)
-	assert.Equal(new_ts[2], tp41)
+	assert.Equal(new_ts[0].Timestamp, tp52.Timestamp)
+	assert.Equal(new_ts[0].Value, tp52.Value+tp41.Value)
+
+	assert.Equal(new_ts[1].Timestamp, tp42.Timestamp)
+	assert.Equal(new_ts[1].Value, tp42.Value+tp41.Value)
+
+	assert.Equal(new_ts[2].Timestamp, tp41.Timestamp)
+	assert.Equal(new_ts[2].Value, tp41.Value+tp32.Value)
+
 	assert.Equal(new_ts[3].Timestamp, tp31.Timestamp)
-	assert.Equal(new_ts[3].Value, uint64(21))
-	assert.Equal(new_ts[4], tp22)
-	assert.Equal(new_ts[5], tp21)
+	assert.Equal(new_ts[3].Value, tp31.Value+tp32.Value)
+
+	assert.Equal(new_ts[4].Timestamp, tp22.Timestamp)
+	assert.Equal(new_ts[4].Value, tp22.Value+tp21.Value)
+
+	assert.Equal(new_ts[5].Timestamp, tp21.Timestamp)
+	assert.Equal(new_ts[5].Value, tp21.Value+tp12.Value)
+
 	assert.Equal(new_ts[6].Timestamp, tp11.Timestamp)
-	assert.Equal(new_ts[6].Value, uint64(8))
+	assert.Equal(new_ts[6].Value, tp11.Value+tp12.Value)
 }
 
 // TestAddMatchingTimeseriesEmpty tests the alternate flows of addMatchingTimeseries.
 // Three permutations of empty parameters are tested.
 func TestAddMatchingTimeseriesEmpty(t *testing.T) {
 	var (
-		tp12 = store.TimePoint{
+		tp12 = statstore.TimePoint{
 			Timestamp: time.Unix(1434212800, 0),
 			Value:     uint64(4),
 		}
-		tp22 = store.TimePoint{
+		tp22 = statstore.TimePoint{
 			Timestamp: time.Unix(1434212806, 0),
 			Value:     uint64(8),
 		}
-		tp32 = store.TimePoint{
+		tp32 = statstore.TimePoint{
 			Timestamp: time.Unix(1434212807, 0),
 			Value:     uint64(11),
 		}
 		assert = assert.New(t)
 	)
-	empty_tps := []store.TimePoint{}
-	tps := []store.TimePoint{tp12, tp22, tp32}
+	empty_tps := []statstore.TimePoint{}
+	tps := []statstore.TimePoint{tp12, tp22, tp32}
 
 	// First call: first argument is empty
 	new_ts := addMatchingTimeseries(empty_tps, tps)
@@ -252,7 +257,7 @@ func TestInstantFromCumulativeMetric(t *testing.T) {
 		assert    = assert.New(t)
 	)
 	afterNow := now.Add(3 * time.Second)
-	oldTP := &store.TimePoint{
+	oldTP := &statstore.TimePoint{
 		Timestamp: now,
 		Value:     uint64(13851000000000),
 	}


### PR DESCRIPTION
Part 2 of #478 

Changeset:
- Moved Getter methods to getters.go and tests to getters_test.go
- renamed top-level entity to Model from Cluster
- added a /nodes/{node-name}/pods endpoint
- Listing endpoints now also return the latest memory and CPU usage value through the new ExternalEntityListEntry struct
- ported the underlying stores to utilize DayStore structs instead. Epsilon is configured statically for each metric at model/types.go

Please do not be discouraged by the PR size, the majority of changes are on unit tests.

\cc @vishh @mvdan @piosz 
