### PR TITLE
Enable TLS option & client certificate authentication

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -303,6 +303,11 @@
 			"Rev": "b07b9918ce6b18614f0e93bfe2cbc98b6590eef5"
 		},
 		{
+			"ImportPath": "k8s.io/kubernetes/pkg/auth/authenticator",
+			"Comment": "v1.1.0-alpha.1-1078-gb07b991",
+			"Rev": "b07b9918ce6b18614f0e93bfe2cbc98b6590eef5"
+		},
+		{
 			"ImportPath": "k8s.io/kubernetes/pkg/auth/user",
 			"Comment": "v1.1.0-alpha.1-1078-gb07b991",
 			"Rev": "b07b9918ce6b18614f0e93bfe2cbc98b6590eef5"
@@ -364,6 +369,11 @@
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/watch",
+			"Comment": "v1.1.0-alpha.1-1078-gb07b991",
+			"Rev": "b07b9918ce6b18614f0e93bfe2cbc98b6590eef5"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/plugin/pkg/auth/authenticator/request/x509",
 			"Comment": "v1.1.0-alpha.1-1078-gb07b991",
 			"Rev": "b07b9918ce6b18614f0e93bfe2cbc98b6590eef5"
 		},

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/auth/authenticator/bearertoken/bearertoken.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/auth/authenticator/bearertoken/bearertoken.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bearertoken
+
+import (
+	"net/http"
+	"strings"
+
+	"k8s.io/kubernetes/pkg/auth/authenticator"
+	"k8s.io/kubernetes/pkg/auth/user"
+)
+
+type Authenticator struct {
+	auth authenticator.Token
+}
+
+func New(auth authenticator.Token) *Authenticator {
+	return &Authenticator{auth}
+}
+
+func (a *Authenticator) AuthenticateRequest(req *http.Request) (user.Info, bool, error) {
+	auth := strings.TrimSpace(req.Header.Get("Authorization"))
+	if auth == "" {
+		return nil, false, nil
+	}
+	parts := strings.Split(auth, " ")
+	if len(parts) < 2 || strings.ToLower(parts[0]) != "bearer" {
+		return nil, false, nil
+	}
+
+	token := parts[1]
+	return a.auth.AuthenticateToken(token)
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/auth/authenticator/interfaces.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/auth/authenticator/interfaces.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authenticator
+
+import (
+	"net/http"
+
+	"k8s.io/kubernetes/pkg/auth/user"
+)
+
+// Token checks a string value against a backing authentication store and returns
+// information about the current user and true if successful, false if not successful,
+// or an error if the token could not be checked.
+type Token interface {
+	AuthenticateToken(token string) (user.Info, bool, error)
+}
+
+// Request attempts to extract authentication information from a request and returns
+// information about the current user and true if successful, false if not successful,
+// or an error if the request could not be checked.
+type Request interface {
+	AuthenticateRequest(req *http.Request) (user.Info, bool, error)
+}
+
+// Password checks a username and password against a backing authentication store and
+// returns information about the user and true if successful, false if not successful,
+// or an error if the username and password could not be checked
+type Password interface {
+	AuthenticatePassword(user, password string) (user.Info, bool, error)
+}
+
+// TokenFunc is a function that implements the Token interface.
+type TokenFunc func(token string) (user.Info, bool, error)
+
+// AuthenticateToken implements authenticator.Token.
+func (f TokenFunc) AuthenticateToken(token string) (user.Info, bool, error) {
+	return f(token)
+}
+
+// RequestFunc is a function that implements the Request interface.
+type RequestFunc func(req *http.Request) (user.Info, bool, error)
+
+// AuthenticateRequest implements authenticator.Request.
+func (f RequestFunc) AuthenticateRequest(req *http.Request) (user.Info, bool, error) {
+	return f(req)
+}
+
+// PasswordFunc is a function that implements the Password interface.
+type PasswordFunc func(user, password string) (user.Info, bool, error)
+
+// AuthenticatePassword implements authenticator.Password.
+func (f PasswordFunc) AuthenticatePassword(user, password string) (user.Info, bool, error) {
+	return f(user, password)
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/auth/authenticator/request/x509/doc.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/auth/authenticator/request/x509/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package x509 provides a request authenticator that validates and
+// extracts user information from client certificates
+package x509

--- a/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/auth/authenticator/request/x509/x509.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/plugin/pkg/auth/authenticator/request/x509/x509.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package x509
+
+import (
+	"crypto/x509"
+	"net/http"
+
+	"k8s.io/kubernetes/pkg/auth/user"
+	"k8s.io/kubernetes/pkg/util/errors"
+)
+
+// UserConversion defines an interface for extracting user info from a client certificate chain
+type UserConversion interface {
+	User(chain []*x509.Certificate) (user.Info, bool, error)
+}
+
+// UserConversionFunc is a function that implements the UserConversion interface.
+type UserConversionFunc func(chain []*x509.Certificate) (user.Info, bool, error)
+
+// User implements x509.UserConversion
+func (f UserConversionFunc) User(chain []*x509.Certificate) (user.Info, bool, error) {
+	return f(chain)
+}
+
+// Authenticator implements request.Authenticator by extracting user info from verified client certificates
+type Authenticator struct {
+	opts x509.VerifyOptions
+	user UserConversion
+}
+
+// New returns a request.Authenticator that verifies client certificates using the provided
+// VerifyOptions, and converts valid certificate chains into user.Info using the provided UserConversion
+func New(opts x509.VerifyOptions, user UserConversion) *Authenticator {
+	return &Authenticator{opts, user}
+}
+
+// AuthenticateRequest authenticates the request using presented client certificates
+func (a *Authenticator) AuthenticateRequest(req *http.Request) (user.Info, bool, error) {
+	if req.TLS == nil {
+		return nil, false, nil
+	}
+
+	var errlist []error
+	for _, cert := range req.TLS.PeerCertificates {
+		chains, err := cert.Verify(a.opts)
+		if err != nil {
+			errlist = append(errlist, err)
+			continue
+		}
+
+		for _, chain := range chains {
+			user, ok, err := a.user.User(chain)
+			if err != nil {
+				errlist = append(errlist, err)
+				continue
+			}
+
+			if ok {
+				return user, ok, err
+			}
+		}
+	}
+	return nil, false, errors.NewAggregate(errlist)
+}
+
+// DefaultVerifyOptions returns VerifyOptions that use the system root certificates, current time,
+// and requires certificates to be valid for client auth (x509.ExtKeyUsageClientAuth)
+func DefaultVerifyOptions() x509.VerifyOptions {
+	return x509.VerifyOptions{
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+}
+
+// CommonNameUserConversion builds user info from a certificate chain using the subject's CommonName
+var CommonNameUserConversion = UserConversionFunc(func(chain []*x509.Certificate) (user.Info, bool, error) {
+	if len(chain[0].Subject.CommonName) == 0 {
+		return nil, false, nil
+	}
+	return &user.DefaultInfo{Name: chain[0].Subject.CommonName}, true, nil
+})
+
+// DNSNameUserConversion builds user info from a certificate chain using the first DNSName on the certificate
+var DNSNameUserConversion = UserConversionFunc(func(chain []*x509.Certificate) (user.Info, bool, error) {
+	if len(chain[0].DNSNames) == 0 {
+		return nil, false, nil
+	}
+	return &user.DefaultInfo{Name: chain[0].DNSNames[0]}, true, nil
+})
+
+// EmailAddressUserConversion builds user info from a certificate chain using the first EmailAddress on the certificate
+var EmailAddressUserConversion = UserConversionFunc(func(chain []*x509.Certificate) (user.Info, bool, error) {
+	if len(chain[0].EmailAddresses) == 0 {
+		return nil, false, nil
+	}
+	return &user.DefaultInfo{Name: chain[0].EmailAddresses[0]}, true, nil
+})

--- a/auth.go
+++ b/auth.go
@@ -1,0 +1,115 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"k8s.io/kubernetes/pkg/auth/authenticator"
+	"k8s.io/kubernetes/pkg/auth/user"
+	x509request "k8s.io/kubernetes/plugin/pkg/auth/authenticator/request/x509"
+)
+
+func newAuthHandler(handler http.Handler) (http.Handler, error) {
+	// Authn/Authz setup
+	authn, err := newAuthenticatorFromClientCAFile(*argTLSClientCAFile)
+	if err != nil {
+		return nil, err
+	}
+
+	authz, err := newAuthorizerFromUserList(strings.Split(*argAllowedUsers, ",")...)
+	if err != nil {
+		return nil, err
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		// Check authn
+		user, ok, err := authn.AuthenticateRequest(req)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if !ok {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		// Check authz
+		allowed, err := authz.AuthorizeRequest(req, user)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if !allowed {
+			http.Error(w, "Forbidden", http.StatusForbidden)
+			return
+		}
+
+		handler.ServeHTTP(w, req)
+	}), nil
+}
+
+// newAuthenticatorFromClientCAFile returns an authenticator.Request or an error
+func newAuthenticatorFromClientCAFile(clientCAFile string) (authenticator.Request, error) {
+	opts := x509request.DefaultVerifyOptions()
+
+	// If at custom CA bundle is provided, load it (otherwise just use system roots)
+	if len(clientCAFile) > 0 {
+		if caData, err := ioutil.ReadFile(clientCAFile); err != nil {
+			return nil, err
+		} else if len(caData) > 0 {
+			roots := x509.NewCertPool()
+			if !roots.AppendCertsFromPEM(caData) {
+				return nil, fmt.Errorf("no valid certs found in %s", clientCAFile)
+			}
+			opts.Roots = roots
+		}
+	}
+
+	return x509request.New(opts, x509request.CommonNameUserConversion), nil
+}
+
+type Authorizer interface {
+	AuthorizeRequest(req *http.Request, user user.Info) (bool, error)
+}
+
+func newAuthorizerFromUserList(allowedUsers ...string) (Authorizer, error) {
+	if len(allowedUsers) == 1 && len(allowedUsers[0]) == 0 {
+		return &allowAnyAuthorizer{}, nil
+	}
+	u := map[string]bool{}
+	for _, allowedUser := range allowedUsers {
+		u[allowedUser] = true
+	}
+	return &userAuthorizer{u}, nil
+}
+
+type allowAnyAuthorizer struct{}
+
+func (a *allowAnyAuthorizer) AuthorizeRequest(req *http.Request, user user.Info) (bool, error) {
+	return true, nil
+}
+
+type userAuthorizer struct {
+	allowedUsers map[string]bool
+}
+
+func (a *userAuthorizer) AuthorizeRequest(req *http.Request, user user.Info) (bool, error) {
+	return a.allowedUsers[user.GetName()], nil
+}


### PR DESCRIPTION
Heapster exposes unencrypted endpoints without authorization. In secure environments like OpenShift we'd like to secure the endpoints, both via TLS & by client certificate so that the master can use a certificate to authenticate for autoscaler stuff, etc.

This PR allows the configuration of TLS cert/key, client certificate checks & restricting users based on the CN of client cert. All optional of course.

Note that the godeps that have been updated are from a `godep restore` & `godep save ./... github.com/progrium/go-extpoints` to add in additional packages - I'm guessing some of the godep json had been updated manually prior to this.

/cc @mwringe @jcantrill @liggitt @pweil-