### PR TITLE
Make the model use a result struct to return stats

### DIFF
--- a/api/v1/model_handlers.go
+++ b/api/v1/model_handlers.go
@@ -469,11 +469,11 @@ func (a *Api) clusterStats(request *restful.Request, response *restful.Response)
 	if model == nil {
 		response.WriteError(400, errModelNotActivated)
 	}
-	res, uptime, err := model.GetClusterStats()
+	res, err := model.GetClusterStats()
 	if err != nil {
 		response.WriteError(400, err)
 	}
-	response.WriteEntity(exportStatBundle(res, uptime))
+	response.WriteEntity(exportStatsResult(res))
 }
 
 // clusterMetrics returns a metric timeseries for a metric of the Cluster entity.
@@ -501,13 +501,13 @@ func (a *Api) nodeStats(request *restful.Request, response *restful.Response) {
 	if model == nil {
 		response.WriteError(400, errModelNotActivated)
 	}
-	res, uptime, err := model.GetNodeStats(model_api.NodeRequest{
+	res, err := model.GetNodeStats(model_api.NodeRequest{
 		NodeName: request.PathParameter("node-name"),
 	})
 	if err != nil {
 		response.WriteError(400, err)
 	}
-	response.WriteEntity(exportStatBundle(res, uptime))
+	response.WriteEntity(exportStatsResult(res))
 }
 
 // nodeMetrics returns a metric timeseries for a metric of the Node entity.
@@ -536,13 +536,13 @@ func (a *Api) namespaceStats(request *restful.Request, response *restful.Respons
 	if model == nil {
 		response.WriteError(400, errModelNotActivated)
 	}
-	res, uptime, err := model.GetNamespaceStats(model_api.NamespaceRequest{
+	res, err := model.GetNamespaceStats(model_api.NamespaceRequest{
 		NamespaceName: request.PathParameter("namespace-name"),
 	})
 	if err != nil {
 		response.WriteError(400, err)
 	}
-	response.WriteEntity(exportStatBundle(res, uptime))
+	response.WriteEntity(exportStatsResult(res))
 }
 
 // namespaceMetrics returns a metric timeseries for a metric of the Namespace entity.
@@ -571,14 +571,14 @@ func (a *Api) podStats(request *restful.Request, response *restful.Response) {
 	if model == nil {
 		response.WriteError(400, errModelNotActivated)
 	}
-	res, uptime, err := model.GetPodStats(model_api.PodRequest{
+	res, err := model.GetPodStats(model_api.PodRequest{
 		NamespaceName: request.PathParameter("namespace-name"),
 		PodName:       request.PathParameter("pod-name"),
 	})
 	if err != nil {
 		response.WriteError(400, err)
 	}
-	response.WriteEntity(exportStatBundle(res, uptime))
+	response.WriteEntity(exportStatsResult(res))
 }
 
 // podMetrics returns a metric timeseries for a metric of the Pod entity.
@@ -635,7 +635,7 @@ func (a *Api) podContainerStats(request *restful.Request, response *restful.Resp
 	if model == nil {
 		response.WriteError(400, errModelNotActivated)
 	}
-	res, uptime, err := model.GetPodContainerStats(model_api.PodContainerRequest{
+	res, err := model.GetPodContainerStats(model_api.PodContainerRequest{
 		NamespaceName: request.PathParameter("namespace-name"),
 		PodName:       request.PathParameter("pod-name"),
 		ContainerName: request.PathParameter("container-name"),
@@ -643,7 +643,7 @@ func (a *Api) podContainerStats(request *restful.Request, response *restful.Resp
 	if err != nil {
 		response.WriteError(400, err)
 	}
-	response.WriteEntity(exportStatBundle(res, uptime))
+	response.WriteEntity(exportStatsResult(res))
 }
 
 // podContainerMetrics returns a metric timeseries for a metric of a Pod Container entity.
@@ -675,14 +675,14 @@ func (a *Api) freeContainerStats(request *restful.Request, response *restful.Res
 	if model == nil {
 		response.WriteError(400, errModelNotActivated)
 	}
-	res, uptime, err := model.GetFreeContainerStats(model_api.FreeContainerRequest{
+	res, err := model.GetFreeContainerStats(model_api.FreeContainerRequest{
 		NodeName:      request.PathParameter("node-name"),
 		ContainerName: request.PathParameter("container-name"),
 	})
 	if err != nil {
 		response.WriteError(400, err)
 	}
-	response.WriteEntity(exportStatBundle(res, uptime))
+	response.WriteEntity(exportStatsResult(res))
 }
 
 // freeContainerMetrics returns a metric timeseries for a metric of the Container entity.
@@ -734,10 +734,10 @@ func parseRequestParam(param string, request *restful.Request, response *restful
 	return req_stamp
 }
 
-// exportStatBundle renders a model.StatBundle and a time.Duration into StatsResponse.
-func exportStatBundle(stats map[string]model_api.StatBundle, uptime time.Duration) types.StatsResponse {
+// exportStatsResult renders a model.StatsResult into a StatsResponse.
+func exportStatsResult(res *model_api.StatsResult) types.StatsResponse {
 	resMap := make(map[string]types.ExternalStatBundle)
-	for key, val := range stats {
+	for key, val := range res.ByName {
 		resMap[key] = types.ExternalStatBundle{
 			Minute: exportStat(val.Minute),
 			Hour:   exportStat(val.Hour),
@@ -745,7 +745,7 @@ func exportStatBundle(stats map[string]model_api.StatBundle, uptime time.Duratio
 		}
 	}
 	return types.StatsResponse{
-		Uptime: uint64(uptime.Seconds()),
+		Uptime: uint64(res.Uptime.Seconds()),
 		Stats:  resMap,
 	}
 }

--- a/model/getters.go
+++ b/model/getters.go
@@ -427,88 +427,122 @@ func (rc *realModel) uptime(infotype *InfoType) time.Duration {
 }
 
 // getClusterStats extracts the derived stats and uptime for the Cluster entity.
-func (rc *realModel) GetClusterStats() (map[string]StatBundle, time.Duration, error) {
+func (rc *realModel) GetClusterStats() (*StatsResult, error) {
 	rc.lock.RLock()
 	defer rc.lock.RUnlock()
-	return getStats(rc.InfoType), rc.uptime(&rc.InfoType), nil
+	s, t := getStats(rc.InfoType)
+	res := &StatsResult{
+		ByName:    s,
+		Timestamp: t,
+		Uptime:    rc.uptime(&rc.InfoType),
+	}
+	return res, nil
 }
 
 // getNodeStats extracts the derived stats and uptime for a Node entity.
-func (rc *realModel) GetNodeStats(req NodeRequest) (map[string]StatBundle, time.Duration, error) {
+func (rc *realModel) GetNodeStats(req NodeRequest) (*StatsResult, error) {
 	rc.lock.RLock()
 	defer rc.lock.RUnlock()
 	node, ok := rc.Nodes[req.NodeName]
 	if !ok {
-		return nil, time.Duration(0), errInvalidNode
+		return nil, errInvalidNode
 	}
-
-	return getStats(node.InfoType), rc.uptime(&node.InfoType), nil
+	s, t := getStats(node.InfoType)
+	res := &StatsResult{
+		ByName:    s,
+		Timestamp: t,
+		Uptime:    rc.uptime(&node.InfoType),
+	}
+	return res, nil
 }
 
 // getNamespaceStats extracts the derived stats and uptime for a Namespace entity.
-func (rc *realModel) GetNamespaceStats(req NamespaceRequest) (map[string]StatBundle, time.Duration, error) {
+func (rc *realModel) GetNamespaceStats(req NamespaceRequest) (*StatsResult, error) {
 	rc.lock.RLock()
 	defer rc.lock.RUnlock()
 	ns, ok := rc.Namespaces[req.NamespaceName]
 	if !ok {
-		return nil, time.Duration(0), errNoSuchNamespace
+		return nil, errNoSuchNamespace
 	}
-
-	return getStats(ns.InfoType), rc.uptime(&ns.InfoType), nil
+	s, t := getStats(ns.InfoType)
+	res := &StatsResult{
+		ByName:    s,
+		Timestamp: t,
+		Uptime:    rc.uptime(&ns.InfoType),
+	}
+	return res, nil
 }
 
 // getPodStats extracts the derived stats and uptime for a Pod entity.
-func (rc *realModel) GetPodStats(req PodRequest) (map[string]StatBundle, time.Duration, error) {
+func (rc *realModel) GetPodStats(req PodRequest) (*StatsResult, error) {
 	rc.lock.RLock()
 	defer rc.lock.RUnlock()
 	ns, ok := rc.Namespaces[req.NamespaceName]
 	if !ok {
-		return nil, time.Duration(0), errNoSuchNamespace
+		return nil, errNoSuchNamespace
 	}
 
 	pod, ok := ns.Pods[req.PodName]
 	if !ok {
-		return nil, time.Duration(0), errNoSuchPod
+		return nil, errNoSuchPod
 	}
 
-	return getStats(pod.InfoType), rc.uptime(&pod.InfoType), nil
+	s, t := getStats(pod.InfoType)
+	res := &StatsResult{
+		ByName:    s,
+		Timestamp: t,
+		Uptime:    rc.uptime(&pod.InfoType),
+	}
+	return res, nil
 }
 
 // getPodContainerStats extracts the derived stats and uptime for a Pod Container entity.
-func (rc *realModel) GetPodContainerStats(req PodContainerRequest) (map[string]StatBundle, time.Duration, error) {
+func (rc *realModel) GetPodContainerStats(req PodContainerRequest) (*StatsResult, error) {
 	rc.lock.RLock()
 	defer rc.lock.RUnlock()
 	ns, ok := rc.Namespaces[req.NamespaceName]
 	if !ok {
-		return nil, time.Duration(0), errNoSuchNamespace
+		return nil, errNoSuchNamespace
 	}
 
 	pod, ok := ns.Pods[req.PodName]
 	if !ok {
-		return nil, time.Duration(0), errNoSuchPod
+		return nil, errNoSuchPod
 	}
 
 	ctr, ok := pod.Containers[req.ContainerName]
 	if !ok {
-		return nil, time.Duration(0), errNoSuchContainer
+		return nil, errNoSuchContainer
 	}
 
-	return getStats(ctr.InfoType), rc.uptime(&ctr.InfoType), nil
+	s, t := getStats(ctr.InfoType)
+	res := &StatsResult{
+		ByName:    s,
+		Timestamp: t,
+		Uptime:    rc.uptime(&ctr.InfoType),
+	}
+	return res, nil
 }
 
 // getFreeContainerStats extracts the derived stats and uptime for a Pod Container entity.
-func (rc *realModel) GetFreeContainerStats(req FreeContainerRequest) (map[string]StatBundle, time.Duration, error) {
+func (rc *realModel) GetFreeContainerStats(req FreeContainerRequest) (*StatsResult, error) {
 	rc.lock.RLock()
 	defer rc.lock.RUnlock()
 	node, ok := rc.Nodes[req.NodeName]
 	if !ok {
-		return nil, time.Duration(0), errInvalidNode
+		return nil, errInvalidNode
 	}
 
 	ctr, ok := node.FreeContainers[req.ContainerName]
 	if !ok {
-		return nil, time.Duration(0), errNoSuchContainer
+		return nil, errNoSuchContainer
 	}
 
-	return getStats(ctr.InfoType), rc.uptime(&ctr.InfoType), nil
+	s, t := getStats(ctr.InfoType)
+	res := &StatsResult{
+		ByName:    s,
+		Timestamp: t,
+		Uptime:    rc.uptime(&ctr.InfoType),
+	}
+	return res, nil
 }

--- a/model/getters_test.go
+++ b/model/getters_test.go
@@ -655,22 +655,22 @@ func TestGetClusterStats(t *testing.T) {
 	)
 
 	// Invocation with no cluster stats
-	res, uptime, err := model.GetClusterStats()
-	assert.Len(res, 0)
-	assert.Equal(uptime, time.Duration(0))
+	res, err := model.GetClusterStats()
+	assert.Len(res.ByName, 0)
+	assert.Equal(res.Uptime, time.Duration(0))
 	assert.NoError(err)
 
 	// Invocation with cluster stats
 	model.Update(source_cache)
-	res, uptime, err = model.GetClusterStats()
-	assert.True(len(res) >= 6)
-	assert.Equal(res[memUsage].Minute.Average, res[memUsage].Minute.Max)
-	assert.Equal(res[memUsage].Minute.Average, res[memUsage].Minute.NinetyFifth)
-	assert.Equal(res[memUsage].Minute.Average, uint64(10000))
-	assert.Equal(res[memUsage].Hour.Max, 2*memUsageEpsilon)
-	assert.Equal(res[memUsage].Hour.Average, 2*memUsageEpsilon)
-	assert.Equal(res[memUsage].Hour.NinetyFifth, 2*memUsageEpsilon)
-	assert.NotEqual(uptime, time.Duration(0))
+	res, err = model.GetClusterStats()
+	assert.True(len(res.ByName) >= 6)
+	assert.Equal(res.ByName[memUsage].Minute.Average, res.ByName[memUsage].Minute.Max)
+	assert.Equal(res.ByName[memUsage].Minute.Average, res.ByName[memUsage].Minute.NinetyFifth)
+	assert.Equal(res.ByName[memUsage].Minute.Average, uint64(10000))
+	assert.Equal(res.ByName[memUsage].Hour.Max, 2*memUsageEpsilon)
+	assert.Equal(res.ByName[memUsage].Hour.Average, 2*memUsageEpsilon)
+	assert.Equal(res.ByName[memUsage].Hour.NinetyFifth, 2*memUsageEpsilon)
+	assert.NotEqual(res.Uptime, time.Duration(0))
 	assert.NoError(err)
 }
 
@@ -684,21 +684,20 @@ func TestGetNodeStats(t *testing.T) {
 	model.Update(source_cache)
 
 	// Invocation with nonexistant node
-	res, uptime, err := model.GetNodeStats(NodeRequest{
+	res, err := model.GetNodeStats(NodeRequest{
 		NodeName: "nonexistant",
 	})
 	assert.Nil(res)
-	assert.Equal(uptime, time.Duration(0))
 	assert.Error(err)
 
 	// Invocation with normal node
-	res, uptime, err = model.GetNodeStats(NodeRequest{
+	res, err = model.GetNodeStats(NodeRequest{
 		NodeName: "hostname2",
 	})
-	assert.True(len(res) >= 6)
-	assert.Equal(res[memUsage].Minute.Average, res[memUsage].Minute.Max)
-	assert.Equal(res[memUsage].Minute.Average, res[memUsage].Minute.NinetyFifth)
-	assert.NotEqual(res[memUsage].Minute.Average, uint64(0))
+	assert.True(len(res.ByName) >= 6)
+	assert.Equal(res.ByName[memUsage].Minute.Average, res.ByName[memUsage].Minute.Max)
+	assert.Equal(res.ByName[memUsage].Minute.Average, res.ByName[memUsage].Minute.NinetyFifth)
+	assert.NotEqual(res.ByName[memUsage].Minute.Average, uint64(0))
 	assert.NoError(err)
 }
 
@@ -712,22 +711,21 @@ func TestGetNamespaceStats(t *testing.T) {
 	model.Update(source_cache)
 
 	// Invocation with nonexistant namespace
-	res, uptime, err := model.GetNamespaceStats(NamespaceRequest{
+	res, err := model.GetNamespaceStats(NamespaceRequest{
 		NamespaceName: "nonexistant",
 	})
 	assert.Nil(res)
-	assert.Equal(uptime, time.Duration(0))
 	assert.Error(err)
 
 	// Invocation with normal namespace
-	res, uptime, err = model.GetNamespaceStats(NamespaceRequest{
+	res, err = model.GetNamespaceStats(NamespaceRequest{
 		NamespaceName: "test",
 	})
-	assert.True(len(res) >= 6)
-	assert.Equal(res[memUsage].Minute.Average, res[memUsage].Minute.Max)
-	assert.Equal(res[memUsage].Minute.Average, res[memUsage].Minute.NinetyFifth)
-	assert.NotEqual(res[memUsage].Minute.Average, uint64(0))
-	assert.NotEqual(res[memUsage].Hour.Average, uint64(0))
+	assert.True(len(res.ByName) >= 6)
+	assert.Equal(res.ByName[memUsage].Minute.Average, res.ByName[memUsage].Minute.Max)
+	assert.Equal(res.ByName[memUsage].Minute.Average, res.ByName[memUsage].Minute.NinetyFifth)
+	assert.NotEqual(res.ByName[memUsage].Minute.Average, uint64(0))
+	assert.NotEqual(res.ByName[memUsage].Hour.Average, uint64(0))
 	assert.NoError(err)
 }
 
@@ -741,38 +739,36 @@ func TestGetPodStats(t *testing.T) {
 	model.Update(source_cache)
 
 	// Invocation with nonexistant namespace
-	res, uptime, err := model.GetPodStats(PodRequest{
+	res, err := model.GetPodStats(PodRequest{
 		NamespaceName: "nonexistant",
 		PodName:       "pod1",
 	})
 	assert.Nil(res)
-	assert.Equal(uptime, time.Duration(0))
 	assert.Error(err)
 
 	// Invocation with normal namespace and nonexistant pod
-	res, uptime, err = model.GetPodStats(PodRequest{
+	res, err = model.GetPodStats(PodRequest{
 		NamespaceName: "test",
 		PodName:       "nonexistant",
 	})
 	assert.Nil(res)
-	assert.Equal(uptime, time.Duration(0))
 	assert.Error(err)
 
 	// Normal Invocation
-	res, uptime, err = model.GetPodStats(PodRequest{
+	res, err = model.GetPodStats(PodRequest{
 		NamespaceName: "test",
 		PodName:       "pod1",
 	})
-	assert.True(len(res) >= 6)
-	assert.Equal(res[memUsage].Minute.Average, res[memUsage].Minute.Max)
-	assert.Equal(res[memUsage].Minute.Average, res[memUsage].Minute.NinetyFifth)
-	assert.NotEqual(res[memUsage].Minute.Average, uint64(0))
-	assert.NotEqual(res[memUsage].Hour.Average, uint64(0))
+	assert.True(len(res.ByName) >= 6)
+	assert.Equal(res.ByName[memUsage].Minute.Average, res.ByName[memUsage].Minute.Max)
+	assert.Equal(res.ByName[memUsage].Minute.Average, res.ByName[memUsage].Minute.NinetyFifth)
+	assert.NotEqual(res.ByName[memUsage].Minute.Average, uint64(0))
+	assert.NotEqual(res.ByName[memUsage].Hour.Average, uint64(0))
 
-	assert.Equal(res[cpuLimit].Minute.Average, res[cpuLimit].Minute.Max)
-	assert.Equal(res[cpuLimit].Minute.Average, res[cpuLimit].Minute.NinetyFifth)
-	assert.NotEqual(res[cpuLimit].Minute.Average, uint64(0))
-	assert.NotEqual(res[cpuLimit].Hour.Average, uint64(0))
+	assert.Equal(res.ByName[cpuLimit].Minute.Average, res.ByName[cpuLimit].Minute.Max)
+	assert.Equal(res.ByName[cpuLimit].Minute.Average, res.ByName[cpuLimit].Minute.NinetyFifth)
+	assert.NotEqual(res.ByName[cpuLimit].Minute.Average, uint64(0))
+	assert.NotEqual(res.ByName[cpuLimit].Hour.Average, uint64(0))
 	assert.NoError(err)
 }
 
@@ -786,47 +782,44 @@ func TestGetPodContainerStats(t *testing.T) {
 	model.Update(source_cache)
 
 	// Invocation with nonexistant namespace
-	res, uptime, err := model.GetPodContainerStats(PodContainerRequest{
+	res, err := model.GetPodContainerStats(PodContainerRequest{
 		NamespaceName: "nonexistant",
 		PodName:       "pod1",
 		ContainerName: "container1",
 	})
 	assert.Nil(res)
-	assert.Equal(uptime, time.Duration(0))
 	assert.Error(err)
 
 	// Invocation with normal namespace and nonexistant pod
-	res, uptime, err = model.GetPodContainerStats(PodContainerRequest{
+	res, err = model.GetPodContainerStats(PodContainerRequest{
 		NamespaceName: "test",
 		PodName:       "nonexistant",
 		ContainerName: "container1",
 	})
 	assert.Nil(res)
-	assert.Equal(uptime, time.Duration(0))
 	assert.Error(err)
 
 	// Invocation with normal namespace and pod, but nonexistant container
-	res, uptime, err = model.GetPodContainerStats(PodContainerRequest{
+	res, err = model.GetPodContainerStats(PodContainerRequest{
 		NamespaceName: "test",
 		PodName:       "pod1",
 		ContainerName: "nonexistant",
 	})
 	assert.Nil(res)
-	assert.Equal(uptime, time.Duration(0))
 	assert.Error(err)
 
 	// Normal Invocation
-	res, uptime, err = model.GetPodContainerStats(PodContainerRequest{
+	res, err = model.GetPodContainerStats(PodContainerRequest{
 		NamespaceName: "test",
 		PodName:       "pod1",
 		ContainerName: "container1",
 	})
-	assert.True(len(res) >= 6)
-	assert.Equal(res[memUsage].Minute.Average, res[memUsage].Minute.Max)
-	assert.Equal(res[memUsage].Minute.Average, res[memUsage].Minute.NinetyFifth)
-	assert.NotEqual(res[memUsage].Minute.Average, uint64(0))
-	assert.NotEqual(res[memUsage].Minute.Max, uint64(0))
-	assert.NotEqual(res[memUsage].Minute.NinetyFifth, uint64(0))
+	assert.True(len(res.ByName) >= 6)
+	assert.Equal(res.ByName[memUsage].Minute.Average, res.ByName[memUsage].Minute.Max)
+	assert.Equal(res.ByName[memUsage].Minute.Average, res.ByName[memUsage].Minute.NinetyFifth)
+	assert.NotEqual(res.ByName[memUsage].Minute.Average, uint64(0))
+	assert.NotEqual(res.ByName[memUsage].Minute.Max, uint64(0))
+	assert.NotEqual(res.ByName[memUsage].Minute.NinetyFifth, uint64(0))
 	assert.NoError(err)
 }
 
@@ -840,32 +833,30 @@ func TestGetFreeContainerStats(t *testing.T) {
 	model.Update(source_cache)
 
 	// Invocation with nonexistant node
-	res, uptime, err := model.GetFreeContainerStats(FreeContainerRequest{
+	res, err := model.GetFreeContainerStats(FreeContainerRequest{
 		NodeName:      "nonexistant",
 		ContainerName: "free_container1",
 	})
 	assert.Nil(res)
-	assert.Equal(uptime, time.Duration(0))
 	assert.Error(err)
 
 	// Invocation with normal node and nonexistant container
-	res, uptime, err = model.GetFreeContainerStats(FreeContainerRequest{
+	res, err = model.GetFreeContainerStats(FreeContainerRequest{
 		NodeName:      "hostname2",
 		ContainerName: "nonexistant",
 	})
 	assert.Nil(res)
-	assert.Equal(uptime, time.Duration(0))
 	assert.Error(err)
 
 	// Normal Invocation
-	res, uptime, err = model.GetFreeContainerStats(FreeContainerRequest{
+	res, err = model.GetFreeContainerStats(FreeContainerRequest{
 		NodeName:      "hostname2",
 		ContainerName: "free_container1",
 	})
-	assert.True(len(res) >= 6)
-	assert.Equal(res[memUsage].Minute.Average, res[memUsage].Minute.Max)
-	assert.Equal(res[memUsage].Minute.Average, res[memUsage].Minute.NinetyFifth)
-	assert.NotEqual(res[memUsage].Minute.Average, uint64(0))
-	assert.NotEqual(res[memUsage].Hour.Average, uint64(0))
+	assert.True(len(res.ByName) >= 6)
+	assert.Equal(res.ByName[memUsage].Minute.Average, res.ByName[memUsage].Minute.Max)
+	assert.Equal(res.ByName[memUsage].Minute.Average, res.ByName[memUsage].Minute.NinetyFifth)
+	assert.NotEqual(res.ByName[memUsage].Minute.Average, uint64(0))
+	assert.NotEqual(res.ByName[memUsage].Hour.Average, uint64(0))
 	assert.NoError(err)
 }

--- a/model/types.go
+++ b/model/types.go
@@ -48,12 +48,12 @@ type Model interface {
 	GetFreeContainerMetric(FreeContainerMetricRequest) ([]statstore.TimePoint, time.Time, error)
 
 	// The GetXStats operations extract all derived stats for a single entity of the cluster.
-	GetClusterStats() (map[string]StatBundle, time.Duration, error)
-	GetNodeStats(NodeRequest) (map[string]StatBundle, time.Duration, error)
-	GetNamespaceStats(NamespaceRequest) (map[string]StatBundle, time.Duration, error)
-	GetPodStats(PodRequest) (map[string]StatBundle, time.Duration, error)
-	GetPodContainerStats(PodContainerRequest) (map[string]StatBundle, time.Duration, error)
-	GetFreeContainerStats(FreeContainerRequest) (map[string]StatBundle, time.Duration, error)
+	GetClusterStats() (*StatsResult, error)
+	GetNodeStats(NodeRequest) (*StatsResult, error)
+	GetNamespaceStats(NamespaceRequest) (*StatsResult, error)
+	GetPodStats(PodRequest) (*StatsResult, error)
+	GetPodContainerStats(PodContainerRequest) (*StatsResult, error)
+	GetFreeContainerStats(FreeContainerRequest) (*StatsResult, error)
 }
 
 // realModel is an implementation of the Model interface.
@@ -175,6 +175,12 @@ type StatBundle struct {
 	Minute Stats
 	Hour   Stats
 	Day    Stats
+}
+
+type StatsResult struct {
+	ByName    map[string]StatBundle
+	Timestamp time.Time
+	Uptime    time.Duration
 }
 
 // Listing Types

--- a/model/util.go
+++ b/model/util.go
@@ -163,11 +163,13 @@ func instantFromCumulativeMetric(value uint64, stamp time.Time, prev *statstore.
 	return instaVal, nil
 }
 
-// getStats extracts derived stats from an InfoType.
-func getStats(info InfoType) map[string]StatBundle {
+// getStats extracts derived stats from an InfoType and their timestamp.
+func getStats(info InfoType) (map[string]StatBundle, time.Time) {
 	res := make(map[string]StatBundle)
+	var timestamp time.Time
 	for key, ds := range info.Metrics {
 		last, lastMax, _ := ds.Hour.Last()
+		timestamp = last.Timestamp
 		minAvg := last.Value
 		minPct := lastMax
 		minMax := lastMax
@@ -196,7 +198,7 @@ func getStats(info InfoType) map[string]StatBundle {
 			},
 		}
 	}
-	return res
+	return res, timestamp
 }
 
 func epsilonFromMetric(metric string) uint64 {

--- a/model/util_test.go
+++ b/model/util_test.go
@@ -334,7 +334,7 @@ func TestGetStats(t *testing.T) {
 	})
 	info := newInfoType(metrics, nil, nil)
 
-	res := getStats(info)
+	res, _ := getStats(info)
 	assert.Len(res, 2)
 	assert.Equal(res[cpuLimit].Minute.Average, uint64(300000))
 	assert.Equal(res[cpuLimit].Minute.Max, uint64(300000))


### PR DESCRIPTION
This makes the interface and functions cleaner, and allows us to add the
timestamp needed by features like the nodeMetrics experimental endpoint.

Extracted from #549.

CC @afein
