### PR TITLE
Updates to the Hawkular-Metrics sink

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -145,7 +145,7 @@
 		},
 		{
 			"ImportPath": "github.com/hawkular/hawkular-client-go/metrics",
-			"Rev": "06bf87e3e131208c321ebd5d21576d94809537a1"
+			"Rev": "58a3868088707267e6c0383bd40c579587779f9a"
 		},
 		{
 			"ImportPath": "github.com/imdario/mergo",

--- a/Godeps/_workspace/src/github.com/hawkular/hawkular-client-go/metrics/client.go
+++ b/Godeps/_workspace/src/github.com/hawkular/hawkular-client-go/metrics/client.go
@@ -8,13 +8,14 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
-// TODO: Add statistics support? Error metrics (connection errors, request errors), request metrics:
-// totals, request rate? mean time, avg time, max, min, percentiles etc.. ? And clear metrics..
-// Stateful metrics? Kinda like Counters.Inc(..) ?
+// TODO Instrumentation? To get statistics?
+// TODO Authorization / Authentication ?
 
 // More detailed error
 
@@ -30,13 +31,14 @@ func (self *HawkularClientError) Error() string {
 // Client creation and instance config
 
 const (
-	base_url string = "hawkular/metrics"
+	base_url string        = "hawkular/metrics"
+	timeout  time.Duration = time.Duration(30 * time.Second)
 )
 
 type Parameters struct {
-	Tenant string
+	Tenant string // Technically optional, but requires setting Tenant() option everytime
 	Host   string
-	Path   string // Optional
+	Path   string // Modifieral
 }
 
 type Client struct {
@@ -44,6 +46,347 @@ type Client struct {
 	url    *url.URL
 	client *http.Client
 }
+
+type HawkularClient interface {
+	Send(*http.Request) (*http.Response, error)
+}
+
+// Modifiers
+
+type Modifier func(*http.Request) error
+
+// Override function to replace the Tenant (defaults to Client default)
+func Tenant(tenant string) Modifier {
+	return func(r *http.Request) error {
+		r.Header.Set("Hawkular-Tenant", tenant)
+		return nil
+	}
+}
+
+// Add payload to the request
+func Data(data interface{}) Modifier {
+	return func(r *http.Request) error {
+		jsonb, err := json.Marshal(data)
+		if err != nil {
+			return err
+		}
+
+		b := bytes.NewBuffer(jsonb)
+		rc := ioutil.NopCloser(b)
+		r.Body = rc
+
+		// fmt.Printf("Sending: %s\n", string(jsonb))
+
+		if b != nil {
+			r.ContentLength = int64(b.Len())
+		}
+		return nil
+	}
+}
+
+func (self *Client) Url(method string, e ...Endpoint) Modifier {
+	// TODO Create composite URLs? Add().Add().. etc? Easier to modify on the fly..
+	return func(r *http.Request) error {
+		u := self.createUrl(e...)
+		r.URL = u
+		r.Method = method
+		return nil
+	}
+}
+
+// Filters for querying
+
+type Filter func(r *http.Request)
+
+func Filters(f ...Filter) Modifier {
+	return func(r *http.Request) error {
+		for _, filter := range f {
+			filter(r)
+		}
+		return nil // Or should filter return err?
+	}
+}
+
+// Add query parameters
+func Param(k string, v string) Filter {
+	return func(r *http.Request) {
+		q := r.URL.Query()
+		q.Set(k, v)
+		r.URL.RawQuery = q.Encode()
+	}
+}
+
+func TypeFilter(t MetricType) Filter {
+	return Param("type", t.shortForm())
+}
+
+func TagsFilter(t map[string]string) Filter {
+	j := tagsEncoder(t)
+	return Param("tags", j)
+}
+
+// Requires HWKMETRICS-233
+func IdFilter(regexp string) Filter {
+	return Param("id", regexp)
+}
+
+func StartTimeFilter(duration time.Duration) Filter {
+	return Param("start", strconv.Itoa(int(duration)))
+}
+
+func EndTimeFilter(duration time.Duration) Filter {
+	return Param("end", strconv.Itoa(int(duration)))
+}
+
+func BucketsFilter(buckets int) Filter {
+	return Param("buckets", strconv.Itoa(buckets))
+}
+
+// The SEND method..
+
+func (self *Client) createRequest() *http.Request {
+	req := &http.Request{
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Header:     make(http.Header),
+		Host:       self.url.Host,
+	}
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Hawkular-Tenant", self.Tenant)
+	return req
+}
+
+func (self *Client) Send(o ...Modifier) (*http.Response, error) {
+	// Initialize
+	r := self.createRequest()
+
+	// Run all the modifiers
+	for _, f := range o {
+		err := f(r)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return self.client.Do(r)
+}
+
+// Commands
+
+func prepend(slice []Modifier, a ...Modifier) []Modifier {
+	p := make([]Modifier, 0, len(slice)+len(a))
+	p = append(p, a...)
+	p = append(p, slice...)
+	return p
+}
+
+// Create new Definition
+func (self *Client) Create(md MetricDefinition, o ...Modifier) (bool, error) {
+	// Keep the order, add custom prepend
+	o = prepend(o, self.Url("POST", TypeEndpoint(md.Type)), Data(md))
+
+	r, err := self.Send(o...)
+	if err != nil {
+		return false, err
+	}
+
+	defer r.Body.Close()
+
+	if r.StatusCode > 399 {
+		err = self.parseErrorResponse(r)
+		if err, ok := err.(*HawkularClientError); ok {
+			if err.Code != http.StatusConflict {
+				return false, err
+			} else {
+				return false, nil
+			}
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// Fetch definitions
+func (self *Client) Definitions(o ...Modifier) ([]*MetricDefinition, error) {
+	o = prepend(o, self.Url("GET", TypeEndpoint(Generic)))
+
+	r, err := self.Send(o...)
+	if err != nil {
+		return nil, err
+	}
+
+	defer r.Body.Close()
+
+	if r.StatusCode == http.StatusOK {
+		b, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			return nil, err
+		}
+		md := []*MetricDefinition{}
+		if b != nil {
+			if err = json.Unmarshal(b, &md); err != nil {
+				return nil, err
+			}
+		}
+		return md, err
+	} else if r.StatusCode > 399 {
+		return nil, self.parseErrorResponse(r)
+	}
+
+	return nil, nil
+}
+
+// Update tags
+func (self *Client) UpdateTags(t MetricType, id string, tags map[string]string, o ...Modifier) error {
+	o = prepend(o, self.Url("PUT", TypeEndpoint(t), SingleMetricEndpoint(id), TagEndpoint()), Data(tags))
+
+	r, err := self.Send(o...)
+	if err != nil {
+		return err
+	}
+
+	defer r.Body.Close()
+
+	if r.StatusCode > 399 {
+		return self.parseErrorResponse(r)
+	}
+
+	return nil
+}
+
+// Delete given tags from the definition
+func (self *Client) DeleteTags(t MetricType, id string, tags map[string]string, o ...Modifier) error {
+	o = prepend(o, self.Url("DELETE", TypeEndpoint(t), SingleMetricEndpoint(id), TagEndpoint(), TagsEndpoint(tags)))
+
+	r, err := self.Send(o...)
+	if err != nil {
+		return err
+	}
+
+	defer r.Body.Close()
+
+	if r.StatusCode > 399 {
+		return self.parseErrorResponse(r)
+	}
+
+	return nil
+}
+
+// Fetch metric definition tags
+func (self *Client) Tags(t MetricType, id string, o ...Modifier) (map[string]string, error) {
+	o = prepend(o, self.Url("GET", TypeEndpoint(t), SingleMetricEndpoint(id), TagEndpoint()))
+
+	r, err := self.Send(o...)
+	if err != nil {
+		return nil, err
+	}
+
+	defer r.Body.Close()
+
+	if r.StatusCode == http.StatusOK {
+		b, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			return nil, err
+		}
+		tags := make(map[string]string)
+		if b != nil {
+			if err = json.Unmarshal(b, &tags); err != nil {
+				return nil, err
+			}
+		}
+		return tags, nil
+	} else if r.StatusCode > 399 {
+		return nil, self.parseErrorResponse(r)
+	}
+
+	return nil, nil
+}
+
+// Write datapoints to the server
+func (self *Client) Write(metrics []MetricHeader, o ...Modifier) error {
+	if len(metrics) > 0 {
+		mHs := make(map[MetricType][]MetricHeader)
+		for _, m := range metrics {
+			if _, found := mHs[m.Type]; !found {
+				mHs[m.Type] = make([]MetricHeader, 0, 1)
+			}
+			mHs[m.Type] = append(mHs[m.Type], m)
+		}
+
+		wg := &sync.WaitGroup{}
+		errorsChan := make(chan error, len(mHs))
+
+		for k, v := range mHs {
+			wg.Add(1)
+			go func(k MetricType, v []MetricHeader) {
+				defer wg.Done()
+
+				// Should be sorted and splitted by type & tenant..
+				on := o
+				on = prepend(on, self.Url("POST", TypeEndpoint(k), DataEndpoint()), Data(v))
+
+				r, err := self.Send(on...)
+				if err != nil {
+					errorsChan <- err
+					return
+				}
+
+				defer r.Body.Close()
+
+				if r.StatusCode > 399 {
+					errorsChan <- self.parseErrorResponse(r)
+				}
+			}(k, v)
+		}
+		wg.Wait()
+		select {
+		case err, ok := <-errorsChan:
+			if ok {
+				return err
+			}
+			// If channel is closed, we're done
+		default:
+			// Nothing to do
+		}
+
+	}
+	return nil
+}
+
+// Read data from the server
+func (self *Client) ReadMetric(t MetricType, id string, o ...Modifier) ([]*Datapoint, error) {
+	o = prepend(o, self.Url("GET", TypeEndpoint(t), SingleMetricEndpoint(id), DataEndpoint()))
+
+	r, err := self.Send(o...)
+	if err != nil {
+		return nil, err
+	}
+
+	defer r.Body.Close()
+
+	if r.StatusCode == http.StatusOK {
+		b, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			return nil, err
+		}
+
+		// Check for GaugeBucketpoint and so on for the rest.. uh
+		dp := []*Datapoint{}
+		if b != nil {
+			if err = json.Unmarshal(b, &dp); err != nil {
+				return nil, err
+			}
+		}
+		return dp, nil
+	} else if r.StatusCode > 399 {
+		return nil, self.parseErrorResponse(r)
+	}
+
+	return nil, nil
+}
+
+// Initialization
 
 func NewHawkularClient(p Parameters) (*Client, error) {
 	if p.Path == "" {
@@ -59,66 +402,21 @@ func NewHawkularClient(p Parameters) (*Client, error) {
 	return &Client{
 		url:    u,
 		Tenant: p.Tenant,
-		client: &http.Client{},
+		client: &http.Client{
+			Timeout: timeout,
+		},
 	}, nil
 }
 
 // Public functions
 
-// Creates a new metric, and returns true if creation succeeded, false if not (metric was already created).
-// err is returned only in case of another error than 'metric already created'
-func (self *Client) Create(md MetricDefinition) (bool, error) {
-	jsonb, err := json.Marshal(&md)
-	if err != nil {
-		return false, err
-	}
-	err = self.post(self.metricsUrl(md.Type), jsonb)
-	if err != nil {
-		if err, ok := err.(*HawkularClientError); ok {
-			if err.Code != http.StatusConflict {
-				return false, err
-			} else {
-				return false, nil
-			}
-		}
-		return false, err
-	}
-	return true, nil
-
-}
-
-// Fetch metric definitions for one metric type
-func (self *Client) Definitions(t MetricType) ([]*MetricDefinition, error) {
-	q := make(map[string]string)
-	q["type"] = t.shortForm()
-	url, err := self.paramUrl(self.metricsUrl(Generic), q)
-	if err != nil {
-		return nil, err
-	}
-	b, err := self.get(url)
-	if err != nil {
-		return nil, err
-	}
-
-	md := []*MetricDefinition{}
-	if b != nil {
-		if err = json.Unmarshal(b, &md); err != nil {
-			return nil, err
-		}
-	}
-
-	for _, m := range md {
-		m.Type = t
-	}
-
-	return md, nil
-}
+// Older functions..
 
 // Return a single definition
 func (self *Client) Definition(t MetricType, id string) (*MetricDefinition, error) {
 	url := self.singleMetricsUrl(t, id)
 
-	b, err := self.get(url)
+	b, err := self.process(url, "GET", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -129,144 +427,36 @@ func (self *Client) Definition(t MetricType, id string) (*MetricDefinition, erro
 			return nil, err
 		}
 	}
-	md.Type = t
 	return &md, nil
-}
-
-// Fetch metric definition tags
-func (self *Client) Tags(t MetricType, id string) (*map[string]string, error) {
-	id_url := self.cleanId(id)
-	b, err := self.get(self.tagsUrl(t, id_url))
-	if err != nil {
-		return nil, err
-	}
-
-	tags := make(map[string]string)
-	// Repetive code.. clean up with other queries to somewhere..
-	if b != nil {
-		if err = json.Unmarshal(b, &tags); err != nil {
-			return nil, err
-		}
-	}
-
-	return &tags, nil
-}
-
-// Replace metric definition tags
-// TODO: Should this be "ReplaceTags" etc?
-func (self *Client) UpdateTags(t MetricType, id string, tags map[string]string) error {
-	id_url := self.cleanId(id)
-	b, err := json.Marshal(tags)
-	if err != nil {
-		return err
-	}
-	return self.put(self.tagsUrl(t, id_url), b)
-}
-
-// Delete given tags from the definition
-func (self *Client) DeleteTags(t MetricType, id_str string, deleted map[string]string) error {
-	id := self.cleanId(id_str)
-	tags := make([]string, 0, len(deleted))
-	for k, v := range deleted {
-		tags = append(tags, fmt.Sprintf("%s:%s", k, v))
-	}
-	j := strings.Join(tags, ",")
-	u := self.tagsUrl(t, id)
-	self.addToUrl(u, j)
-	return self.del(u)
-}
-
-// Take input of single Metric instance. If Timestamp is not defined, use current time
-func (self *Client) PushSingleGaugeMetric(id string, m Datapoint) error {
-	// id = self.cleanId(id)
-
-	if _, ok := m.Value.(float64); !ok {
-		f, err := ConvertToFloat64(m.Value)
-		if err != nil {
-			return err
-		}
-		m.Value = f
-	}
-
-	if m.Timestamp == 0 {
-		m.Timestamp = UnixMilli(time.Now())
-	}
-
-	mH := MetricHeader{
-		Id:   id,
-		Data: []Datapoint{m},
-		Type: Gauge,
-	}
-	return self.Write([]MetricHeader{mH})
 }
 
 // Read single Gauge metric's datapoints.
 // TODO: Remove and replace with better Read properties? Perhaps with iterators?
 func (self *Client) SingleGaugeMetric(id string, options map[string]string) ([]*Datapoint, error) {
-	id = self.cleanId(id)
-	url, err := self.paramUrl(self.dataUrl(self.singleMetricsUrl(Gauge, id)), options)
+	id = cleanId(id)
+	u := self.paramUrl(self.dataUrl(self.singleMetricsUrl(Gauge, id)), options)
 
-	if err != nil {
-		return nil, err
-	}
-	b, err := self.get(url)
+	// fmt.Printf("Receiving for %s, from: %s\n", self.Tenant, u)
+
+	b, err := self.process(u, "GET", nil)
 	if err != nil {
 		return nil, err
 	}
 	metrics := []*Datapoint{}
 
 	if b != nil {
+		// fmt.Printf("Received: %s\n", string(b))
 		if err = json.Unmarshal(b, &metrics); err != nil {
 			return nil, err
 		}
 	}
-
 	return metrics, nil
 
 }
 
-// func (self *Client) QueryGaugesWithTags(id string, tags map[string]string) ([]MetricDefinition, error) {
-
-// Write using mixedmultimetrics
-// For now supports only single metricType per request
-func (self *Client) Write(metrics []MetricHeader) error {
-	if len(metrics) > 0 {
-		metricType := metrics[0].Type // Temp solution
-		if err := metricType.validate(); err != nil {
-			return err
-		}
-
-		jsonb, err := json.Marshal(&metrics)
-		if err != nil {
-			return err
-		}
-		return self.post(self.dataUrl(self.metricsUrl(metricType)), jsonb)
-	}
-	return nil
-}
-
 // HTTP Helper functions
 
-func (self *Client) get(url *url.URL) ([]byte, error) {
-	return self.send(url, "GET", nil)
-}
-
-func (self *Client) post(url *url.URL, json []byte) error {
-	_, err := self.send(url, "POST", json)
-	return err
-}
-
-func (self *Client) put(url *url.URL, json []byte) error {
-	_, err := self.send(url, "PUT", json)
-	return err
-}
-
-func (self *Client) del(url *url.URL) error {
-	_, err := self.send(url, "DELETE", nil)
-	return err
-}
-
-func (self *Client) cleanId(id string) string {
+func cleanId(id string) string {
 	return url.QueryEscape(id)
 }
 
@@ -301,17 +491,39 @@ func (self *Client) newRequest(url *url.URL, method string, body io.Reader) (*ht
 	return req, nil
 }
 
+// Helper function that transforms struct to json and fetches the correct tenant information
+// TODO: Try the decorator pattern to replace all these simple functions?
+func (self *Client) process(url *url.URL, method string, data interface{}) ([]byte, error) {
+	jsonb, err := json.Marshal(&data)
+	if err != nil {
+		return nil, err
+	}
+	return self.send(url, method, jsonb)
+}
+
 func (self *Client) send(url *url.URL, method string, json []byte) ([]byte, error) {
 	// Have to replicate http.NewRequest here to avoid calling of url.Parse,
 	// which has a bug when it comes to encoded url
 	req, _ := self.newRequest(url, method, bytes.NewBuffer(json))
 	req.Header.Add("Content-Type", "application/json")
+	// if len(tenant) > 0 {
+	// req.Header.Add("Hawkular-Tenant", tenant)
+	// } else {
 	req.Header.Add("Hawkular-Tenant", self.Tenant)
+	// }
+
+	// fmt.Printf("curl -X %s -H 'Hawkular-Tenant: %s' %s\n", req.Method, req.Header.Get("Hawkular-Tenant"), req.URL)
+
 	resp, err := self.client.Do(req)
+
+	// fmt.Printf("%s\n", resp.Header.Get("Content-Length"))
+	// fmt.Printf("%d\n", resp.StatusCode)
 
 	if err != nil {
 		return nil, err
 	}
+
+	// fmt.Printf("Received bytes: %d\n", resp.ContentLength)
 
 	defer resp.Body.Close()
 
@@ -350,40 +562,89 @@ func (self *Client) parseErrorResponse(resp *http.Response) error {
 
 // URL functions (...)
 
+type Endpoint func(u *url.URL)
+
+func (self *Client) createUrl(e ...Endpoint) *url.URL {
+	mu := *self.url
+	for _, f := range e {
+		f(&mu)
+	}
+	return &mu
+}
+
+func TypeEndpoint(t MetricType) Endpoint {
+	return func(u *url.URL) {
+		addToUrl(u, t.String())
+	}
+}
+
+func SingleMetricEndpoint(id string) Endpoint {
+	return func(u *url.URL) {
+		addToUrl(u, url.QueryEscape(id))
+	}
+}
+
+func TagEndpoint() Endpoint {
+	return func(u *url.URL) {
+		addToUrl(u, "tags")
+	}
+}
+
+func TagsEndpoint(tags map[string]string) Endpoint {
+	return func(u *url.URL) {
+		addToUrl(u, tagsEncoder(tags))
+	}
+}
+
+func DataEndpoint() Endpoint {
+	return func(u *url.URL) {
+		addToUrl(u, "data")
+	}
+}
+
 func (self *Client) metricsUrl(metricType MetricType) *url.URL {
 	mu := *self.url
-	self.addToUrl(&mu, metricType.String())
+	addToUrl(&mu, metricType.String())
 	return &mu
 }
 
 func (self *Client) singleMetricsUrl(metricType MetricType, id string) *url.URL {
 	mu := self.metricsUrl(metricType)
-	self.addToUrl(mu, id)
+	addToUrl(mu, id)
 	return mu
 }
 
 func (self *Client) tagsUrl(mt MetricType, id string) *url.URL {
 	mu := self.singleMetricsUrl(mt, id)
-	self.addToUrl(mu, "tags")
+	addToUrl(mu, "tags")
 	return mu
 }
 
 func (self *Client) dataUrl(url *url.URL) *url.URL {
-	self.addToUrl(url, "data")
+	addToUrl(url, "data")
 	return url
 }
 
-func (self *Client) addToUrl(u *url.URL, s string) *url.URL {
+func addToUrl(u *url.URL, s string) *url.URL {
 	u.Opaque = fmt.Sprintf("%s/%s", u.Opaque, s)
 	return u
 }
 
-func (self *Client) paramUrl(u *url.URL, options map[string]string) (*url.URL, error) {
+func tagsEncoder(t map[string]string) string {
+	tags := make([]string, 0, len(t))
+	for k, v := range t {
+		tags = append(tags, fmt.Sprintf("%s:%s", k, v))
+	}
+	j := strings.Join(tags, ",")
+	return j
+}
+
+func (self *Client) paramUrl(u *url.URL, options map[string]string) *url.URL {
 	q := u.Query()
 	for k, v := range options {
 		q.Set(k, v)
 	}
 
 	u.RawQuery = q.Encode()
-	return u, nil
+	return u
 }

--- a/Godeps/_workspace/src/github.com/hawkular/hawkular-client-go/metrics/client_test.go
+++ b/Godeps/_workspace/src/github.com/hawkular/hawkular-client-go/metrics/client_test.go
@@ -15,7 +15,8 @@ func integrationClient() (*Client, error) {
 		return nil, err
 	}
 	// p := Parameters{Tenant: t, Host: "localhost:8080", Path: "hawkular/metrics"}
-	p := Parameters{Tenant: t, Host: "localhost:8080"}
+	// p := Parameters{Tenant: t, Host: "localhost:8180"}
+	p := Parameters{Tenant: t, Host: "192.168.1.105:8080"}
 	// p := Parameters{Tenant: t, Host: "209.132.178.218:18080"}
 	return NewHawkularClient(p)
 }
@@ -31,6 +32,31 @@ func randomString() (string, error) {
 func createError(err error) {
 }
 
+func TestTenantModifier(t *testing.T) {
+	c, err := integrationClient()
+	assert.Nil(t, err)
+
+	ot, _ := randomString()
+
+	// Create for another tenant
+	id := "test.metric.create.numeric.tenant.1"
+	md := MetricDefinition{Id: id, Type: Gauge}
+
+	ok, err := c.Create(md, Tenant(ot))
+	assert.Nil(t, err)
+	assert.True(t, ok, "MetricDefinition should have been created")
+
+	// Try to fetch from default tenant - should fail
+	mds, err := c.Definitions(Filters(TypeFilter(Gauge)))
+	assert.Nil(t, err)
+	assert.Nil(t, mds)
+
+	// Try to fetch from the given tenant - should succeed
+	mds, err = c.Definitions(Filters(TypeFilter(Gauge)), Tenant(ot))
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(mds))
+}
+
 func TestCreate(t *testing.T) {
 	c, err := integrationClient()
 	assert.Nil(t, err)
@@ -41,7 +67,9 @@ func TestCreate(t *testing.T) {
 	assert.Nil(t, err)
 	assert.True(t, ok, "MetricDefinition should have been created")
 
-	// Commented out, see HWKMETRICS-110
+	// Following would be nice:
+	// mdd, err := c.Definitions(Filters(Type(Gauge), Id(id)))
+
 	// mdd, err := c.Definition(Gauge, id)
 	// assert.Nil(t, err)
 	// assert.Equal(t, md.Id, mdd.Id)
@@ -63,11 +91,11 @@ func TestCreate(t *testing.T) {
 
 	md_reten := MetricDefinition{Id: "test/metric/create/availability/1", RetentionTime: 12, Type: Availability}
 	ok, err = c.Create(md_reten)
-	assert.True(t, ok, "MetricDefinition should have been created")
 	assert.Nil(t, err)
+	assert.True(t, ok, "MetricDefinition should have been created")
 
 	// Fetch all the previously created metrics and test equalities..
-	mdq, err := c.Definitions(Gauge)
+	mdq, err := c.Definitions(Filters(TypeFilter(Gauge)))
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(mdq), "Size of the returned gauge metrics does not match 2")
 
@@ -79,148 +107,103 @@ func TestCreate(t *testing.T) {
 	assert.Equal(t, md.Id, mdm[id].Id)
 	assert.True(t, reflect.DeepEqual(tags, mdm["test.metric.create.numeric.2"].Tags))
 
-	mda, err := c.Definitions(Availability)
+	mda, err := c.Definitions(Filters(TypeFilter(Availability)))
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(mda))
 	assert.Equal(t, "test/metric/create/availability/1", mda[0].Id)
 	assert.Equal(t, 12, mda[0].RetentionTime)
 
 	if mda[0].Type != Availability {
-		t.FailNow()
+		assert.FailNow(t, "Type did not match Availability", int(mda[0].Type))
 	}
-}
-
-func TestAddGaugeSingle(t *testing.T) {
-	c, err := integrationClient()
-	assert.Nil(t, err)
-
-	// With timestamp
-	m := Datapoint{Timestamp: time.Now().UnixNano() / 1e6, Value: 1.34}
-	err = c.PushSingleGaugeMetric("test/numeric/single/1", m)
-	assert.Nil(t, err)
-
-	// Without preset timestamp
-	m = Datapoint{Value: 2}
-	err = c.PushSingleGaugeMetric("test.numeric.single.2", m)
-	assert.Nil(t, err)
-
-	//  for both metrics and check that they're correctly filled
-	params := make(map[string]string)
-	metrics, err := c.SingleGaugeMetric("test/numeric/single/1", params)
-	assert.Nil(t, err)
-	assert.Equal(t, 1, len(metrics), "Received different amount of datapoints than sent")
-
-	metrics, err = c.SingleGaugeMetric("test.numeric.single.2", params)
-	assert.Nil(t, err)
-	assert.Equal(t, 1, len(metrics), "Received more datapoints than written")
-	assert.False(t, metrics[0].Timestamp < 1, "Timestamp was not correctly populated")
 }
 
 func TestTagsModification(t *testing.T) {
-	if c, err := integrationClient(); err == nil {
-		id := "test/tags/modify/1"
-		// Create metric without tags
-		md := MetricDefinition{Id: id, Type: Gauge}
-		ok, err := c.Create(md)
-		assert.Nil(t, err)
-		assert.True(t, ok, "MetricDefinition should have been created")
+	c, err := integrationClient()
+	assert.Nil(t, err)
+	id := "test/tags/modify/1"
+	// Create metric without tags
+	md := MetricDefinition{Id: id, Type: Gauge}
+	ok, err := c.Create(md)
+	assert.Nil(t, err)
+	assert.True(t, ok, "MetricDefinition should have been created")
 
-		// Add tags
-		tags := make(map[string]string)
-		tags["ab"] = "ac"
-		tags["host"] = "test"
-		err = c.UpdateTags(Gauge, id, tags)
-		assert.Nil(t, err)
+	// Add tags
+	tags := make(map[string]string)
+	tags["ab"] = "ac"
+	tags["host"] = "test"
+	err = c.UpdateTags(Gauge, id, tags)
+	assert.Nil(t, err)
 
-		// Fetch metric tags - check for equality
-		md_tags, err := c.Tags(Gauge, id)
-		assert.Nil(t, err)
+	// Fetch metric tags - check for equality
+	md_tags, err := c.Tags(Gauge, id)
+	assert.Nil(t, err)
 
-		assert.True(t, reflect.DeepEqual(tags, *md_tags), "Tags did not match the updated ones")
+	assert.True(t, reflect.DeepEqual(tags, md_tags), "Tags did not match the updated ones")
 
-		// Delete some metric tags
-		err = c.DeleteTags(Gauge, id, tags)
-		assert.Nil(t, err)
+	// Delete some metric tags
+	err = c.DeleteTags(Gauge, id, tags)
+	assert.Nil(t, err)
 
-		// Fetch metric - check that tags were deleted
-		md_tags, err = c.Tags(Gauge, id)
-		assert.Nil(t, err)
-		assert.False(t, len(*md_tags) > 0, "Received deleted tags")
-	}
-}
-
-func TestTags(t *testing.T) {
-	if c, err := integrationClient(); err == nil {
-		tags := make(map[string]string)
-		tTag, err := randomString()
-		tags[tTag] = "testValue"
-
-		// Write with tags
-		m := Datapoint{Value: float64(0.01), Tags: tags}
-		err = c.PushSingleGaugeMetric("test.tags.numeric.1", m)
-		assert.NoError(t, err)
-
-		// Search metrics with tag
-
-		// 		    @GET
-		// @Path("/{tenantId}/numeric")
-		// @ApiOperation(value = "Find numeric metrics data by their tags.", response = Map.cla@ApiParam(value = "Tag list", required = true) @Param("tags") Tags tags
-
-		// Get metric definition tags
-		// @Path("/{tenantId}/metrics/numeric/{id}/tags")
-		// @ApiOperation(value = "Retrieve tags associated with the metric definition.", response = Metric.class)
-
-		// Fetch a metric with values and check we still have tags
-	}
+	// Fetch metric - check that tags were deleted
+	md_tags, err = c.Tags(Gauge, id)
+	assert.Nil(t, err)
+	assert.False(t, len(md_tags) > 0, "Received deleted tags")
 }
 
 func TestAddMixedMulti(t *testing.T) {
 
 	// Modify to send both Availability as well as Gauge metrics at the same time
-	if c, err := integrationClient(); err == nil {
+	c, err := integrationClient()
+	assert.NoError(t, err)
 
-		mone := Datapoint{Value: 1.45, Timestamp: UnixMilli(time.Now())}
-		hone := MetricHeader{
-			Id:   "test.multi.numeric.1",
-			Data: []Datapoint{mone},
-			Type: Gauge,
-		}
-
-		mtwo_1 := Datapoint{Value: 2, Timestamp: UnixMilli(time.Now())}
-
-		mtwo_2_t := UnixMilli(time.Now()) - 1e3
-
-		mtwo_2 := Datapoint{Value: float64(4.56), Timestamp: mtwo_2_t}
-		htwo := MetricHeader{
-			Id:   "test.multi.numeric.2",
-			Data: []Datapoint{mtwo_1, mtwo_2},
-			Type: Gauge,
-		}
-
-		h := []MetricHeader{hone, htwo}
-
-		err = c.Write(h)
-		assert.NoError(t, err)
-
-		var checkDatapoints = func(id string, expected int) []*Datapoint {
-			metric, err := c.SingleGaugeMetric(id, make(map[string]string))
-			assert.NoError(t, err)
-			assert.Equal(t, expected, len(metric), "Amount of datapoints does not match expected value")
-			return metric
-		}
-
-		checkDatapoints("test.multi.numeric.1", 1)
-		checkDatapoints("test.multi.numeric.2", 2)
-	} else {
-		t.Error(err)
+	mone := Datapoint{Value: 1.45, Timestamp: UnixMilli(time.Now())}
+	hone := MetricHeader{
+		Id:   "test.multi.numeric.1",
+		Data: []Datapoint{mone},
+		Type: Gauge,
 	}
+
+	mtwo_1 := Datapoint{Value: 2, Timestamp: UnixMilli(time.Now())}
+
+	mtwo_2_t := UnixMilli(time.Now()) - 1e3
+
+	mtwo_2 := Datapoint{Value: float64(4.56), Timestamp: mtwo_2_t}
+	htwo := MetricHeader{
+		Id:   "test.multi.numeric.2",
+		Data: []Datapoint{mtwo_1, mtwo_2},
+		Type: Counter,
+	}
+
+	h := []MetricHeader{hone, htwo}
+
+	err = c.Write(h)
+	assert.NoError(t, err)
+
+	time.Sleep(1000 * time.Millisecond)
+
+	var checkDatapoints = func(id string, typ MetricType, expected int) []*Datapoint {
+		metric, err := c.ReadMetric(typ, id)
+		assert.NoError(t, err)
+		assert.Equal(t, expected, len(metric), "Amount of datapoints does not match expected value")
+		return metric
+	}
+
+	checkDatapoints(hone.Id, hone.Type, 1)
+	checkDatapoints(htwo.Id, htwo.Type, 2)
 }
 
 func TestCheckErrors(t *testing.T) {
 	c, err := integrationClient()
 	assert.Nil(t, err)
 
-	err = c.PushSingleGaugeMetric("test.number.as.string", Datapoint{Value: "notFloat"})
+	mH := MetricHeader{
+		Id:   "test.number.as.string",
+		Data: []Datapoint{Datapoint{Value: "notFloat"}},
+		Type: Gauge,
+	}
+
+	err = c.Write([]MetricHeader{mH})
 	assert.NotNil(t, err, "Invalid non-float value should not be accepted")
 	_, err = c.SingleGaugeMetric("test.not.existing", make(map[string]string))
 	assert.Nil(t, err, "Querying empty metric should not generate an error")

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Source configuration is documented [here](docs/source-configuration.md).
 
 ### Running Heapster on Kubernetes
 
-Heapster supports a pluggable storage backend. It supports [InfluxDB](http://influxdb.com) with [Grafana](http://grafana.org/docs/features/influxdb), [Google Cloud Monitoring](https://cloud.google.com/monitoring/) and [Google Cloud Logging](https://cloud.google.com/logging/). We welcome patches that add additional storage backends.
+Heapster supports a pluggable storage backend. It supports [InfluxDB](http://influxdb.com) with [Grafana](http://grafana.org/docs/features/influxdb), [Google Cloud Monitoring](https://cloud.google.com/monitoring/), [Google Cloud Logging](https://cloud.google.com/logging/) and [Hawkular](http://www.hawkular.org). We welcome patches that add additional storage backends.
 
 To run Heapster on a Kubernetes cluster with,
 - InfluxDB use [this guide](docs/influxdb.md). 
@@ -23,6 +23,10 @@ Take a look at the storage schema [here](docs/storage-schema.md).
 
 When Heapster is running on a Kubernetes cluster, the [Heapster Model](docs/model.md)
 can be used to extract aggregated metrics and derived stats for various Kubernetes cluster entities.
+
+### Running Heapster on Openshift
+
+Using Heapster to monitor an Openshift cluster requires some additional changes to the Kubernetes instructions to allow communication between the Heapster instance and Openshift's secured endpoints. To run a combination of Heapster and Hawkular-Metrics, follow [this guide](https://github.com/hawkular/hawkular-metrics/blob/master/containers/README.adoc). 
 
 ### Running Heapster on CoreOS
 

--- a/docs/sink-configuration.md
+++ b/docs/sink-configuration.md
@@ -75,6 +75,7 @@ If `HAWKULAR_SERVER_URL` includes any path, the default `hawkular/metrics` is ov
 The following options are available:
 
 * `tenant` - Hawkular-Metrics tenantId (default: `heapster`)
+* `labelToTenant` - Hawkular-Metrics uses given label's value as tenant value when storing data
 
 ## Modifying the sinks at runtime
 

--- a/docs/storage-schema.md
+++ b/docs/storage-schema.md
@@ -79,13 +79,13 @@ TODO: Add a snapshot of all the metrics stored in GCM.
 
 ### Hawkular
 
-Each metric is stored as separate timeseries (metric) in Hawkular-Metrics with tags being inherited from common ancestor type. The metric name is created with the following format: `containerName/podId/metricName` (`/` is separator). All the metrics are stored as gauges at this point (this might change after the counter type has been redefined in the Hawkular). Each definition stores the labels as tags with following addons:
+Each metric is stored as separate timeseries (metric) in Hawkular-Metrics with tags being inherited from common ancestor type. The metric name is created with the following format: `containerName/podId/metricName` (`/` is separator). Each definition stores the labels as tags with following addons:
 
 * All the Label descriptions are stored as label_description
 * The ancestor metric name (such as cpu/usage) is stored under the tag `descriptor_name`
 * To ease search, a tag with `group_id` stores the key `containerName/metricName` so each podId can be linked under a single timeseries if necessary.
-* Type (Gauge / Cumulative) is stored to `type` tag
 * Units are stored under `units` tag
+* If labelToTenant parameter is given, any metric with the label will use this label's value as the target tenant. If the metric doesn't have the label defined, default tenant is used.
 
 At the start, all the definitions are fetched from the Hawkular-Metrics tenant and filtered to cache only the Heapster metrics. It is recommended to use a separate tenant for Heapster information if you have lots of metrics from other systems, but not required.
 

--- a/sinks/hawkular/driver.go
+++ b/sinks/hawkular/driver.go
@@ -39,44 +39,59 @@ const (
 
 type hawkularSink struct {
 	client  *metrics.Client
-	models  map[string]metrics.MetricDefinition // Model definitions
+	models  map[string]*metrics.MetricDefinition // Model definitions
 	regLock sync.Mutex
 	reg     map[string]*metrics.MetricDefinition // Real definitions
 
 	uri *url.URL
+
+	labelTenant string
 }
 
 // START: ExternalSink interface implementations
 
 func (self *hawkularSink) Register(mds []sink_api.MetricDescriptor) error {
-	self.regLock.Lock()
-	defer self.regLock.Unlock()
-
 	// Create model definitions based on the MetricDescriptors
 	for _, md := range mds {
 		hmd := self.descriptorToDefinition(&md)
-		self.models[md.Name] = hmd
+		self.models[md.Name] = &hmd
 	}
 
 	// Fetch currently known metrics from Hawkular-Metrics and cache them
-	prev, err := self.client.Definitions(metrics.Gauge)
+	types := []metrics.MetricType{metrics.Gauge, metrics.Counter}
+	for _, t := range types {
+		err := self.updateDefinitions(t)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Fetches definitions from the server and checks that they're matching the descriptors
+func (self *hawkularSink) updateDefinitions(mt metrics.MetricType) error {
+	mds, err := self.client.Definitions(metrics.Filters(metrics.TypeFilter(mt)))
 	if err != nil {
 		return err
 	}
 
-	for _, p := range prev {
+	self.regLock.Lock()
+	defer self.regLock.Unlock()
+
+	for _, p := range mds {
 		// If no descriptorTag is found, this metric does not belong to Heapster
 		if mk, found := p.Tags[descriptorTag]; found {
-			model := self.models[mk]
-			if !self.recent(p, &model) {
-				if err := self.client.UpdateTags(metrics.Gauge, p.Id, p.Tags); err != nil {
-					return err
+			if model, f := self.models[mk]; f {
+				if !self.recent(p, model) {
+					if err := self.client.UpdateTags(mt, p.Id, p.Tags); err != nil {
+						return err
+					}
 				}
 			}
 			self.reg[p.Id] = p
 		}
 	}
-
 	return nil
 }
 
@@ -113,15 +128,13 @@ func (self *hawkularSink) descriptorToDefinition(md *sink_api.MetricDescriptor) 
 	if len(md.Units.String()) > 0 {
 		tags[unitsTag] = md.Units.String()
 	}
-	if len(md.Type.String()) > 0 {
-		tags[typeTag] = md.Type.String()
-	}
 
 	tags[descriptorTag] = md.Name
 
 	hmd := metrics.MetricDefinition{
 		Id:   md.Name,
 		Tags: tags,
+		Type: heapsterTypeToHawkularType(md.Type),
 	}
 
 	return hmd
@@ -139,7 +152,7 @@ func (self *hawkularSink) idName(p *sink_api.Point) string {
 
 // Check that metrics tags are defined on the Hawkular server and if not,
 // register the metric definition.
-func (self *hawkularSink) registerIfNecessary(t *sink_api.Timeseries) error {
+func (self *hawkularSink) registerIfNecessary(t *sink_api.Timeseries, m ...metrics.Modifier) error {
 	key := self.idName(t.Point)
 
 	self.regLock.Lock()
@@ -150,24 +163,31 @@ func (self *hawkularSink) registerIfNecessary(t *sink_api.Timeseries) error {
 	if _, found := self.reg[key]; !found {
 		// Register the metric descriptor here..
 		if md, f := self.models[t.MetricDescriptor.Name]; f {
+			// Copy the original map
+			mdd := *md
+			tags := make(map[string]string)
+			for k, v := range mdd.Tags {
+				tags[k] = v
+			}
+			mdd.Tags = tags
+
 			// Set tag values
 			for k, v := range t.Point.Labels {
-				md.Tags[k] = v
+				mdd.Tags[k] = v
 			}
 
-			md.Tags[groupTag] = self.groupName(t.Point)
-			md.Tags[descriptorTag] = t.MetricDescriptor.Name
+			mdd.Tags[groupTag] = self.groupName(t.Point)
+			mdd.Tags[descriptorTag] = t.MetricDescriptor.Name
 
 			// Create metric, use updateTags instead of Create because we know it is unique
-			if err := self.client.UpdateTags(metrics.Gauge, key, md.Tags); err != nil {
+			if err := self.client.UpdateTags(mdd.Type, key, mdd.Tags, m...); err != nil {
 				// Log error and don't add this key to the lookup table
 				glog.Errorf("Could not update tags: %s", err)
 				return err
 			}
 
 			// Add to the lookup table
-			self.reg[key] = &md
-			glog.Infof("Registered new metric definition: %s", key)
+			self.reg[key] = &mdd
 		} else {
 			return fmt.Errorf("Could not find definition model with name %s", t.MetricDescriptor.Name)
 		}
@@ -179,10 +199,30 @@ func (self *hawkularSink) registerIfNecessary(t *sink_api.Timeseries) error {
 
 func (self *hawkularSink) StoreTimeseries(ts []sink_api.Timeseries) error {
 	if len(ts) > 0 {
-		mhs := make([]metrics.MetricHeader, 0, len(ts))
+		tmhs := make(map[string][]metrics.MetricHeader)
+
+		if &self.labelTenant == nil {
+			tmhs[self.client.Tenant] = make([]metrics.MetricHeader, 0, len(ts))
+		}
+
+		wg := &sync.WaitGroup{}
 
 		for _, t := range ts {
-			self.registerIfNecessary(&t)
+
+			tenant := self.client.Tenant
+
+			if &self.labelTenant != nil {
+				if v, found := t.Point.Labels[self.labelTenant]; found {
+					tenant = v
+				}
+			}
+
+			// Registering should not block the processing
+			wg.Add(1)
+			go func(t *sink_api.Timeseries, tenant string) {
+				defer wg.Done()
+				self.registerIfNecessary(t, metrics.Tenant(tenant))
+			}(&t, tenant)
 
 			if t.MetricDescriptor.ValueType == sink_api.ValueBool {
 				// TODO: Model to availability type once we see some real world examples
@@ -196,10 +236,23 @@ func (self *hawkularSink) StoreTimeseries(ts []sink_api.Timeseries) error {
 				continue
 			}
 
-			mhs = append(mhs, *mH)
+			if _, found := tmhs[tenant]; !found {
+				tmhs[tenant] = make([]metrics.MetricHeader, 0)
+			}
+
+			tmhs[tenant] = append(tmhs[tenant], *mH)
 		}
 
-		return self.client.Write(mhs)
+		for k, v := range tmhs {
+			wg.Add(1)
+			go func(v []metrics.MetricHeader, k string) {
+				defer wg.Done()
+				if err := self.client.Write(v, metrics.Tenant(k)); err != nil {
+					glog.Errorf(err.Error())
+				}
+			}(v, k)
+		}
+		wg.Wait()
 	}
 	return nil
 }
@@ -220,33 +273,46 @@ func (self *hawkularSink) pointToMetricHeader(t *sink_api.Timeseries) (*metrics.
 		Timestamp: metrics.UnixMilli(p.End),
 	}
 
-	// At the moment all the values are converted to gauges.
 	mh := &metrics.MetricHeader{
 		Id:   name,
 		Data: []metrics.Datapoint{m},
-		Type: metrics.Gauge,
+		Type: heapsterTypeToHawkularType(t.MetricDescriptor.Type),
 	}
+
 	return mh, nil
 }
 
+func heapsterTypeToHawkularType(t sink_api.MetricType) metrics.MetricType {
+	switch t {
+	case sink_api.MetricCumulative:
+		return metrics.Counter
+	case sink_api.MetricGauge:
+		return metrics.Gauge
+	default:
+		return metrics.Gauge
+	}
+}
+
 func (self *hawkularSink) DebugInfo() string {
-	info := fmt.Sprintf("Hawkular-Metrics Sink\n")
+	info := fmt.Sprintf("%s\n", self.Name())
 
 	self.regLock.Lock()
 	defer self.regLock.Unlock()
-	info += fmt.Sprintf("Known metrics: %d", len(self.reg))
+	info += fmt.Sprintf("Known metrics: %d\n", len(self.reg))
+	if &self.labelTenant != nil {
+		info += fmt.Sprintf("Using label '%s' as tenant information\n", self.labelTenant)
+	}
 
 	// TODO Add here statistics from the Hawkular-Metrics client instance
 	return info
 }
 
 func (self *hawkularSink) StoreEvents(events []kube_api.Event) error {
-	// TODO: Delegate to Fabric8 event storage (if available) until Hawkular has a solution?
 	return nil
 }
 
 func (self *hawkularSink) Name() string {
-	return "Hawkular-Metrics sink"
+	return "Hawkular-Metrics Sink"
 }
 
 // END: ExternalSink
@@ -272,6 +338,10 @@ func (self *hawkularSink) init() error {
 		p.Tenant = v[0]
 	}
 
+	if v, found := opts["labelToTenant"]; found {
+		self.labelTenant = v[0]
+	}
+
 	c, err := metrics.NewHawkularClient(p)
 	if err != nil {
 		return err
@@ -279,7 +349,7 @@ func (self *hawkularSink) init() error {
 
 	self.client = c
 	self.reg = make(map[string]*metrics.MetricDefinition)
-	self.models = make(map[string]metrics.MetricDefinition)
+	self.models = make(map[string]*metrics.MetricDefinition)
 
 	glog.Infof("Initialised Hawkular Sink with parameters %v", p)
 	return nil


### PR DESCRIPTION
This PR adds some changes to the Hawkular-Metrics sink described below. Some of the changes are done to provide better support for using Heapster on the Openshift v3, while others are fixes that did not work correctly in the first version. Do not merge yet, requires still an update to the Hawkular-Metrics client (to released version) - but open to comments.

New features:

* Add support for Cumulative metric type
* Add feature to transform metric label value to Hawkular-Metrics tenant

Tests:

* Add integration tests to check Register and Timeseries methods.

Improvements:

* Parallel Storetimeseries operations to improve performance when storing to multiple tenants
* Make registerIfNecessary happen in the background goroutine

Fixes:

* Fix registerIfNecessary leaking map reference between metrics. 

Documentation:

* Improve documentation of Hawkular-Metrics sink and add link to instructions on deploying Heapster + Hawkular-Metrics combination to Openshift (kubernetes.json should work on plain Kubernetes also with small changes)