### PR TITLE
Enable content encoding negotation

### DIFF
--- a/api/v1/api.go
+++ b/api/v1/api.go
@@ -18,7 +18,6 @@ import (
 	"net/http"
 
 	restful "github.com/emicklei/go-restful"
-	"github.com/golang/glog"
 	"k8s.io/heapster/api/v1/types"
 	"k8s.io/heapster/manager"
 	sinksApi "k8s.io/heapster/sinks/api"
@@ -46,7 +45,6 @@ func (a *Api) Register(container *restful.Container) {
 		Doc("Exports the latest point for all Heapster metrics").
 		Produces(restful.MIME_JSON)
 	ws.Route(ws.GET("").
-		Filter(compressionFilter).
 		To(a.exportMetrics).
 		Doc("export the latest data point for all metrics").
 		Operation("exportMetrics").
@@ -79,18 +77,6 @@ func (a *Api) Register(container *restful.Container) {
 	container.Add(ws)
 
 	a.RegisterModel(container)
-}
-
-func compressionFilter(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
-	// wrap responseWriter into a compressing one
-	compress, err := restful.NewCompressingResponseWriter(resp.ResponseWriter, restful.ENCODING_GZIP)
-	if err != nil {
-		glog.Warningf("Failed to create CompressingResponseWriter for request %q: %v", req.Request.URL, err)
-		return
-	}
-	resp.ResponseWriter = compress
-	defer compress.Close()
-	chain.ProcessFilter(req, resp)
 }
 
 // Labels used by the target schema. A target schema uniquely identifies a container.

--- a/api/v1/model_handlers.go
+++ b/api/v1/model_handlers.go
@@ -46,28 +46,24 @@ func (a *Api) RegisterModel(container *restful.Container) {
 	// The / endpoint returns a list of all the entities that are available in the model
 	ws.Route(ws.GET("/").
 		To(a.allEntities).
-		Filter(compressionFilter).
 		Doc("Get a list of all entities available in the model").
 		Operation("allEntities"))
 
 	// The /metrics/ endpoint returns a list of all available metrics for the Cluster entity of the model.
 	ws.Route(ws.GET("/metrics/").
 		To(a.availableMetrics).
-		Filter(compressionFilter).
 		Doc("Get a list of all available metrics for the Cluster entity").
 		Operation("availableMetrics"))
 
 	// The /stats/ endpoint returns a list of all available stats for the Cluster entity of the model.
 	ws.Route(ws.GET("/stats/").
 		To(a.clusterStats).
-		Filter(compressionFilter).
 		Doc("Get all available stats for the Cluster entity").
 		Operation("clusterStats"))
 
 	// The /metrics/{metric-name} endpoint exposes an aggregated metric for the Cluster entity of the model.
 	ws.Route(ws.GET("/metrics/{metric-name}").
 		To(a.clusterMetrics).
-		Filter(compressionFilter).
 		Doc("Export an aggregated cluster-level metric").
 		Operation("clusterMetrics").
 		Param(ws.PathParameter("metric-name", "The name of the requested metric").DataType("string")).
@@ -78,7 +74,6 @@ func (a *Api) RegisterModel(container *restful.Container) {
 	// The /nodes/ endpoint returns a list of all Node entities in the cluster.
 	ws.Route(ws.GET("/nodes/").
 		To(a.allNodes).
-		Filter(compressionFilter).
 		Doc("Get a list of all Nodes in the model").
 		Operation("allNodes").
 		Writes(types.MetricResult{}))
@@ -86,7 +81,6 @@ func (a *Api) RegisterModel(container *restful.Container) {
 	// The /nodes/{node-name} endpoint returns a list of all available API paths for a Node entity.
 	ws.Route(ws.GET("/nodes/{node-name}").
 		To(a.nodePaths).
-		Filter(compressionFilter).
 		Doc("Get a list of all available API paths for a Node entity").
 		Operation("nodePaths").
 		Param(ws.PathParameter("node-name", "The name of the node to lookup").DataType("string")))
@@ -94,7 +88,6 @@ func (a *Api) RegisterModel(container *restful.Container) {
 	// The /nodes/{node-name}/stats endpoint returns all available derived stats for a Node entity.
 	ws.Route(ws.GET("/nodes/{node-name}/stats/").
 		To(a.nodeStats).
-		Filter(compressionFilter).
 		Doc("Get all available stats for a Node entity.").
 		Operation("nodeStats").
 		Param(ws.PathParameter("node-name", "The name of the node to lookup").DataType("string")))
@@ -102,7 +95,6 @@ func (a *Api) RegisterModel(container *restful.Container) {
 	// The /nodes/{node-name}/metrics endpoint returns a list of all available metrics for a Node entity.
 	ws.Route(ws.GET("/nodes/{node-name}/metrics/").
 		To(a.availableMetrics).
-		Filter(compressionFilter).
 		Doc("Get a list of all available metrics for a Node entity").
 		Operation("availableMetrics").
 		Param(ws.PathParameter("node-name", "The name of the node to lookup").DataType("string")))
@@ -111,7 +103,6 @@ func (a *Api) RegisterModel(container *restful.Container) {
 	// The {node-name} parameter is the hostname of a specific node.
 	ws.Route(ws.GET("/nodes/{node-name}/metrics/{metric-name}").
 		To(a.nodeMetrics).
-		Filter(compressionFilter).
 		Doc("Export a node-level metric").
 		Operation("nodeMetrics").
 		Param(ws.PathParameter("node-name", "The name of the node to lookup").DataType("string")).
@@ -124,14 +115,12 @@ func (a *Api) RegisterModel(container *restful.Container) {
 		// The /namespaces/ endpoint returns a list of all Namespace entities in the model.
 		ws.Route(ws.GET("/namespaces/").
 			To(a.allNamespaces).
-			Filter(compressionFilter).
 			Doc("Get a list of all Namespaces in the model").
 			Operation("allNamespaces"))
 
 		// The /namespaces/{namespace-name} endpoint returns a list of all available API Paths for a Namespace entity.
 		ws.Route(ws.GET("/namespaces/{namespace-name}").
 			To(a.namespacePaths).
-			Filter(compressionFilter).
 			Doc("Get a list of all available API paths for a namespace entity").
 			Operation("namespacePaths").
 			Param(ws.PathParameter("namespace-name", "The name of the namespace to lookup").DataType("string")))
@@ -139,7 +128,6 @@ func (a *Api) RegisterModel(container *restful.Container) {
 		// The /namespaces/{namespace-name}/stats endpoint returns all available derived stats for a Namespace entity.
 		ws.Route(ws.GET("/namespaces/{namespace-name}/stats/").
 			To(a.namespaceStats).
-			Filter(compressionFilter).
 			Doc("Get all available stats for a Namespace entity.").
 			Operation("namespaceStats").
 			Param(ws.PathParameter("namespace-name", "The name of the namespace to lookup").DataType("string")))
@@ -147,7 +135,6 @@ func (a *Api) RegisterModel(container *restful.Container) {
 		// The /namespaces/{namespace-name}/metrics endpoint returns a list of all available metrics for a Namespace entity.
 		ws.Route(ws.GET("/namespaces/{namespace-name}/metrics").
 			To(a.availableMetrics).
-			Filter(compressionFilter).
 			Doc("Get a list of all available metrics for a Namespace entity").
 			Operation("availableMetrics").
 			Param(ws.PathParameter("namespace-name", "The name of the namespace to lookup").DataType("string")))
@@ -156,7 +143,6 @@ func (a *Api) RegisterModel(container *restful.Container) {
 		// for a Namespace entity of the model.
 		ws.Route(ws.GET("/namespaces/{namespace-name}/metrics/{metric-name}").
 			To(a.namespaceMetrics).
-			Filter(compressionFilter).
 			Doc("Export an aggregated namespace-level metric").
 			Operation("namespaceMetrics").
 			Param(ws.PathParameter("namespace-name", "The name of the namespace to lookup").DataType("string")).
@@ -169,7 +155,6 @@ func (a *Api) RegisterModel(container *restful.Container) {
 		// under a specified namespace.
 		ws.Route(ws.GET("/namespaces/{namespace-name}/pods").
 			To(a.allPods).
-			Filter(compressionFilter).
 			Doc("Get a list of all Pods in the model, belonging to the specified Namespace").
 			Operation("allPods").
 			Param(ws.PathParameter("namespace-name", "The name of the namespace to lookup").DataType("string")))
@@ -178,7 +163,6 @@ func (a *Api) RegisterModel(container *restful.Container) {
 		// API paths available for a pod
 		ws.Route(ws.GET("/namespaces/{namespace-name}/pods/{pod-name}").
 			To(a.podPaths).
-			Filter(compressionFilter).
 			Doc("Get a list of all API paths available for a Pod entity").
 			Operation("podPaths").
 			Param(ws.PathParameter("namespace-name", "The name of the namespace to lookup").DataType("string")).
@@ -187,7 +171,6 @@ func (a *Api) RegisterModel(container *restful.Container) {
 		// The /namespaces/{namespace-name}/pods/{pod-name}/stats endpoint returns all available derived stats for a Pod entity.
 		ws.Route(ws.GET("/namespaces/{namespace-name}/pods/{pod-name}/stats/").
 			To(a.podStats).
-			Filter(compressionFilter).
 			Doc("Get all available stats for a Pod entity.").
 			Operation("podStats").
 			Param(ws.PathParameter("namespace-name", "The name of the namespace to lookup").DataType("string")).
@@ -196,7 +179,6 @@ func (a *Api) RegisterModel(container *restful.Container) {
 		// The /namespaces/{namespace-name}/pods/{pod-name}/metrics endpoint returns a list of all available metrics for a Pod entity.
 		ws.Route(ws.GET("/namespaces/{namespace-name}/pods/{pod-name}/metrics").
 			To(a.availableMetrics).
-			Filter(compressionFilter).
 			Doc("Get a list of all available metrics for a Pod entity").
 			Operation("availableMetrics").
 			Param(ws.PathParameter("namespace-name", "The name of the namespace to lookup").DataType("string")).
@@ -206,7 +188,6 @@ func (a *Api) RegisterModel(container *restful.Container) {
 		// an aggregated metric for a Pod entity of the model.
 		ws.Route(ws.GET("/namespaces/{namespace-name}/pods/{pod-name}/metrics/{metric-name}").
 			To(a.podMetrics).
-			Filter(compressionFilter).
 			Doc("Export an aggregated pod-level metric").
 			Operation("podMetrics").
 			Param(ws.PathParameter("namespace-name", "The name of the namespace to lookup").DataType("string")).
@@ -219,7 +200,6 @@ func (a *Api) RegisterModel(container *restful.Container) {
 		// under a specified namespace and pod.
 		ws.Route(ws.GET("/namespaces/{namespace-name}/pods/{pod-name}/containers").
 			To(a.allPodContainers).
-			Filter(compressionFilter).
 			Doc("Get a list of all Containers in the model, belonging to the specified Namespace and Pod").
 			Operation("allPodContainers").
 			Param(ws.PathParameter("namespace-name", "The name of the namespace to lookup").DataType("string")).
@@ -229,7 +209,6 @@ func (a *Api) RegisterModel(container *restful.Container) {
 		// returns a list of all API paths available for a Pod Container
 		ws.Route(ws.GET("/namespaces/{namespace-name}/pods/{pod-name}/containers/{container-name}").
 			To(a.containerPaths).
-			Filter(compressionFilter).
 			Doc("Get a list of all API paths available for a Pod Container entity").
 			Operation("containerPaths").
 			Param(ws.PathParameter("namespace-name", "The name of the namespace to lookup").DataType("string")).
@@ -239,7 +218,6 @@ func (a *Api) RegisterModel(container *restful.Container) {
 		// The /namespaces/{namespace-name}/pods/{pod-name}/containers/{container-name}/stats endpoint returns derived stats for a Pod Container entity.
 		ws.Route(ws.GET("/namespaces/{namespace-name}/pods/{pod-name}/containers/{container-name}/stats/").
 			To(a.podContainerStats).
-			Filter(compressionFilter).
 			Doc("Get all available stats for a Pod Container entity.").
 			Operation("podContainerStats").
 			Param(ws.PathParameter("namespace-name", "The name of the namespace to lookup").DataType("string")).
@@ -250,7 +228,6 @@ func (a *Api) RegisterModel(container *restful.Container) {
 		// returns a list of all available metrics for a Pod Container entity.
 		ws.Route(ws.GET("/namespaces/{namespace-name}/pods/{pod-name}/containers/{container-name}/metrics").
 			To(a.availableMetrics).
-			Filter(compressionFilter).
 			Doc("Get a list of all available metrics for a Pod entity").
 			Operation("availableMetrics").
 			Param(ws.PathParameter("namespace-name", "The name of the namespace to lookup").DataType("string")).
@@ -261,7 +238,6 @@ func (a *Api) RegisterModel(container *restful.Container) {
 		// a metric for a Container entity of the model.
 		ws.Route(ws.GET("/namespaces/{namespace-name}/pods/{pod-name}/containers/{container-name}/metrics/{metric-name}").
 			To(a.podContainerMetrics).
-			Filter(compressionFilter).
 			Doc("Export an aggregated metric for a Pod Container").
 			Operation("podContainerMetrics").
 			Param(ws.PathParameter("namespace-name", "The name of the namespace to use").DataType("string")).
@@ -275,7 +251,6 @@ func (a *Api) RegisterModel(container *restful.Container) {
 		// The /nodes/{node-name}/pods/ endpoint returns a list of all Pods entities under a specified node.
 		ws.Route(ws.GET("/nodes/{node-name}/pods/").
 			To(a.nodePods).
-			Filter(compressionFilter).
 			Doc("Get a list of all Pods belonging to a specified Node in the model").
 			Operation("nodePods").
 			Param(ws.PathParameter("node-name", "The name of the namespace to lookup").DataType("string")))
@@ -285,7 +260,6 @@ func (a *Api) RegisterModel(container *restful.Container) {
 	// under a specified node.
 	ws.Route(ws.GET("/nodes/{node-name}/freecontainers/").
 		To(a.allFreeContainers).
-		Filter(compressionFilter).
 		Doc("Get a list of all free Containers in the model, belonging to the specified Node").
 		Operation("allFreeContainers").
 		Param(ws.PathParameter("node-name", "The name of the namespace to lookup").DataType("string")))
@@ -294,7 +268,6 @@ func (a *Api) RegisterModel(container *restful.Container) {
 	// the available subpaths for a free container
 	ws.Route(ws.GET("/nodes/{node-name}/freecontainers/{container-name}/").
 		To(a.containerPaths).
-		Filter(compressionFilter).
 		Doc("Get a list of API paths for a free Container entity").
 		Operation("freeContainerMetrics").
 		Param(ws.PathParameter("node-name", "The name of the node to use").DataType("string")).
@@ -304,7 +277,6 @@ func (a *Api) RegisterModel(container *restful.Container) {
 	// The /nodes/{node-name}/freecontainers/{container-name}/stats endpoint returns derived stats for a Free Container entity.
 	ws.Route(ws.GET("/nodes/{node-name}/freecontainers/{container-name}/stats").
 		To(a.freeContainerStats).
-		Filter(compressionFilter).
 		Doc("Get all available stats for a Free Container entity.").
 		Operation("freeContainerStats").
 		Param(ws.PathParameter("node-name", "The name of the namespace to lookup").DataType("string")).
@@ -314,7 +286,6 @@ func (a *Api) RegisterModel(container *restful.Container) {
 	// returns a list of all available metrics for a Free Container entity.
 	ws.Route(ws.GET("/nodes/{node-name}/freecontainers/{container-name}/metrics").
 		To(a.availableMetrics).
-		Filter(compressionFilter).
 		Doc("Get a list of all available metrics for a free Container entity").
 		Operation("availableMetrics").
 		Param(ws.PathParameter("node-name", "The name of the namespace to lookup").DataType("string")).
@@ -324,7 +295,6 @@ func (a *Api) RegisterModel(container *restful.Container) {
 	// a metric for a free Container entity of the model.
 	ws.Route(ws.GET("/nodes/{node-name}/freecontainers/{container-name}/metrics/{metric-name}").
 		To(a.freeContainerMetrics).
-		Filter(compressionFilter).
 		Doc("Export a container-level metric for a free container").
 		Operation("freeContainerMetrics").
 		Param(ws.PathParameter("node-name", "The name of the node to use").DataType("string")).
@@ -339,7 +309,6 @@ func (a *Api) RegisterModel(container *restful.Container) {
 		// metrics for a list od pods of the model.
 		ws.Route(ws.GET("/namespaces/{namespace-name}/pod-list/{pod-list}/metrics/{metric-name}").
 			To(a.podListMetrics).
-			Filter(compressionFilter).
 			Doc("Export a metric for all pods from the given list").
 			Operation("podListMetric").
 			Param(ws.PathParameter("namespace-name", "The name of the namespace to lookup").DataType("string")).

--- a/handlers.go
+++ b/handlers.go
@@ -42,6 +42,7 @@ func setupHandlers(sourcesList []api.Source, sink sinks.ExternalSinkManager, m m
 
 	// Make API handler.
 	wsContainer := restful.NewContainer()
+	wsContainer.EnableContentEncoding(true)
 	a := v1.NewApi(m, runningInKubernetes)
 	a.Register(wsContainer)
 


### PR DESCRIPTION
Current approach of forcing gzip encoding isn't very friendly to clients. With this approach clients can use standard `Accept-Encoding` header to request compress, either gzip or deflate, as provided by go-restful.