### PR TITLE
Improved the out-of-the-box experience for Grafana

### DIFF
--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -1,0 +1,14 @@
+#
+# Stock Grafana + a few custom dashboards
+#
+
+FROM grafana/grafana:2.1.0
+
+RUN apt-get update && \
+    apt-get install -y curl
+
+COPY dashboards /dashboards
+COPY run.sh /run.sh
+
+EXPOSE 3000
+ENTRYPOINT /run.sh

--- a/grafana/Makefile
+++ b/grafana/Makefile
@@ -1,0 +1,13 @@
+
+TAG = v2.1.0
+PREFIX = kubernetes
+
+all: container
+
+container:
+	docker build -t $(PREFIX)/heapster_grafana:$(TAG) .
+
+push:
+	docker push $(PREFIX)/grafana:$(TAG)
+
+

--- a/grafana/README.md
+++ b/grafana/README.md
@@ -1,0 +1,17 @@
+# Grafana Image For Heapster/InfluxDB
+
+## What's In It
+* Stock Grafana.
+* Create a datasource for InfluxDB.
+* Create a couple of dashboards during startup. These dashboards leverage templating and repeating of panels features in Grafana 2.0, to discover nodes, pods, and containers automatically.
+
+## How To Use It
+* InfluxDB service URL can be passed in via the environment variable __INFLUXDB_SERVICE_URL__.
+* If __INFLUXDB_SERVICE_URL__ isn't defined, it will discover and use the external service URL, if available.
+* Otherwise, it will fall back to http://monitoring-influxdb:8086.
+
+## How To Build It
+
+cd $GOPATH/src/k8s.io/heapster/grafana
+
+make all

--- a/grafana/RELEASES.md
+++ b/grafana/RELEASES.md
@@ -1,0 +1,6 @@
+# Release Notes for Grafana container.
+
+## 2.1.0 (9-28-2015)
+- Support Grafana 2.1.0 and InfluxDB 0.8.9.
+- Auto populate pods and nodes using Grafana templates.
+

--- a/grafana/dashboards/cluster.json
+++ b/grafana/dashboards/cluster.json
@@ -1,0 +1,893 @@
+{
+  "dashboard":
+  {
+    "title": "Kubernetes Cluster",
+    "originalTitle": "Kubernetes Cluster",
+    "tags": [],
+    "style": "dark",
+    "timezone": "browser",
+    "editable": true,
+    "hideControls": false,
+    "sharedCrosshair": false,
+    "rows": [
+      {
+        "collapse": true,
+        "editable": true,
+        "height": "100px",
+        "panels": [
+          {
+            "content": "#### This dashboard displays Memory, CPU and Disk metrics at both cluster and node levels. Select a node from the above dropdown to see metrics specific to that node. Select \"All\" to see metrics for all nodes side by side.\n\n##### * Cluster metrics are sum across all nodes.\n##### * Node metrics are displayed on one panel for easy comparison.\n##### * There's also a panel for each node so one could \"double-click\" into the node for further analysis.\n",
+            "editable": true,
+            "error": false,
+            "id": 23,
+            "links": [],
+            "mode": "markdown",
+            "span": 12,
+            "style": {},
+            "title": "",
+            "transparent": true,
+            "type": "text"
+          }
+        ],
+        "showTitle": true,
+        "title": "Documentation"
+      },
+      {
+        "collapse": false,
+        "editable": true,
+        "height": "250px",
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": "influxdb-datasource",
+            "decimals": 2,
+            "editable": true,
+            "error": false,
+            "fill": 3,
+            "grid": {
+              "leftLogBase": 1,
+              "leftMax": null,
+              "leftMin": null,
+              "rightLogBase": 1,
+              "rightMax": null,
+              "rightMin": null,
+              "threshold1": null,
+              "threshold1Color": "rgba(216, 200, 27, 0.27)",
+              "threshold2": null,
+              "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "id": 6,
+            "interval": "",
+            "leftYAxisLabel": "",
+            "legend": {
+              "avg": false,
+              "current": true,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 3,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+              {
+                "alias": "Used Memory",
+                "yaxis": 2
+              },
+              {
+                "alias": "Total Used Memory",
+                "yaxis": 1
+              },
+              {
+                "alias": "Total Working Set",
+                "yaxis": 1
+              }
+            ],
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "alias": "Limit",
+                "column": "value",
+                "fields": [
+                  {
+                    "func": "sum",
+                    "name": "value"
+                  }
+                ],
+                "function": "mean",
+                "groupByTags": [],
+                "measurement": "memory/limit_bytes_gauge",
+                "query": "SELECT sum(value) FROM \"memory/limit_bytes_gauge\" WHERE \"container_name\" = 'machine' AND $timeFilter GROUP BY time(10s)",
+                "rawQuery": true,
+                "tags": [
+                  {
+                    "key": "hostname",
+                    "value": "/$node/"
+                  },
+                  {
+                    "condition": "AND",
+                    "key": "container_name",
+                    "value": "machine"
+                  }
+                ]
+              },
+              {
+                "alias": "Usage",
+                "column": "value",
+                "fields": [
+                  {
+                    "func": "last",
+                    "name": "value"
+                  }
+                ],
+                "function": "mean",
+                "groupByTags": [],
+                "measurement": "memory/usage_bytes_gauge",
+                "query": "SELECT sum(value) FROM \"memory/usage_bytes_gauge\" WHERE \"container_name\" = 'machine' AND $timeFilter GROUP BY time(10s)",
+                "rawQuery": true,
+                "tags": [
+                  {
+                    "key": "hostname",
+                    "value": "/$node/"
+                  },
+                  {
+                    "condition": "AND",
+                    "key": "container_name",
+                    "value": "machine"
+                  }
+                ]
+              },
+              {
+                "alias": "Working Set",
+                "column": "value",
+                "fields": [
+                  {
+                    "func": "last",
+                    "name": "value"
+                  }
+                ],
+                "function": "mean",
+                "groupByTags": [],
+                "measurement": "memory/usage_bytes_gauge",
+                "query": "SELECT sum(value) FROM \"memory/working_set_bytes_gauge\" WHERE \"container_name\" = 'machine' AND $timeFilter GROUP BY time(10s)",
+                "rawQuery": true,
+                "tags": [
+                  {
+                    "key": "hostname",
+                    "value": "/$node/"
+                  },
+                  {
+                    "condition": "AND",
+                    "key": "container_name",
+                    "value": "machine"
+                  }
+                ]
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "",
+            "tooltip": {
+              "shared": true,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "x-axis": true,
+            "y-axis": true,
+            "y_formats": [
+              "bytes",
+              "bytes"
+            ]
+          }
+        ],
+        "showTitle": true,
+        "title": "Overall Cluster Memory Usage"
+      },
+      {
+        "collapse": false,
+        "editable": true,
+        "height": "250px",
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": "influxdb-datasource",
+            "decimals": 2,
+            "editable": true,
+            "error": false,
+            "fill": 3,
+            "grid": {
+              "leftLogBase": 1,
+              "leftMax": null,
+              "leftMin": null,
+              "rightLogBase": 1,
+              "rightMax": null,
+              "rightMin": null,
+              "threshold1": null,
+              "threshold1Color": "rgba(216, 200, 27, 0.27)",
+              "threshold2": null,
+              "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "id": 15,
+            "interval": "",
+            "leftYAxisLabel": "",
+            "legend": {
+              "avg": false,
+              "current": true,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 3,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+              {
+                "alias": "Used Memory",
+                "yaxis": 2
+              },
+              {
+                "alias": "Total Used Memory",
+                "yaxis": 1
+              },
+              {
+                "alias": "Total Working Set",
+                "yaxis": 1
+              }
+            ],
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "alias": "",
+                "column": "value",
+                "condition": "container_name = 'machine'",
+                "fields": [
+                  {
+                    "func": "mean",
+                    "name": "value"
+                  }
+                ],
+                "function": "mean",
+                "groupByTags": [
+                  "hostname"
+                ],
+                "groupby_field": "hostname",
+                "interval": "",
+                "measurement": "memory/working_set_bytes_gauge",
+                "query": "select hostname, mean(value) from \"memory/limit_bytes_gauge\" where $timeFilter and container_name = 'machine' group by time($interval), hostname order asc",
+                "rawQuery": true,
+                "series": "memory/limit_bytes_gauge",
+                "tags": [
+                  {
+                    "key": "container_name",
+                    "value": "machine"
+                  }
+                ]
+              },
+              {
+                "alias": "",
+                "column": "value",
+                "condition": "container_name = 'machine'",
+                "fields": [
+                  {
+                    "func": "mean",
+                    "name": "value"
+                  }
+                ],
+                "function": "mean",
+                "groupByTags": [
+                  "hostname"
+                ],
+                "groupby_field": "hostname",
+                "interval": "",
+                "measurement": "memory/working_set_bytes_gauge",
+                "query": "select hostname, mean(value) from \"memory/working_set_bytes_gauge\" where $timeFilter and container_name = 'machine' group by time($interval), hostname order asc",
+                "rawQuery": true,
+                "series": "memory/limit_bytes_gauge",
+                "tags": [
+                  {
+                    "key": "container_name",
+                    "value": "machine"
+                  }
+                ]
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "",
+            "tooltip": {
+              "shared": true,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "x-axis": true,
+            "y-axis": true,
+            "y_formats": [
+              "bytes",
+              "bytes"
+            ]
+          }
+        ],
+        "showTitle": true,
+        "title": "Memory Usage Group By Node"
+      },
+      {
+        "collapse": false,
+        "editable": true,
+        "height": "250px",
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": "influxdb-datasource",
+            "decimals": 2,
+            "editable": true,
+            "error": false,
+            "fill": 3,
+            "grid": {
+              "leftLogBase": 1,
+              "leftMax": null,
+              "leftMin": null,
+              "rightLogBase": 1,
+              "rightMax": null,
+              "rightMin": null,
+              "threshold1": null,
+              "threshold1Color": "rgba(216, 200, 27, 0.27)",
+              "threshold2": null,
+              "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "id": 7,
+            "interval": "10s",
+            "leftYAxisLabel": "",
+            "legend": {
+              "avg": false,
+              "current": true,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 3,
+            "links": [],
+            "minSpan": 6,
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": "node",
+            "repeatIteration": 1443041003983,
+            "scopedVars": {
+            },
+            "seriesOverrides": [
+              {
+                "alias": "Used Memory",
+                "yaxis": 1
+              },
+              {
+                "alias": "Working Set",
+                "yaxis": 1
+              }
+            ],
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "alias": "Usage",
+                "column": "value",
+                "fields": [
+                  {
+                    "func": "last",
+                    "name": "value"
+                  }
+                ],
+                "function": "mean",
+                "groupByTags": [],
+                "hide": false,
+                "measurement": "memory/usage_bytes_gauge",
+                "query": "SELECT last(value) FROM \"memory/usage_bytes_gauge\" WHERE \"hostname\" =~ /$node/ AND \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval)",
+                "rawQuery": true,
+                "tags": [
+                  {
+                    "key": "hostname",
+                    "value": "/$node/"
+                  },
+                  {
+                    "condition": "AND",
+                    "key": "container_name",
+                    "value": "machine"
+                  }
+                ]
+              },
+              {
+                "alias": "Working Set",
+                "column": "value",
+                "fields": [
+                  {
+                    "func": "last",
+                    "name": "value"
+                  }
+                ],
+                "function": "mean",
+                "groupByTags": [],
+                "hide": false,
+                "measurement": "memory/working_set_bytes_gauge",
+                "query": "SELECT last(value) FROM \"memory/working_set_bytes_gauge\" WHERE \"hostname\" =~ /$node/ AND \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval)",
+                "rawQuery": true,
+                "tags": [
+                  {
+                    "key": "hostname",
+                    "value": "/$node/"
+                  },
+                  {
+                    "condition": "AND",
+                    "key": "container_name",
+                    "value": "machine"
+                  }
+                ]
+              },
+              {
+                "alias": "Limit",
+                "column": "value",
+                "condition": "hostname ~= /$node/ and container_name = 'machine'",
+                "function": "mean",
+                "interval": "10s",
+                "query": "select last(value) from \"memory/limit_bytes_gauge\" where $timeFilter and hostname =~ /$node/ and container_name = 'machine' group by time($interval)",
+                "rawQuery": true,
+                "series": "memory/limit_bytes_gauge",
+                "target": ""
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "$node Memory Usage",
+            "tooltip": {
+              "shared": true,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "x-axis": true,
+            "y-axis": true,
+            "y_formats": [
+              "bytes",
+              "bytes"
+            ]
+          }
+        ],
+        "repeat": null,
+        "scopedVars": {},
+        "showTitle": true,
+        "title": "Individual Node Memory Usage"
+      },
+      {
+        "collapse": false,
+        "editable": true,
+        "height": "250px",
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": "influxdb-datasource",
+            "decimals": 2,
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {
+              "leftLogBase": 1,
+              "leftMax": null,
+              "leftMin": null,
+              "rightLogBase": 1,
+              "rightMax": null,
+              "rightMin": null,
+              "threshold1": null,
+              "threshold1Color": "rgba(216, 200, 27, 0.27)",
+              "threshold2": null,
+              "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "id": 9,
+            "legend": {
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+              {
+                "alias": "Used Disk",
+                "yaxis": 2
+              },
+              {
+                "alias": "Total Used Disk",
+                "yaxis": 2
+              }
+            ],
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "alias": "Limit",
+                "column": "value",
+                "fields": [
+                  {
+                    "func": "mean",
+                    "name": "value"
+                  }
+                ],
+                "function": "mean",
+                "groupByTags": [],
+                "interval": "10s",
+                "query": "SELECT sum(value) FROM \"filesystem/limit_bytes_gauge\" WHERE \"container_name\" = 'machine' AND $timeFilter GROUP BY time(10s)",
+                "rawQuery": true,
+                "tags": []
+              },
+              {
+                "alias": "Usage",
+                "column": "value",
+                "fields": [
+                  {
+                    "func": "mean",
+                    "name": "value"
+                  }
+                ],
+                "function": "mean",
+                "groupByTags": [],
+                "interval": "10s",
+                "query": "SELECT sum(value) FROM \"filesystem/usage_bytes_gauge\" WHERE \"container_name\" = 'machine' AND $timeFilter GROUP BY time(10s)",
+                "rawQuery": true,
+                "tags": []
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "",
+            "tooltip": {
+              "shared": true,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "x-axis": true,
+            "y-axis": true,
+            "y_formats": [
+              "bytes",
+              "bytes"
+            ]
+          }
+        ],
+        "showTitle": true,
+        "title": "Overall Cluster Disk Usage"
+      },
+      {
+        "collapse": false,
+        "editable": true,
+        "height": "250px",
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": "influxdb-datasource",
+            "decimals": 2,
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {
+              "leftLogBase": 1,
+              "leftMax": null,
+              "leftMin": null,
+              "rightLogBase": 1,
+              "rightMax": null,
+              "rightMin": null,
+              "threshold1": null,
+              "threshold1Color": "rgba(216, 200, 27, 0.27)",
+              "threshold2": null,
+              "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "id": 19,
+            "legend": {
+              "avg": false,
+              "current": true,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+              {
+                "alias": "Used Disk",
+                "yaxis": 2
+              },
+              {
+                "alias": "Total Used Disk",
+                "yaxis": 2
+              }
+            ],
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "alias": "",
+                "column": "value",
+                "fields": [
+                  {
+                    "func": "mean",
+                    "name": "value"
+                  }
+                ],
+                "function": "mean",
+                "groupByTags": [
+                  "hostname"
+                ],
+                "interval": "10s",
+                "measurement": "filesystem/limit_bytes_gauge",
+                "query": "SELECT hostname, mean(value) FROM \"filesystem/limit_bytes_gauge\" WHERE \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval), \"hostname\"",
+                "rawQuery": true,
+                "tags": [
+                  {
+                    "key": "container_name",
+                    "value": "machine"
+                  }
+                ]
+              },
+              {
+                "alias": "",
+                "column": "value",
+                "fields": [
+                  {
+                    "func": "mean",
+                    "name": "value"
+                  }
+                ],
+                "function": "mean",
+                "groupByTags": [
+                  "hostname"
+                ],
+                "interval": "10s",
+                "measurement": "filesystem/usage_bytes_gauge",
+                "query": "SELECT hostname, mean(value) FROM \"filesystem/usage_bytes_gauge\" WHERE \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval), \"hostname\"",
+                "rawQuery": true,
+                "tags": [
+                  {
+                    "key": "container_name",
+                    "value": "machine"
+                  }
+                ]
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "",
+            "tooltip": {
+              "shared": true,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "x-axis": true,
+            "y-axis": true,
+            "y_formats": [
+              "bytes",
+              "bytes"
+            ]
+          }
+        ],
+        "showTitle": true,
+        "title": "Disk Usage Group By Node"
+      },
+      {
+        "collapse": false,
+        "editable": true,
+        "height": "250px",
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": "influxdb-datasource",
+            "decimals": 2,
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {
+              "leftLogBase": 1,
+              "leftMax": null,
+              "leftMin": null,
+              "rightLogBase": 1,
+              "rightMax": null,
+              "rightMin": null,
+              "threshold1": null,
+              "threshold1Color": "rgba(216, 200, 27, 0.27)",
+              "threshold2": null,
+              "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "id": 10,
+            "legend": {
+              "avg": true,
+              "current": true,
+              "max": true,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 2,
+            "links": [],
+            "minSpan": 6,
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": "node",
+            "scopedVars": {
+            },
+            "seriesOverrides": [
+              {
+                "alias": "Used Disk",
+                "yaxis": 2
+              }
+            ],
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "alias": "Limit",
+                "column": "value",
+                "fields": [
+                  {
+                    "func": "mean",
+                    "name": "value"
+                  }
+                ],
+                "function": "mean",
+                "groupByTags": [],
+                "query": "SELECT last(value) FROM \"filesystem/limit_bytes_gauge\" WHERE \"hostname\" =~ /$node/ AND \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval)",
+                "rawQuery": true,
+                "tags": []
+              },
+              {
+                "alias": "Usage",
+                "column": "value",
+                "fields": [
+                  {
+                    "func": "mean",
+                    "name": "value"
+                  }
+                ],
+                "function": "mean",
+                "groupByTags": [],
+                "query": "SELECT last(value) FROM \"filesystem/usage_bytes_gauge\" WHERE \"hostname\" =~ /$node/ AND \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval)",
+                "rawQuery": true,
+                "tags": []
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "$node Disk Usage",
+            "tooltip": {
+              "shared": true,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "x-axis": true,
+            "y-axis": true,
+            "y_formats": [
+              "bytes",
+              "bytes"
+            ]
+          }
+        ],
+        "showTitle": true,
+        "title": "Individual Node Disk Usage"
+      }
+    ],
+    "nav": [
+      {
+        "collapse": false,
+        "enable": true,
+        "notice": false,
+        "now": true,
+        "refresh_intervals": [
+          "5s",
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h",
+          "2h",
+          "1d"
+        ],
+        "status": "Stable",
+        "time_options": [
+          "5m",
+          "15m",
+          "1h",
+          "6h",
+          "12h",
+          "24h",
+          "2d",
+          "7d",
+          "30d"
+        ],
+        "type": "timepicker"
+      }
+    ],
+    "time": {
+      "from": "now-5m",
+      "to": "now"
+    },
+    "templating": {
+      "list": [
+        {
+          "allFormat": "glob",
+          "current": {
+          },
+          "datasource": "influxdb-datasource",
+          "includeAll": true,
+          "label": "Node",
+          "multi": false,
+          "multiFormat": "glob",
+          "name": "node",
+          "options": [
+          ],
+          "query": "select distinct(hostname) from \"memory/limit_bytes_gauge\" where time > now() - 10m",
+          "refresh": true,
+          "refresh_on_load": true,
+          "regex": "",
+          "type": "query",
+          "useTags": false
+        }
+      ]
+    },
+    "annotations": {
+      "list": []
+    },
+    "schemaVersion": 6,
+    "version": 8,
+    "links": []
+  }
+}

--- a/grafana/dashboards/containers.json
+++ b/grafana/dashboards/containers.json
@@ -1,0 +1,267 @@
+{
+  "dashboard":
+  {
+    "title": "Containers",
+    "originalTitle": "Containers",
+    "tags": [],
+    "style": "dark",
+    "timezone": "browser",
+    "editable": true,
+    "hideControls": false,
+    "sharedCrosshair": false,
+    "rows": [
+      {
+        "collapse": false,
+        "editable": true,
+        "height": "250px",
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": "influxdb-datasource",
+            "decimals": 2,
+            "editable": true,
+            "error": false,
+            "fill": 3,
+            "grid": {
+              "leftLogBase": 1,
+              "leftMax": null,
+              "leftMin": null,
+              "rightLogBase": 1,
+              "rightMax": null,
+              "rightMin": null,
+              "threshold1": null,
+              "threshold1Color": "rgba(216, 200, 27, 0.27)",
+              "threshold2": null,
+              "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "hideTimeOverride": false,
+            "id": 1,
+            "interval": "10s",
+            "legend": {
+              "avg": false,
+              "current": true,
+              "max": true,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 3,
+            "links": [],
+            "minSpan": 4,
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": "container",
+            "scopedVars": {
+              "container": {
+              }
+            },
+            "seriesOverrides": [
+              {},
+              {
+                "alias": "Used Memory",
+                "yaxis": 1
+              }
+            ],
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "alias": "Limit",
+                "column": "value",
+                "fields": [
+                  {
+                    "func": "last",
+                    "name": "value"
+                  }
+                ],
+                "fill": "",
+                "function": "mean",
+                "groupByTags": [],
+                "hide": false,
+                "interval": "10s",
+                "measurement": "memory/limit_bytes_gauge",
+                "query": "SELECT last(value) FROM \"memory/limit_bytes_gauge\" WHERE container_name =~ /$container/ AND $timeFilter GROUP BY time($interval)",
+                "rawQuery": true,
+                "tags": [
+                  {
+                    "key": "container_name",
+                    "value": "/$container/"
+                  }
+                ]
+              },
+              {
+                "alias": "Usage",
+                "column": "value",
+                "fields": [
+                  {
+                    "func": "last",
+                    "name": "value"
+                  }
+                ],
+                "fill": "null",
+                "function": "mean",
+                "groupByTags": [],
+                "hide": false,
+                "interval": "10s",
+                "measurement": "memory/usage_bytes_gauge",
+                "query": "SELECT mean(value) FROM \"memory/usage_bytes_gauge\" WHERE \"container_name\" =~ /$container/ AND $timeFilter GROUP BY time($interval)",
+                "rawQuery": true,
+                "tags": [
+                  {
+                    "key": "container_name",
+                    "value": "/$container/"
+                  }
+                ]
+              },
+              {
+                "alias": "Working Set",
+                "column": "value",
+                "fields": [
+                  {
+                    "func": "last",
+                    "name": "value"
+                  }
+                ],
+                "fill": "null",
+                "function": "mean",
+                "groupByTags": [],
+                "hide": false,
+                "interval": "10s",
+                "measurement": "memory/working_set_bytes_gauge",
+                "query": "SELECT mean(value) FROM \"memory/working_set_bytes_gauge\" WHERE \"container_name\" =~ /$container/ AND $timeFilter GROUP BY time($interval)",
+                "rawQuery": true,
+                "tags": [
+                  {
+                    "key": "container_name",
+                    "value": "/$container/"
+                  }
+                ]
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Container \"$container\" Memory Usage",
+            "tooltip": {
+              "shared": true,
+              "value_type": "cumulative"
+            },
+            "transparent": false,
+            "type": "graph",
+            "x-axis": true,
+            "y-axis": true,
+            "y_formats": [
+              "bytes",
+              "short"
+            ]
+          }
+        ],
+        "title": "Container Memory"
+      }
+    ],
+    "nav": [
+      {
+        "collapse": false,
+        "enable": true,
+        "notice": false,
+        "now": true,
+        "refresh_intervals": [
+          "5s",
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h",
+          "2h",
+          "1d"
+        ],
+        "status": "Stable",
+        "time_options": [
+          "5m",
+          "15m",
+          "1h",
+          "6h",
+          "12h",
+          "24h",
+          "2d",
+          "7d",
+          "30d"
+        ],
+        "type": "timepicker"
+      }
+    ],
+    "time": {
+      "from": "now-5m",
+      "to": "now"
+    },
+    "templating": {
+      "list": [
+        {
+          "allFormat": "regex wildcard",
+          "current": {
+          },
+          "datasource": "influxdb-datasource",
+          "includeAll": true,
+          "multi": false,
+          "multiFormat": "glob",
+          "name": "namespace",
+          "options": [
+          ],
+          "query": "select distinct(pod_namespace) from \"uptime_ms_cumulative\" where time > now() - 1m",
+          "refresh": true,
+          "refresh_on_load": true,
+          "type": "query",
+          "useTags": false
+        },
+        {
+          "allFormat": "regex wildcard",
+          "current": {
+          },
+          "datasource": "influxdb-datasource",
+          "includeAll": true,
+          "multi": false,
+          "multiFormat": "glob",
+          "name": "pod",
+          "options": [
+          ],
+          "query": "select distinct(pod_name) FROM \"uptime_ms_cumulative\" where pod_namespace =~ /$namespace/ and time > now() - 1m",
+          "refresh": true,
+          "refresh_on_load": true,
+          "type": "query",
+          "useTags": false
+        },
+        {
+          "allFormat": "glob",
+          "current": {
+          },
+          "datasource": "influxdb-datasource",
+          "includeAll": true,
+          "multi": false,
+          "multiFormat": "glob",
+          "name": "container",
+          "options": [
+          ],
+          "query": "select distinct(container_name) from \"uptime_ms_cumulative\" where pod_name =~ /$pod/ and \"pod_namespace\" =~ /$namespace/ and time > now() - 1m",
+          "refresh": true,
+          "refresh_on_load": true,
+          "type": "query",
+          "useTags": false
+        }
+      ]
+    },
+    "annotations": {
+      "list": []
+    },
+    "schemaVersion": 6,
+    "version": 6,
+    "links": []
+  }
+}

--- a/grafana/run.sh
+++ b/grafana/run.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+HEADER_CONTENT_TYPE="Content-Type: application/json"
+HEADER_ACCEPT="Accept: application/json"
+
+GRAFANA_USER=${GRAFANA_USER:-admin}
+GRAFANA_PASSWD=${GRAFANA_PASSWD:-admin}
+GRAFANA_PORT=${GRAFANA_PORT:-3000}
+
+INFLUXDB_HOST=${INFLUXDB_HOST:-"monitoring-influxdb"}
+INFLUXDB_DATABASE=${INFLUXDB_DATABASE:-k8s}
+INFLUXDB_PASSWORD=${INFLUXDB_PASSWORD:-root}
+INFLUXDB_PORT=${INFLUXDB_PORT:-8086}
+INFLUXDB_USER=${INFLUXDB_USER:-root}
+
+DASHBOARD_LOCATION=${DASHBOARD_LOCATION:-"/dashboards"}
+
+# Allow access to dashboards without having to log in
+export GF_AUTH_ANONYMOUS_ENABLED=true
+export GF_SERVER_HTTP_PORT=${GRAFANA_PORT}
+
+BACKEND_ACCESS_MODE=${BACKEND_ACCESS_MODE:-proxy}
+INFLUXDB_SERVICE_URL=${INFLUXDB_SERVICE_URL}
+if [ -n "$INFLUXDB_SERVICE_URL" ]; then
+  echo "Influxdb service URL is provided."
+else
+  INFLUXDB_SERVICE_URL="http://${INFLUXDB_HOST}:${INFLUXDB_PORT}"
+fi
+
+echo "Using the following URL for InfluxDB: ${INFLUXDB_SERVICE_URL}"
+echo "Using the following backend access mode for InfluxDB: ${BACKEND_ACCESS_MODE}"
+
+set -m
+echo "Starting Grafana in the background"
+exec /usr/sbin/grafana-server --config=/etc/grafana/grafana.ini cfg:default.paths.data=/var/lib/grafana cfg:default.paths.logs=/var/log/grafana &
+
+echo "Waiting for Grafana to come up..."
+until $(curl --fail --output /dev/null --silent http://${GRAFANA_USER}:${GRAFANA_PASSWD}@localhost:${GRAFANA_PORT}/api/org); do
+  printf "."
+  sleep 2
+done
+echo "Grafana is up and running."
+echo "Creating default influxdb datasource..."
+curl -i -XPOST -H "${HEADER_ACCEPT}" -H "${HEADER_CONTENT_TYPE}" "http://${GRAFANA_USER}:${GRAFANA_PASSWD}@localhost:${GRAFANA_PORT}/api/datasources" -d '
+{ 
+  "name": "influxdb-datasource",
+  "type": "influxdb_08",
+  "access": "'"${BACKEND_ACCESS_MODE}"'",
+  "isDefault": true,
+  "url": "'"${INFLUXDB_SERVICE_URL}"'",
+  "password": "'"${INFLUXDB_PASSWORD}"'",
+  "user": "'"${INFLUXDB_USER}"'",
+  "database": "'"${INFLUXDB_DATABASE}"'"
+}'
+
+echo ""
+echo "Importing default dashboards..."
+for filename in ${DASHBOARD_LOCATION}/*.json; do
+  echo "Importing ${filename} ..."
+  curl -i -XPOST --data "@${filename}" -H "${HEADER_ACCEPT}" -H "${HEADER_CONTENT_TYPE}" "http://${GRAFANA_USER}:${GRAFANA_PASSWD}@localhost:${GRAFANA_PORT}/api/dashboards/db"
+  echo ""
+  echo "Done importing ${filename}"
+done
+echo ""
+echo "Bringing Grafana back to the foreground"
+fg
+


### PR DESCRIPTION
    - Create a datasource for InfluxDB during startup.
    - Import a couple of default dashboards, which use templating to discover hosts, pods and containers.