### PR TITLE
Upgrading to InfluxDB v0.8.9

### DIFF
--- a/deploy/kube-config/influxdb/influxdb-grafana-controller.json
+++ b/deploy/kube-config/influxdb/influxdb-grafana-controller.json
@@ -22,7 +22,7 @@
 	    "spec": {
 		"containers": [
 		    {
-			"image": "kubernetes/heapster_influxdb:v0.3",
+			"image": "kubernetes/heapster_influxdb:v0.4",
 			"name": "influxdb",
 			"ports": [
 			    {

--- a/influxdb/Dockerfile
+++ b/influxdb/Dockerfile
@@ -2,9 +2,9 @@
 FROM ubuntu:trusty
 
 # Install InfluxDB
-ENV INFLUXDB_VERSION 0.8.8
+ENV INFLUXDB_VERSION 0.8.9
 
-RUN apt-get update && apt-get install -y curl && curl -s -o /tmp/influxdb_latest_amd64.deb https://s3.amazonaws.com/influxdb/influxdb_${INFLUXDB_VERSION}_amd64.deb && \
+RUN apt-get update && apt-get install -y curl && curl -s -o /tmp/influxdb_latest_amd64.deb http://get.influxdb.org.s3.amazonaws.com/influxdb_${INFLUXDB_VERSION}_amd64.deb && \
   dpkg -i /tmp/influxdb_latest_amd64.deb && \
   rm /tmp/influxdb_latest_amd64.deb
 

--- a/influxdb/RELEASES.md
+++ b/influxdb/RELEASES.md
@@ -1,4 +1,7 @@
 # Release Notes for heapster influxdb container.
 
+## 0.4 (9-17-2015)
+- Updated to InfluxDB v0.8.9 to pave way for safely upgrading to influxDB v0.9.x
+
 ## 0.3 (1-19-2015)
 - Updated Influxdb version number to 0.8.8, paving way for collectd support.


### PR DESCRIPTION
This is required for safely upgrading to InfluxDB v0.9