### PR TITLE
Grafana 2.1.0 and InfluxDB 0.9.4 Support E2E

### DIFF
--- a/deploy/kube-config/influxdb/influxdb-grafana-controller.yaml
+++ b/deploy/kube-config/influxdb/influxdb-grafana-controller.yaml
@@ -26,7 +26,13 @@ spec:
         - mountPath: /data
           name: influxdb-storage
       - name: grafana
-        image: grafana/grafana:2.1.0
+        image: kubernetes/heapster_grafana:2.1.0
+        ports:
+          - containerPort: 3000
+            hostPort: 3000
+        env:
+          - name: "INFLUXDB_SERVICE_URL"
+            value: "http://monitoring-influxdb:8086"
       volumes:
       - name: influxdb-storage
         emptyDir: {}

--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -1,0 +1,14 @@
+#
+# Stock Grafana + a few custom dashboards
+#
+
+FROM grafana/grafana:2.1.0
+
+RUN apt-get update && \
+    apt-get install -y curl
+
+COPY dashboards /dashboards
+COPY run.sh /run.sh
+
+EXPOSE 3000
+ENTRYPOINT /run.sh

--- a/grafana/Makefile
+++ b/grafana/Makefile
@@ -1,0 +1,13 @@
+
+TAG = 2.1.0
+PREFIX = kubernetes
+
+all: container
+
+container:
+	docker build -t $(PREFIX)/heapster_grafana:$(TAG) .
+
+push:
+	docker push $(PREFIX)/grafana:$(TAG)
+
+

--- a/grafana/README.md
+++ b/grafana/README.md
@@ -1,0 +1,17 @@
+# Grafana Image For Heapster/InfluxDB
+
+## What's In It
+* Stock Grafana.
+* Create a datasource for InfluxDB.
+* Create a couple of dashboards during startup. These dashboards leverage templating and repeating of panels features in Grafana 2.0, to discover nodes, pods, and containers automatically.
+
+## How To Use It
+* InfluxDB service URL can be passed in via the environment variable __INFLUXDB_SERVICE_URL__.
+* If __INFLUXDB_SERVICE_URL__ isn't defined, it will discover and use the external service URL, if available.
+* Otherwise, it will fall back to http://monitoring-influxdb:8086.
+
+## How To Build It
+
+cd $GOPATH/src/k8s.io/heapster/grafana
+
+make all

--- a/grafana/RELEASES.md
+++ b/grafana/RELEASES.md
@@ -1,0 +1,5 @@
+# Release Notes for Grafana container.
+
+## 2.1.0 (9-28-2015)
+- Support Grafana 2.1.0 and InfluxDB 0.9.4
+

--- a/grafana/dashboards/cluster.json
+++ b/grafana/dashboards/cluster.json
@@ -1,0 +1,1110 @@
+{
+  "dashboard":
+  {
+    "title": "Kubernetes Cluster",
+    "originalTitle": "Kubernetes Cluster",
+    "tags": [],
+    "style": "dark",
+    "timezone": "browser",
+    "editable": true,
+    "hideControls": false,
+    "sharedCrosshair": false,
+    "rows": [
+      {
+        "collapse": true,
+        "editable": true,
+        "height": "100px",
+        "panels": [
+          {
+            "content": "#### This dashboard displays Memory, CPU and Disk metrics at both cluster and node levels. Select a node from the above dropdown to see metrics specific to that node. Select \"All\" to see metrics for all nodes side by side.\n\n##### * Cluster metrics are sum across all nodes.\n##### * Node metrics are displayed on one panel for easy comparison.\n##### * There's also a panel for each node so one could \"double-click\" into the node for further analysis.\n",
+            "editable": true,
+            "error": false,
+            "id": 23,
+            "links": [],
+            "mode": "markdown",
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+          }
+        ],
+        "showTitle": true,
+        "title": "Documentation"
+      },
+      {
+        "collapse": false,
+        "editable": true,
+        "height": "250px",
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": null,
+            "decimals": 2,
+            "editable": true,
+            "error": false,
+            "fill": 3,
+            "grid": {
+              "leftLogBase": 1,
+              "leftMax": null,
+              "leftMin": null,
+              "rightLogBase": 1,
+              "rightMax": null,
+              "rightMin": null,
+              "threshold1": null,
+              "threshold1Color": "rgba(216, 200, 27, 0.27)",
+              "threshold2": null,
+              "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "id": 6,
+            "interval": "",
+            "leftYAxisLabel": "",
+            "legend": {
+              "avg": false,
+              "current": true,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 3,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+              {
+                "alias": "Used Memory",
+                "yaxis": 2
+              },
+              {
+                "alias": "Total Used Memory",
+                "yaxis": 1
+              },
+              {
+                "alias": "Total Working Set",
+                "yaxis": 1
+              }
+            ],
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "alias": "Limit",
+                "fields": [
+                  {
+                    "func": "sum",
+                    "name": "value"
+                  }
+                ],
+                "groupByTags": [],
+                "measurement": "memory/limit_bytes_gauge",
+                "query": "SELECT sum(value) FROM \"memory/limit_bytes_gauge\" WHERE \"container_name\" = 'machine' AND $timeFilter GROUP BY time(10s)",
+                "rawQuery": true,
+                "tags": [
+                  {
+                    "key": "hostname",
+                    "value": "/$node/"
+                  },
+                  {
+                    "condition": "AND",
+                    "key": "container_name",
+                    "value": "machine"
+                  }
+                ]
+              },
+              {
+                "alias": "Usage",
+                "fields": [
+                  {
+                    "func": "last",
+                    "name": "value"
+                  }
+                ],
+                "groupByTags": [],
+                "measurement": "memory/usage_bytes_gauge",
+                "query": "SELECT sum(value) FROM \"memory/usage_bytes_gauge\" WHERE \"container_name\" = 'machine' AND $timeFilter GROUP BY time(10s)",
+                "rawQuery": true,
+                "tags": [
+                  {
+                    "key": "hostname",
+                    "value": "/$node/"
+                  },
+                  {
+                    "condition": "AND",
+                    "key": "container_name",
+                    "value": "machine"
+                  }
+                ]
+              },
+              {
+                "alias": "Working Set",
+                "fields": [
+                  {
+                    "func": "last",
+                    "name": "value"
+                  }
+                ],
+                "groupByTags": [],
+                "measurement": "memory/usage_bytes_gauge",
+                "query": "SELECT sum(value) FROM \"memory/working_set_bytes_gauge\" WHERE \"container_name\" = 'machine' AND $timeFilter GROUP BY time(10s)",
+                "rawQuery": true,
+                "tags": [
+                  {
+                    "key": "hostname",
+                    "value": "/$node/"
+                  },
+                  {
+                    "condition": "AND",
+                    "key": "container_name",
+                    "value": "machine"
+                  }
+                ]
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "",
+            "tooltip": {
+              "shared": true,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "x-axis": true,
+            "y-axis": true,
+            "y_formats": [
+              "bytes",
+              "bytes"
+            ]
+          }
+        ],
+        "showTitle": true,
+        "title": "Overall Cluster Memory Usage"
+      },
+      {
+        "collapse": false,
+        "editable": true,
+        "height": "250px",
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": null,
+            "decimals": 2,
+            "editable": true,
+            "error": false,
+            "fill": 3,
+            "grid": {
+              "leftLogBase": 1,
+              "leftMax": null,
+              "leftMin": null,
+              "rightLogBase": 1,
+              "rightMax": null,
+              "rightMin": null,
+              "threshold1": null,
+              "threshold1Color": "rgba(216, 200, 27, 0.27)",
+              "threshold2": null,
+              "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "id": 15,
+            "interval": "",
+            "leftYAxisLabel": "",
+            "legend": {
+              "avg": false,
+              "current": true,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 3,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+              {
+                "alias": "Used Memory",
+                "yaxis": 2
+              },
+              {
+                "alias": "Total Used Memory",
+                "yaxis": 1
+              },
+              {
+                "alias": "Total Working Set",
+                "yaxis": 1
+              }
+            ],
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "alias": "",
+                "fields": [
+                  {
+                    "func": "mean",
+                    "name": "value"
+                  }
+                ],
+                "groupByTags": [
+                  "hostname"
+                ],
+                "measurement": "memory/limit_bytes_gauge",
+                "query": "SELECT mean(value) FROM \"memory/limit_bytes_gauge\" WHERE \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval), \"hostname\"",
+                "rawQuery": false,
+                "tags": [
+                  {
+                    "key": "container_name",
+                    "value": "machine"
+                  }
+                ]
+              },
+              {
+                "alias": "",
+                "fields": [
+                  {
+                    "func": "mean",
+                    "name": "value"
+                  }
+                ],
+                "groupByTags": [
+                  "hostname"
+                ],
+                "measurement": "memory/working_set_bytes_gauge",
+                "query": "SELECT mean(value) FROM \"memory/working_set_bytes_gauge\" WHERE \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval), \"hostname\"",
+                "rawQuery": false,
+                "tags": [
+                  {
+                    "key": "container_name",
+                    "value": "machine"
+                  }
+                ]
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "",
+            "tooltip": {
+              "shared": true,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "x-axis": true,
+            "y-axis": true,
+            "y_formats": [
+              "bytes",
+              "bytes"
+            ]
+          }
+        ],
+        "showTitle": true,
+        "title": "Memory Usage Group By Node"
+      },
+      {
+        "collapse": false,
+        "editable": true,
+        "height": "250px",
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": null,
+            "decimals": 2,
+            "editable": true,
+            "error": false,
+            "fill": 3,
+            "grid": {
+              "leftLogBase": 1,
+              "leftMax": null,
+              "leftMin": null,
+              "rightLogBase": 1,
+              "rightMax": null,
+              "rightMin": null,
+              "threshold1": null,
+              "threshold1Color": "rgba(216, 200, 27, 0.27)",
+              "threshold2": null,
+              "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "id": 7,
+            "leftYAxisLabel": "",
+            "legend": {
+              "avg": false,
+              "current": true,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 3,
+            "links": [],
+            "minSpan": 6,
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": "node",
+            "repeatIteration": 1443041003983,
+            "scopedVars": {
+            },
+            "seriesOverrides": [
+              {
+                "alias": "Used Memory",
+                "yaxis": 1
+              },
+              {
+                "alias": "Working Set",
+                "yaxis": 1
+              }
+            ],
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "alias": "Limit",
+                "fields": [
+                  {
+                    "func": "last",
+                    "name": "value"
+                  }
+                ],
+                "groupByTags": [],
+                "measurement": "memory/limit_bytes_gauge",
+                "query": "SELECT last(value) FROM \"memory/limit_bytes_gauge\" WHERE \"hostname\" =~ /$node/ AND \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval)",
+                "tags": [
+                  {
+                    "key": "hostname",
+                    "value": "/$node/"
+                  },
+                  {
+                    "condition": "AND",
+                    "key": "container_name",
+                    "value": "machine"
+                  }
+                ]
+              },
+              {
+                "alias": "Usage",
+                "fields": [
+                  {
+                    "func": "last",
+                    "name": "value"
+                  }
+                ],
+                "groupByTags": [],
+                "measurement": "memory/usage_bytes_gauge",
+                "query": "SELECT last(value) FROM \"memory/usage_bytes_gauge\" WHERE \"hostname\" =~ /$node/ AND \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval)",
+                "tags": [
+                  {
+                    "key": "hostname",
+                    "value": "/$node/"
+                  },
+                  {
+                    "condition": "AND",
+                    "key": "container_name",
+                    "value": "machine"
+                  }
+                ]
+              },
+              {
+                "alias": "Working Set",
+                "fields": [
+                  {
+                    "func": "last",
+                    "name": "value"
+                  }
+                ],
+                "groupByTags": [],
+                "measurement": "memory/working_set_bytes_gauge",
+                "query": "SELECT last(value) FROM \"memory/working_set_bytes_gauge\" WHERE \"hostname\" =~ /$node/ AND \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval)",
+                "tags": [
+                  {
+                    "key": "hostname",
+                    "value": "/$node/"
+                  },
+                  {
+                    "condition": "AND",
+                    "key": "container_name",
+                    "value": "machine"
+                  }
+                ]
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "$node Memory Usage",
+            "tooltip": {
+              "shared": true,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "x-axis": true,
+            "y-axis": true,
+            "y_formats": [
+              "bytes",
+              "bytes"
+            ]
+          }
+        ],
+        "repeat": null,
+        "scopedVars": {
+        },
+        "showTitle": true,
+        "title": "Individual Node Memory Usage"
+      },
+      {
+        "collapse": false,
+        "editable": true,
+        "height": "250px",
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": null,
+            "decimals": 2,
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {
+              "leftLogBase": 1,
+              "leftMax": null,
+              "leftMin": null,
+              "rightLogBase": 1,
+              "rightMax": null,
+              "rightMin": null,
+              "threshold1": null,
+              "threshold1Color": "rgba(216, 200, 27, 0.27)",
+              "threshold2": null,
+              "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "id": 11,
+            "interval": "10s",
+            "legend": {
+              "avg": false,
+              "current": true,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+              {
+                "alias": "usage",
+                "yaxis": 2
+              }
+            ],
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "alias": "",
+                "fields": [
+                  {
+                    "func": "mean",
+                    "name": "value"
+                  }
+                ],
+                "groupByTags": [
+                  "hostname"
+                ],
+                "measurement": "cpu/limit_gauge",
+                "query": "SELECT mean(value) FROM \"cpu/limit_gauge\" WHERE \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval), \"hostname\"",
+                "rawQuery": true,
+                "tags": [
+                  {
+                    "key": "container_name",
+                    "value": "machine"
+                  }
+                ]
+              },
+              {
+                "alias": "",
+                "fields": [
+                  {
+                    "func": "derivative",
+                    "name": "value"
+                  }
+                ],
+                "groupByTags": [],
+                "measurement": "cpu/usage_ns_cumulative",
+                "query": "SELECT derivative(value)/10000000 FROM \"cpu/usage_ns_cumulative\" WHERE \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval), \"hostname\"",
+                "rawQuery": true,
+                "tags": [
+                  {
+                    "key": "container_name",
+                    "value": "machine"
+                  },
+                  {
+                    "condition": "AND",
+                    "key": "hostname",
+                    "value": "/$node/"
+                  }
+                ],
+                "target": ""
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "",
+            "tooltip": {
+              "shared": true,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "x-axis": true,
+            "y-axis": true,
+            "y_formats": [
+              "ms",
+              "ms"
+            ]
+          }
+        ],
+        "showTitle": true,
+        "title": "CPU Usage Group By Node"
+      },
+      {
+        "collapse": false,
+        "editable": true,
+        "height": "250px",
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": null,
+            "decimals": 2,
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {
+              "leftLogBase": 1,
+              "leftMax": null,
+              "leftMin": null,
+              "rightLogBase": 1,
+              "rightMax": null,
+              "rightMin": null,
+              "threshold1": null,
+              "threshold1Color": "rgba(216, 200, 27, 0.27)",
+              "threshold2": null,
+              "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "id": 16,
+            "interval": "10s",
+            "legend": {
+              "avg": false,
+              "current": true,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "minSpan": 6,
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": "node",
+            "scopedVars": {
+            },
+            "seriesOverrides": [
+              {
+                "alias": "usage",
+                "yaxis": 2
+              }
+            ],
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "alias": "Limit",
+                "fields": [
+                  {
+                    "func": "mean",
+                    "name": "value"
+                  }
+                ],
+                "groupByTags": [],
+                "measurement": "cpu/limit_gauge",
+                "query": "SELECT mean(value) FROM \"cpu/limit_gauge\" WHERE \"container_name\" = 'machine' AND \"hostname\" =~ /$node/ AND $timeFilter GROUP BY time($interval)",
+                "rawQuery": false,
+                "tags": [
+                  {
+                    "key": "container_name",
+                    "value": "machine"
+                  },
+                  {
+                    "condition": "AND",
+                    "key": "hostname",
+                    "value": "/$node/"
+                  }
+                ]
+              },
+              {
+                "alias": "Usage",
+                "fields": [
+                  {
+                    "func": "derivative",
+                    "name": "value"
+                  }
+                ],
+                "groupByTags": [],
+                "measurement": "cpu/usage_ns_cumulative",
+                "query": "SELECT derivative(value)/10000000 FROM \"cpu/usage_ns_cumulative\" WHERE \"container_name\" = 'machine' AND \"hostname\" =~ /$node/ AND $timeFilter GROUP BY time($interval)",
+                "rawQuery": true,
+                "tags": [
+                  {
+                    "key": "container_name",
+                    "value": "machine"
+                  },
+                  {
+                    "condition": "AND",
+                    "key": "hostname",
+                    "value": "/$node/"
+                  }
+                ],
+                "target": ""
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "$node CPU Usage",
+            "tooltip": {
+              "shared": true,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "x-axis": true,
+            "y-axis": true,
+            "y_formats": [
+              "ms",
+              "ms"
+            ]
+          }
+        ],
+        "showTitle": true,
+        "title": "Individual Node CPU Usage"
+      },
+      {
+        "collapse": false,
+        "editable": true,
+        "height": "250px",
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": null,
+            "decimals": 2,
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {
+              "leftLogBase": 1,
+              "leftMax": null,
+              "leftMin": null,
+              "rightLogBase": 1,
+              "rightMax": null,
+              "rightMin": null,
+              "threshold1": null,
+              "threshold1Color": "rgba(216, 200, 27, 0.27)",
+              "threshold2": null,
+              "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "id": 9,
+            "legend": {
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+              {
+                "alias": "Used Disk",
+                "yaxis": 2
+              },
+              {
+                "alias": "Total Used Disk",
+                "yaxis": 2
+              }
+            ],
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "alias": "Limit",
+                "fields": [
+                  {
+                    "func": "mean",
+                    "name": "value"
+                  }
+                ],
+                "groupByTags": [],
+                "query": "SELECT sum(value) FROM \"filesystem/limit_bytes_gauge\" WHERE \"container_name\" = 'machine' AND $timeFilter GROUP BY time(10s)",
+                "rawQuery": true,
+                "tags": []
+              },
+              {
+                "alias": "Usage",
+                "fields": [
+                  {
+                    "func": "mean",
+                    "name": "value"
+                  }
+                ],
+                "groupByTags": [],
+                "query": "SELECT sum(value) FROM \"filesystem/usage_bytes_gauge\" WHERE \"container_name\" = 'machine' AND $timeFilter GROUP BY time(10s)",
+                "rawQuery": true,
+                "tags": []
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "",
+            "tooltip": {
+              "shared": true,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "x-axis": true,
+            "y-axis": true,
+            "y_formats": [
+              "bytes",
+              "bytes"
+            ]
+          }
+        ],
+        "showTitle": true,
+        "title": "Overall Cluster Disk Usage"
+      },
+      {
+        "collapse": false,
+        "editable": true,
+        "height": "250px",
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": null,
+            "decimals": 2,
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {
+              "leftLogBase": 1,
+              "leftMax": null,
+              "leftMin": null,
+              "rightLogBase": 1,
+              "rightMax": null,
+              "rightMin": null,
+              "threshold1": null,
+              "threshold1Color": "rgba(216, 200, 27, 0.27)",
+              "threshold2": null,
+              "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "id": 19,
+            "legend": {
+              "avg": false,
+              "current": true,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+              {
+                "alias": "Used Disk",
+                "yaxis": 2
+              },
+              {
+                "alias": "Total Used Disk",
+                "yaxis": 2
+              }
+            ],
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "alias": "",
+                "fields": [
+                  {
+                    "func": "mean",
+                    "name": "value"
+                  }
+                ],
+                "groupByTags": [
+                  "hostname"
+                ],
+                "measurement": "filesystem/limit_bytes_gauge",
+                "query": "SELECT mean(value) FROM \"filesystem/limit_bytes_gauge\" WHERE \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval), \"hostname\"",
+                "rawQuery": false,
+                "tags": [
+                  {
+                    "key": "container_name",
+                    "value": "machine"
+                  }
+                ]
+              },
+              {
+                "alias": "",
+                "fields": [
+                  {
+                    "func": "mean",
+                    "name": "value"
+                  }
+                ],
+                "groupByTags": [
+                  "hostname"
+                ],
+                "measurement": "filesystem/usage_bytes_gauge",
+                "query": "SELECT mean(value) FROM \"filesystem/usage_bytes_gauge\" WHERE \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval), \"hostname\"",
+                "rawQuery": false,
+                "tags": [
+                  {
+                    "key": "container_name",
+                    "value": "machine"
+                  }
+                ]
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "",
+            "tooltip": {
+              "shared": true,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "x-axis": true,
+            "y-axis": true,
+            "y_formats": [
+              "bytes",
+              "bytes"
+            ]
+          }
+        ],
+        "showTitle": true,
+        "title": "Disk Usage Group By Node"
+      },
+      {
+        "collapse": false,
+        "editable": true,
+        "height": "250px",
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": null,
+            "decimals": 2,
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {
+              "leftLogBase": 1,
+              "leftMax": null,
+              "leftMin": null,
+              "rightLogBase": 1,
+              "rightMax": null,
+              "rightMin": null,
+              "threshold1": null,
+              "threshold1Color": "rgba(216, 200, 27, 0.27)",
+              "threshold2": null,
+              "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "id": 10,
+            "legend": {
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "minSpan": 6,
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": "node",
+            "scopedVars": {
+            },
+            "seriesOverrides": [
+              {
+                "alias": "Used Disk",
+                "yaxis": 2
+              }
+            ],
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "alias": "Limit",
+                "fields": [
+                  {
+                    "func": "mean",
+                    "name": "value"
+                  }
+                ],
+                "groupByTags": [],
+                "query": "SELECT last(value) FROM \"filesystem/limit_bytes_gauge\" WHERE \"hostname\" =~ /$node/ AND \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval)",
+                "rawQuery": true,
+                "tags": []
+              },
+              {
+                "alias": "Usage",
+                "fields": [
+                  {
+                    "func": "mean",
+                    "name": "value"
+                  }
+                ],
+                "groupByTags": [],
+                "query": "SELECT last(value) FROM \"filesystem/usage_bytes_gauge\" WHERE \"hostname\" =~ /$node/ AND \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval)",
+                "rawQuery": true,
+                "tags": []
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "$node Disk Usage",
+            "tooltip": {
+              "shared": true,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "x-axis": true,
+            "y-axis": true,
+            "y_formats": [
+              "bytes",
+              "bytes"
+            ]
+          }
+        ],
+        "showTitle": true,
+        "title": "Individual Node Disk Usage"
+      }
+    ],
+    "nav": [
+      {
+        "collapse": false,
+        "enable": true,
+        "notice": false,
+        "now": true,
+        "refresh_intervals": [
+          "5s",
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h",
+          "2h",
+          "1d"
+        ],
+        "status": "Stable",
+        "time_options": [
+          "5m",
+          "15m",
+          "1h",
+          "6h",
+          "12h",
+          "24h",
+          "2d",
+          "7d",
+          "30d"
+        ],
+        "type": "timepicker"
+      }
+    ],
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
+    "templating": {
+      "list": [
+        {
+          "allFormat": "glob",
+          "current": {
+          },
+          "datasource": null,
+          "includeAll": true,
+          "label": "Node",
+          "multi": false,
+          "multiFormat": "glob",
+          "name": "node",
+          "options": [
+          ],
+          "query": "SHOW TAG VALUES FROM \"uptime_ms_cumulative\" WITH KEY = \"hostname\"\t",
+          "refresh": true,
+          "refresh_on_load": true,
+          "regex": "",
+          "type": "query",
+          "useTags": false
+        }
+      ]
+    },
+    "annotations": {
+      "list": []
+    },
+    "schemaVersion": 6,
+    "version": 33,
+    "links": []
+  }
+}

--- a/grafana/dashboards/containers.json
+++ b/grafana/dashboards/containers.json
@@ -1,0 +1,376 @@
+{
+  "dashboard":
+  {
+    "title": "Containers",
+    "originalTitle": "Containers",
+    "tags": [],
+    "style": "dark",
+    "timezone": "browser",
+    "editable": true,
+    "hideControls": false,
+    "sharedCrosshair": false,
+    "rows": [
+      {
+        "collapse": false,
+        "editable": true,
+        "height": "250px",
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": null,
+            "decimals": 2,
+            "editable": true,
+            "error": false,
+            "fill": 3,
+            "grid": {
+              "leftLogBase": 1,
+              "leftMax": null,
+              "leftMin": null,
+              "rightLogBase": 1,
+              "rightMax": null,
+              "rightMin": null,
+              "threshold1": null,
+              "threshold1Color": "rgba(216, 200, 27, 0.27)",
+              "threshold2": null,
+              "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "hideTimeOverride": false,
+            "id": 1,
+            "interval": "10s",
+            "legend": {
+              "avg": false,
+              "current": true,
+              "max": true,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 3,
+            "links": [],
+            "minSpan": 4,
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": "container",
+            "scopedVars": {
+            },
+            "seriesOverrides": [
+              {},
+              {
+                "alias": "Used Memory",
+                "yaxis": 1
+              }
+            ],
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "alias": "Limit",
+                "fields": [
+                  {
+                    "func": "last",
+                    "name": "value"
+                  }
+                ],
+                "fill": "null",
+                "groupByTags": [],
+                "hide": false,
+                "measurement": "memory/limit_bytes_gauge",
+                "query": "SELECT last(value) FROM \"memory/limit_bytes_gauge\" WHERE \"container_name\" =~ /$container/ AND $timeFilter GROUP BY time($interval) fill(null)",
+                "rawQuery": false,
+                "tags": [
+                  {
+                    "key": "container_name",
+                    "value": "/$container/"
+                  }
+                ]
+              },
+              {
+                "alias": "Usage",
+                "fields": [
+                  {
+                    "func": "last",
+                    "name": "value"
+                  }
+                ],
+                "fill": "null",
+                "groupByTags": [],
+                "hide": false,
+                "measurement": "memory/usage_bytes_gauge",
+                "query": "SELECT last(value) FROM \"memory/usage_bytes_gauge\" WHERE \"container_name\" =~ /$container/ AND $timeFilter GROUP BY time($interval) fill(null)",
+                "rawQuery": false,
+                "tags": [
+                  {
+                    "key": "container_name",
+                    "value": "/$container/"
+                  }
+                ]
+              },
+              {
+                "alias": "Working Set",
+                "fields": [
+                  {
+                    "func": "last",
+                    "name": "value"
+                  }
+                ],
+                "fill": "null",
+                "groupByTags": [],
+                "hide": false,
+                "measurement": "memory/working_set_bytes_gauge",
+                "query": "SELECT last(value) FROM \"memory/working_set_bytes_gauge\" WHERE \"container_name\" =~ /$container/ AND $timeFilter GROUP BY time($interval) fill(null)",
+                "rawQuery": false,
+                "tags": [
+                  {
+                    "key": "container_name",
+                    "value": "/$container/"
+                  }
+                ]
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Container \"$container\" Memory Usage",
+            "tooltip": {
+              "shared": true,
+              "value_type": "cumulative"
+            },
+            "transparent": false,
+            "type": "graph",
+            "x-axis": true,
+            "y-axis": true,
+            "y_formats": [
+              "bytes",
+              "short"
+            ]
+          }
+        ],
+        "title": "Container Memory"
+      },
+      {
+        "collapse": false,
+        "editable": true,
+        "height": "250px",
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": null,
+            "decimals": 2,
+            "editable": true,
+            "error": false,
+            "fill": 3,
+            "grid": {
+              "leftLogBase": 1,
+              "leftMax": null,
+              "leftMin": null,
+              "rightLogBase": 1,
+              "rightMax": null,
+              "rightMin": null,
+              "threshold1": null,
+              "threshold1Color": "rgba(216, 200, 27, 0.27)",
+              "threshold2": null,
+              "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "hideTimeOverride": false,
+            "id": 14,
+            "interval": "10s",
+            "legend": {
+              "avg": false,
+              "current": true,
+              "max": true,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 3,
+            "links": [],
+            "minSpan": 4,
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": "container",
+            "scopedVars": {
+            },
+            "seriesOverrides": [
+              {},
+              {
+                "alias": "Used Memory",
+                "yaxis": 1
+              }
+            ],
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "alias": "Limit",
+                "fields": [
+                  {
+                    "func": "mean",
+                    "name": "value"
+                  }
+                ],
+                "fill": "null",
+                "groupByTags": [],
+                "hide": false,
+                "measurement": "cpu/limit_gauge",
+                "query": "SELECT mean(value) FROM \"cpu/limit_gauge\" WHERE \"container_name\" =~ /$container/ AND $timeFilter GROUP BY time($interval) fill(null)",
+                "rawQuery": true,
+                "tags": [
+                  {
+                    "key": "container_name",
+                    "value": "/$container/"
+                  }
+                ]
+              },
+              {
+                "alias": "Usage",
+                "fields": [
+                  {
+                    "func": "mean",
+                    "name": "value"
+                  }
+                ],
+                "fill": "null",
+                "groupByTags": [],
+                "hide": false,
+                "measurement": "cpu/limit_gauge",
+                "query": "SELECT derivative(value)/10000000 FROM \"cpu/usage_ns_cumulative\" WHERE \"container_name\" =~ /$container/ AND $timeFilter GROUP BY time($interval)",
+                "rawQuery": true,
+                "tags": [
+                  {
+                    "key": "container_name",
+                    "value": "/$container/"
+                  }
+                ]
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Container \"$container\" CPU Usage",
+            "tooltip": {
+              "shared": true,
+              "value_type": "cumulative"
+            },
+            "transparent": false,
+            "type": "graph",
+            "x-axis": true,
+            "y-axis": true,
+            "y_formats": [
+              "ms",
+              "short"
+            ]
+          }
+        ],
+        "title": "Container CPU"
+      }
+    ],
+    "nav": [
+      {
+        "collapse": false,
+        "enable": true,
+        "notice": false,
+        "now": true,
+        "refresh_intervals": [
+          "5s",
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h",
+          "2h",
+          "1d"
+        ],
+        "status": "Stable",
+        "time_options": [
+          "5m",
+          "15m",
+          "1h",
+          "6h",
+          "12h",
+          "24h",
+          "2d",
+          "7d",
+          "30d"
+        ],
+        "type": "timepicker"
+      }
+    ],
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
+    "templating": {
+      "list": [
+        {
+          "type": "query",
+          "refresh": true,
+          "refresh_on_load": true,
+          "datasource": null,
+          "refresh_on_load": false,
+          "name": "namespace",
+          "options": [
+          ],
+          "includeAll": true,
+          "allFormat": "regex wildcard",
+          "multi": false,
+          "multiFormat": "glob",
+          "query": "SHOW TAG VALUES FROM \"uptime_ms_cumulative\" WITH KEY = \"pod_namespace\"",
+          "current": {
+          }
+        },
+        {
+          "allFormat": "regex wildcard",
+          "current": {
+          },
+          "datasource": null,
+          "includeAll": true,
+          "multi": false,
+          "multiFormat": "glob",
+          "name": "pod",
+          "options": [
+          ],
+          "query": "SHOW TAG VALUES FROM \"uptime_ms_cumulative\" WITH KEY = \"pod_name\" WHERE pod_namespace =~ /$namespace/ ",
+          "refresh": true,
+          "refresh_on_load": true,
+          "type": "query"
+        },
+        {
+          "allFormat": "glob",
+          "current": {
+          },
+          "datasource": null,
+          "includeAll": true,
+          "multi": false,
+          "multiFormat": "glob",
+          "name": "container",
+          "options": [
+          ],
+          "query": "SHOW TAG VALUES FROM \"uptime_ms_cumulative\" WITH KEY = \"container_name\" WHERE pod_name =~ /$pod/ and \"pod_namespace\" =~ /$namespace/",
+          "refresh": true,
+          "refresh_on_load": true,
+          "type": "query"
+        }
+      ]
+    },
+    "annotations": {
+      "list": []
+    },
+    "schemaVersion": 6,
+    "version": 4,
+    "links": []
+  }
+}

--- a/grafana/run.sh
+++ b/grafana/run.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+HEADER_CONTENT_TYPE="Content-Type: application/json"
+HEADER_ACCEPT="Accept: application/json"
+
+GRAFANA_USER=${GRAFANA_USER:-admin}
+GRAFANA_PASSWD=${GRAFANA_PASSWD:-admin}
+GRAFANA_PORT=${GRAFANA_PORT:-3000}
+
+INFLUXDB_HOST=${INFLUXDB_HOST:-"monitoring-influxdb"}
+INFLUXDB_DATABASE=${INFLUXDB_DATABASE:-k8s}
+INFLUXDB_PASSWORD=${INFLUXDB_PASSWORD:-root}
+INFLUXDB_PORT=${INFLUXDB_PORT:-8086}
+INFLUXDB_USER=${INFLUXDB_USER:-root}
+
+DASHBOARD_LOCATION=${DASHBOARD_LOCATION:-"/dashboards"}
+
+# Allow access to dashboards without having to log in
+export GF_AUTH_ANONYMOUS_ENABLED=true
+export GF_SERVER_HTTP_PORT=${GRAFANA_PORT}
+
+BACKEND_ACCESS_MODE=${BACKEND_ACCESS_MODE:-proxy}
+INFLUXDB_SERVICE_URL=${INFLUXDB_SERVICE_URL}
+if [ -n "$INFLUXDB_SERVICE_URL" ]; then
+  echo "Influxdb service URL is provided."
+else
+  INFLUXDB_SERVICE_URL="http://${INFLUXDB_HOST}:${INFLUXDB_PORT}"
+fi
+
+echo "Using the following URL for InfluxDB: ${INFLUXDB_SERVICE_URL}"
+echo "Using the following backend access mode for InfluxDB: ${BACKEND_ACCESS_MODE}"
+
+set -m
+echo "Starting Grafana in the background"
+exec /usr/sbin/grafana-server --config=/etc/grafana/grafana.ini cfg:default.paths.data=/var/lib/grafana cfg:default.paths.logs=/var/log/grafana &
+
+echo "Waiting for Grafana to come up..."
+until $(curl --fail --output /dev/null --silent http://${GRAFANA_USER}:${GRAFANA_PASSWD}@localhost:${GRAFANA_PORT}/api/org); do
+  printf "."
+  sleep 2
+done
+echo "Grafana is up and running."
+echo "Creating default influxdb datasource..."
+curl -i -XPOST -H "${HEADER_ACCEPT}" -H "${HEADER_CONTENT_TYPE}" "http://${GRAFANA_USER}:${GRAFANA_PASSWD}@localhost:${GRAFANA_PORT}/api/datasources" -d '
+{ 
+  "name": "influxdb-datasource",
+  "type": "influxdb",
+  "access": "'"${BACKEND_ACCESS_MODE}"'",
+  "isDefault": true,
+  "url": "'"${INFLUXDB_SERVICE_URL}"'",
+  "password": "'"${INFLUXDB_PASSWORD}"'",
+  "user": "'"${INFLUXDB_USER}"'",
+  "database": "'"${INFLUXDB_DATABASE}"'"
+}'
+
+echo ""
+echo "Importing default dashboards..."
+for filename in ${DASHBOARD_LOCATION}/*.json; do
+  echo "Importing ${filename} ..."
+  curl -i -XPOST --data "@${filename}" -H "${HEADER_ACCEPT}" -H "${HEADER_CONTENT_TYPE}" "http://${GRAFANA_USER}:${GRAFANA_PASSWD}@localhost:${GRAFANA_PORT}/api/dashboards/db"
+  echo ""
+  echo "Done importing ${filename}"
+done
+echo ""
+echo "Bringing Grafana back to the foreground"
+fg
+


### PR DESCRIPTION
* Discover InfluxDB service endpoint and create a datasource using Grafana API.
* Import a couple of dashboards which use templating and repeated panels in Grafana 2.1.0.
* The dashboards pick up nodes, pods, and containers automatically with zero configurations.