### PR TITLE
Add container labels to the list of labels exported by heapster.

### DIFF
--- a/sinks/api/decoder.go
+++ b/sinks/api/decoder.go
@@ -15,6 +15,7 @@
 package v1
 
 import (
+	"fmt"
 	"time"
 
 	"k8s.io/heapster/sinks/cache"
@@ -94,6 +95,12 @@ func (self *decoder) getContainerMetrics(container *cache.ContainerElement, labe
 	}
 	labels[LabelContainerName.Key] = container.Name
 	labels[LabelContainerBaseImage.Key] = container.Image
+	// Add container specific labels along with existing labels.
+	containerLabels := util.LabelsToString(container.Labels, ",")
+	if labels[LabelLabels.Key] != "" {
+		containerLabels = fmt.Sprintf("%s,%s", labels[LabelLabels.Key], containerLabels)
+	}
+	labels[LabelLabels.Key] = containerLabels
 
 	if _, exists := labels[LabelHostID.Key]; !exists {
 		labels[LabelHostID.Key] = container.ExternalID

--- a/sinks/cache/impl.go
+++ b/sinks/cache/impl.go
@@ -198,6 +198,7 @@ func (rc *realCache) StorePods(pods []source_api.Pod) error {
 			ce.Metadata = Metadata{
 				Name:     cont.Name,
 				Hostname: cont.Hostname,
+				Labels:   cont.Spec.Labels,
 			}
 			ce.Image = cont.Image
 			ce.Metadata.LastUpdate = storeSpecAndStats(ce, cont)
@@ -240,6 +241,7 @@ func (rc *realCache) StoreContainers(containers []source_api.Container) error {
 				ne.freeContainers[cont.Name] = ce
 			}
 		}
+		ce.Metadata.Labels = cont.Spec.Labels
 		ce.Image = cont.Image
 		ce.Metadata.LastUpdate = storeSpecAndStats(ce, cont)
 		ce.lastUpdated = now


### PR DESCRIPTION
This is useful for monitoring based on labels set to container images.

xref: https://github.com/kubernetes/kubernetes/pull/13612

cc @dchen1107 