### PR TITLE
Skip TestEventsBasic broken and flaky test

### DIFF
--- a/sources/kube_events_test.go
+++ b/sources/kube_events_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func TestEventsBasic(t *testing.T) {
+	t.Skip("Broken and flaky test - first fix #537 and #565")
 	handler := util.FakeHandler{
 		StatusCode:   200,
 		RequestBody:  "something",


### PR DESCRIPTION
As discussed offline with @vishh, this test is fundamentally broken and
doesn't test anything properly. It doesn't fail because the events list never
gets processed. If it does, #537 takes place since the events list is wrong.
Even if it doesn't, #565 can also appear.

Since the test is flawed and flaky, best remove it until it is rewritten
properly. Right now it's causing issues with pull requests since its flakyness
comes up often thanks to -race.