### PR TITLE
Support BearerToken authentication with Kubelets

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -323,8 +323,7 @@
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/unversioned",
-			"Comment": "v1.1.0-alpha.1-1078-gb07b991",
-			"Rev": "b07b9918ce6b18614f0e93bfe2cbc98b6590eef5"
+		        "Rev": "5ad24837841e585ee9e821eba6a6cb376f4c3120"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/controller/framework",
@@ -358,8 +357,7 @@
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util",
-			"Comment": "v1.1.0-alpha.1-1078-gb07b991",
-			"Rev": "b07b9918ce6b18614f0e93bfe2cbc98b6590eef5"
+			"Rev": "5ad24837841e585ee9e821eba6a6cb376f4c3120"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/version",

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/auth/clientauth_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/auth/clientauth_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth_test
+
+import (
+	"io/ioutil"
+	"os"
+	"reflect"
+	"testing"
+
+	clientauth "k8s.io/kubernetes/pkg/client/unversioned/auth"
+)
+
+func TestLoadFromFile(t *testing.T) {
+	loadAuthInfoTests := []struct {
+		authData  string
+		authInfo  *clientauth.Info
+		expectErr bool
+	}{
+		{
+			`{"user": "user", "password": "pass"}`,
+			&clientauth.Info{User: "user", Password: "pass"},
+			false,
+		},
+		{
+			"", nil, true,
+		},
+	}
+	for _, loadAuthInfoTest := range loadAuthInfoTests {
+		tt := loadAuthInfoTest
+		aifile, err := ioutil.TempFile("", "testAuthInfo")
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		if tt.authData != "missing" {
+			defer os.Remove(aifile.Name())
+			defer aifile.Close()
+			_, err = aifile.WriteString(tt.authData)
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+		} else {
+			aifile.Close()
+			os.Remove(aifile.Name())
+		}
+		authInfo, err := clientauth.LoadFromFile(aifile.Name())
+		gotErr := err != nil
+		if gotErr != tt.expectErr {
+			t.Errorf("expected errorness: %v, actual errorness: %v", tt.expectErr, gotErr)
+		}
+		if !reflect.DeepEqual(authInfo, tt.authInfo) {
+			t.Errorf("Expected %v, got %v", tt.authInfo, authInfo)
+		}
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/client_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/client_test.go
@@ -1,0 +1,354 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/emicklei/go-restful/swagger"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/version"
+)
+
+const nameRequiredError = "resource name may not be empty"
+
+type testRequest struct {
+	Method  string
+	Path    string
+	Header  string
+	Query   url.Values
+	Body    runtime.Object
+	RawBody *string
+}
+
+type Response struct {
+	StatusCode int
+	Body       runtime.Object
+	RawBody    *string
+}
+
+type testClient struct {
+	*Client
+	Request  testRequest
+	Response Response
+	Error    bool
+	Created  bool
+	Version  string
+	server   *httptest.Server
+	handler  *util.FakeHandler
+	// For query args, an optional function to validate the contents
+	// useful when the contents can change but still be correct.
+	// Maps from query arg key to validator.
+	// If no validator is present, string equality is used.
+	QueryValidator map[string]func(string, string) bool
+}
+
+func (c *testClient) Setup(t *testing.T) *testClient {
+	c.handler = &util.FakeHandler{
+		StatusCode: c.Response.StatusCode,
+	}
+	if responseBody := body(t, c.Response.Body, c.Response.RawBody); responseBody != nil {
+		c.handler.ResponseBody = *responseBody
+	}
+	c.server = httptest.NewServer(c.handler)
+	if c.Client == nil {
+		version := c.Version
+		if len(version) == 0 {
+			version = testapi.Default.Version()
+		}
+		c.Client = NewOrDie(&Config{
+			Host:    c.server.URL,
+			Version: version,
+		})
+
+		// TODO: caesarxuchao: hacky way to specify version of Experimental client.
+		// We will fix this by supporting multiple group versions in Config
+		version = c.Version
+		if len(version) == 0 {
+			version = testapi.Experimental.Version()
+		}
+		c.ExperimentalClient = NewExperimentalOrDie(&Config{
+			Host:    c.server.URL,
+			Version: version,
+		})
+	}
+	c.QueryValidator = map[string]func(string, string) bool{}
+	return c
+}
+
+func (c *testClient) Validate(t *testing.T, received runtime.Object, err error) {
+	c.ValidateCommon(t, err)
+
+	if c.Response.Body != nil && !api.Semantic.DeepDerivative(c.Response.Body, received) {
+		t.Errorf("bad response for request %#v: expected %#v, got %#v", c.Request, c.Response.Body, received)
+	}
+}
+
+func (c *testClient) ValidateRaw(t *testing.T, received []byte, err error) {
+	c.ValidateCommon(t, err)
+
+	if c.Response.Body != nil && !reflect.DeepEqual(c.Response.Body, received) {
+		t.Errorf("bad response for request %#v: expected %#v, got %#v", c.Request, c.Response.Body, received)
+	}
+}
+
+func (c *testClient) ValidateCommon(t *testing.T, err error) {
+	defer c.server.Close()
+
+	if c.Error {
+		if err == nil {
+			t.Errorf("error expected for %#v, got none", c.Request)
+		}
+		return
+	}
+	if err != nil {
+		t.Errorf("no error expected for %#v, got: %v", c.Request, err)
+	}
+
+	if c.handler.RequestReceived == nil {
+		t.Errorf("handler had an empty request, %#v", c)
+		return
+	}
+
+	requestBody := body(t, c.Request.Body, c.Request.RawBody)
+	actualQuery := c.handler.RequestReceived.URL.Query()
+	t.Logf("got query: %v", actualQuery)
+	t.Logf("path: %v", c.Request.Path)
+	// We check the query manually, so blank it out so that FakeHandler.ValidateRequest
+	// won't check it.
+	c.handler.RequestReceived.URL.RawQuery = ""
+	c.handler.ValidateRequest(t, path.Join(c.Request.Path), c.Request.Method, requestBody)
+	for key, values := range c.Request.Query {
+		validator, ok := c.QueryValidator[key]
+		if !ok {
+			switch key {
+			case api.LabelSelectorQueryParam(testapi.Default.Version()):
+				validator = validateLabels
+			case api.FieldSelectorQueryParam(testapi.Default.Version()):
+				validator = validateFields
+			default:
+				validator = func(a, b string) bool { return a == b }
+			}
+		}
+		observed := actualQuery.Get(key)
+		wanted := strings.Join(values, "")
+		if !validator(wanted, observed) {
+			t.Errorf("Unexpected query arg for key: %s.  Expected %s, Received %s", key, wanted, observed)
+		}
+	}
+	if c.Request.Header != "" {
+		if c.handler.RequestReceived.Header.Get(c.Request.Header) == "" {
+			t.Errorf("header %q not found in request %#v", c.Request.Header, c.handler.RequestReceived)
+		}
+	}
+
+	if expected, received := requestBody, c.handler.RequestBody; expected != nil && *expected != received {
+		t.Errorf("bad body for request %#v: expected %s, got %s", c.Request, *expected, received)
+	}
+}
+
+// buildResourcePath is a convenience function for knowing if a namespace should be in a path param or not
+func buildResourcePath(namespace, resource string) string {
+	if len(namespace) > 0 {
+		return path.Join("namespaces", namespace, resource)
+	}
+	return resource
+}
+
+// buildQueryValues is a convenience function for knowing if a namespace should be in a query param or not
+func buildQueryValues(query url.Values) url.Values {
+	v := url.Values{}
+	if query != nil {
+		for key, values := range query {
+			for _, value := range values {
+				v.Add(key, value)
+			}
+		}
+	}
+	return v
+}
+
+func validateLabels(a, b string) bool {
+	sA, eA := labels.Parse(a)
+	if eA != nil {
+		return false
+	}
+	sB, eB := labels.Parse(b)
+	if eB != nil {
+		return false
+	}
+	return sA.String() == sB.String()
+}
+
+func validateFields(a, b string) bool {
+	sA, _ := fields.ParseSelector(a)
+	sB, _ := fields.ParseSelector(b)
+	return sA.String() == sB.String()
+}
+
+func body(t *testing.T, obj runtime.Object, raw *string) *string {
+	if obj != nil {
+		_, kind, err := api.Scheme.ObjectVersionAndKind(obj)
+		if err != nil {
+			t.Errorf("unexpected encoding error: %v", err)
+		}
+		// TODO: caesarxuchao: we should detect which group an object belongs to
+		// by using the version returned by Schem.ObjectVersionAndKind() once we
+		// split the schemes for internal objects.
+		// TODO: caesarxuchao: we should add a map from kind to group in Scheme.
+		var bs []byte
+		if api.Scheme.Recognizes(testapi.Default.GroupAndVersion(), kind) {
+			bs, err = testapi.Default.Codec().Encode(obj)
+			if err != nil {
+				t.Errorf("unexpected encoding error: %v", err)
+			}
+		} else if api.Scheme.Recognizes(testapi.Experimental.GroupAndVersion(), kind) {
+			bs, err = testapi.Experimental.Codec().Encode(obj)
+			if err != nil {
+				t.Errorf("unexpected encoding error: %v", err)
+			}
+		} else {
+			t.Errorf("unexpected kind: %v", kind)
+		}
+		body := string(bs)
+		return &body
+	}
+	return raw
+}
+
+func TestGetServerVersion(t *testing.T) {
+	expect := version.Info{
+		Major:     "foo",
+		Minor:     "bar",
+		GitCommit: "baz",
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		output, err := json.Marshal(expect)
+		if err != nil {
+			t.Errorf("unexpected encoding error: %v", err)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(output)
+	}))
+	client := NewOrDie(&Config{Host: server.URL})
+
+	got, err := client.ServerVersion()
+	if err != nil {
+		t.Fatalf("unexpected encoding error: %v", err)
+	}
+	if e, a := expect, *got; !reflect.DeepEqual(e, a) {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+}
+
+func TestGetServerAPIVersions(t *testing.T) {
+	versions := []string{"v1", "v2", "v3"}
+	expect := api.APIVersions{Versions: versions}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		output, err := json.Marshal(expect)
+		if err != nil {
+			t.Errorf("unexpected encoding error: %v", err)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(output)
+	}))
+	client := NewOrDie(&Config{Host: server.URL})
+	got, err := client.ServerAPIVersions()
+	if err != nil {
+		t.Fatalf("unexpected encoding error: %v", err)
+	}
+	if e, a := expect, *got; !reflect.DeepEqual(e, a) {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+}
+
+func swaggerSchemaFakeServer() (*httptest.Server, error) {
+	request := 1
+	var sErr error
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		var resp interface{}
+		if request == 1 {
+			resp = api.APIVersions{Versions: []string{"v1", "v2", "v3"}}
+			request++
+		} else {
+			resp = swagger.ApiDeclaration{}
+		}
+		output, err := json.Marshal(resp)
+		if err != nil {
+			sErr = err
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(output)
+	}))
+	return server, sErr
+}
+
+func TestGetSwaggerSchema(t *testing.T) {
+	expect := swagger.ApiDeclaration{}
+
+	server, err := swaggerSchemaFakeServer()
+	if err != nil {
+		t.Errorf("unexpected encoding error: %v", err)
+	}
+
+	client := NewOrDie(&Config{Host: server.URL})
+	got, err := client.SwaggerSchema("v1")
+	if err != nil {
+		t.Fatalf("unexpected encoding error: %v", err)
+	}
+	if e, a := expect, *got; !reflect.DeepEqual(e, a) {
+		t.Errorf("expected %v, got %v", e, a)
+	}
+}
+
+func TestGetSwaggerSchemaFail(t *testing.T) {
+	expErr := "API version: v4 is not supported by the server. Use one of: [v1 v2 v3]"
+
+	server, err := swaggerSchemaFakeServer()
+	if err != nil {
+		t.Errorf("unexpected encoding error: %v", err)
+	}
+
+	client := NewOrDie(&Config{Host: server.URL})
+	got, err := client.SwaggerSchema("v4")
+	if got != nil {
+		t.Fatalf("unexpected response: %v", got)
+	}
+	if err.Error() != expErr {
+		t.Errorf("expected an error, got %v", err)
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api/helpers_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api/helpers_test.go
@@ -1,0 +1,301 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/ghodss/yaml"
+)
+
+func newMergedConfig(certFile, certContent, keyFile, keyContent, caFile, caContent string, t *testing.T) Config {
+	if err := ioutil.WriteFile(certFile, []byte(certContent), 0644); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if err := ioutil.WriteFile(keyFile, []byte(keyContent), 0600); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if err := ioutil.WriteFile(caFile, []byte(caContent), 0644); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	return Config{
+		AuthInfos: map[string]*AuthInfo{
+			"red-user":  {Token: "red-token", ClientCertificateData: []byte(certContent), ClientKeyData: []byte(keyContent)},
+			"blue-user": {Token: "blue-token", ClientCertificate: certFile, ClientKey: keyFile}},
+		Clusters: map[string]*Cluster{
+			"cow-cluster":     {Server: "http://cow.org:8080", CertificateAuthorityData: []byte(caContent)},
+			"chicken-cluster": {Server: "http://chicken.org:8080", CertificateAuthority: caFile}},
+		Contexts: map[string]*Context{
+			"federal-context": {AuthInfo: "red-user", Cluster: "cow-cluster"},
+			"shaker-context":  {AuthInfo: "blue-user", Cluster: "chicken-cluster"}},
+		CurrentContext: "federal-context",
+	}
+}
+
+func TestMinifySuccess(t *testing.T) {
+	certFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(certFile.Name())
+	keyFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(keyFile.Name())
+	caFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(caFile.Name())
+
+	mutatingConfig := newMergedConfig(certFile.Name(), "cert", keyFile.Name(), "key", caFile.Name(), "ca", t)
+
+	if err := MinifyConfig(&mutatingConfig); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if len(mutatingConfig.Contexts) > 1 {
+		t.Errorf("unexpected contexts: %v", mutatingConfig.Contexts)
+	}
+	if _, exists := mutatingConfig.Contexts["federal-context"]; !exists {
+		t.Errorf("missing context")
+	}
+
+	if len(mutatingConfig.Clusters) > 1 {
+		t.Errorf("unexpected clusters: %v", mutatingConfig.Clusters)
+	}
+	if _, exists := mutatingConfig.Clusters["cow-cluster"]; !exists {
+		t.Errorf("missing cluster")
+	}
+
+	if len(mutatingConfig.AuthInfos) > 1 {
+		t.Errorf("unexpected users: %v", mutatingConfig.AuthInfos)
+	}
+	if _, exists := mutatingConfig.AuthInfos["red-user"]; !exists {
+		t.Errorf("missing user")
+	}
+}
+
+func TestMinifyMissingContext(t *testing.T) {
+	certFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(certFile.Name())
+	keyFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(keyFile.Name())
+	caFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(caFile.Name())
+
+	mutatingConfig := newMergedConfig(certFile.Name(), "cert", keyFile.Name(), "key", caFile.Name(), "ca", t)
+	mutatingConfig.CurrentContext = "missing"
+
+	errMsg := "cannot locate context missing"
+
+	if err := MinifyConfig(&mutatingConfig); err == nil || err.Error() != errMsg {
+		t.Errorf("expected %v, got %v", errMsg, err)
+	}
+}
+
+func TestMinifyMissingCluster(t *testing.T) {
+	certFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(certFile.Name())
+	keyFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(keyFile.Name())
+	caFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(caFile.Name())
+
+	mutatingConfig := newMergedConfig(certFile.Name(), "cert", keyFile.Name(), "key", caFile.Name(), "ca", t)
+	delete(mutatingConfig.Clusters, mutatingConfig.Contexts[mutatingConfig.CurrentContext].Cluster)
+
+	errMsg := "cannot locate cluster cow-cluster"
+
+	if err := MinifyConfig(&mutatingConfig); err == nil || err.Error() != errMsg {
+		t.Errorf("expected %v, got %v", errMsg, err)
+	}
+}
+
+func TestMinifyMissingAuthInfo(t *testing.T) {
+	certFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(certFile.Name())
+	keyFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(keyFile.Name())
+	caFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(caFile.Name())
+
+	mutatingConfig := newMergedConfig(certFile.Name(), "cert", keyFile.Name(), "key", caFile.Name(), "ca", t)
+	delete(mutatingConfig.AuthInfos, mutatingConfig.Contexts[mutatingConfig.CurrentContext].AuthInfo)
+
+	errMsg := "cannot locate user red-user"
+
+	if err := MinifyConfig(&mutatingConfig); err == nil || err.Error() != errMsg {
+		t.Errorf("expected %v, got %v", errMsg, err)
+	}
+}
+
+func TestFlattenSuccess(t *testing.T) {
+	certFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(certFile.Name())
+	keyFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(keyFile.Name())
+	caFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(caFile.Name())
+
+	certData := "cert"
+	keyData := "key"
+	caData := "ca"
+
+	unchangingCluster := "cow-cluster"
+	unchangingAuthInfo := "red-user"
+	changingCluster := "chicken-cluster"
+	changingAuthInfo := "blue-user"
+
+	startingConfig := newMergedConfig(certFile.Name(), certData, keyFile.Name(), keyData, caFile.Name(), caData, t)
+	mutatingConfig := startingConfig
+
+	if err := FlattenConfig(&mutatingConfig); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if len(mutatingConfig.Contexts) != 2 {
+		t.Errorf("unexpected contexts: %v", mutatingConfig.Contexts)
+	}
+	if !reflect.DeepEqual(startingConfig.Contexts, mutatingConfig.Contexts) {
+		t.Errorf("expected %v, got %v", startingConfig.Contexts, mutatingConfig.Contexts)
+	}
+
+	if len(mutatingConfig.Clusters) != 2 {
+		t.Errorf("unexpected clusters: %v", mutatingConfig.Clusters)
+	}
+	if !reflect.DeepEqual(startingConfig.Clusters[unchangingCluster], mutatingConfig.Clusters[unchangingCluster]) {
+		t.Errorf("expected %v, got %v", startingConfig.Clusters[unchangingCluster], mutatingConfig.Clusters[unchangingCluster])
+	}
+	if len(mutatingConfig.Clusters[changingCluster].CertificateAuthority) != 0 {
+		t.Errorf("unexpected caFile")
+	}
+	if string(mutatingConfig.Clusters[changingCluster].CertificateAuthorityData) != caData {
+		t.Errorf("expected %v, got %v", caData, string(mutatingConfig.Clusters[changingCluster].CertificateAuthorityData))
+	}
+
+	if len(mutatingConfig.AuthInfos) != 2 {
+		t.Errorf("unexpected users: %v", mutatingConfig.AuthInfos)
+	}
+	if !reflect.DeepEqual(startingConfig.AuthInfos[unchangingAuthInfo], mutatingConfig.AuthInfos[unchangingAuthInfo]) {
+		t.Errorf("expected %v, got %v", startingConfig.AuthInfos[unchangingAuthInfo], mutatingConfig.AuthInfos[unchangingAuthInfo])
+	}
+	if len(mutatingConfig.AuthInfos[changingAuthInfo].ClientCertificate) != 0 {
+		t.Errorf("unexpected caFile")
+	}
+	if string(mutatingConfig.AuthInfos[changingAuthInfo].ClientCertificateData) != certData {
+		t.Errorf("expected %v, got %v", certData, string(mutatingConfig.AuthInfos[changingAuthInfo].ClientCertificateData))
+	}
+	if len(mutatingConfig.AuthInfos[changingAuthInfo].ClientKey) != 0 {
+		t.Errorf("unexpected caFile")
+	}
+	if string(mutatingConfig.AuthInfos[changingAuthInfo].ClientKeyData) != keyData {
+		t.Errorf("expected %v, got %v", keyData, string(mutatingConfig.AuthInfos[changingAuthInfo].ClientKeyData))
+	}
+
+}
+
+func ExampleMinifyAndShorten() {
+	certFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(certFile.Name())
+	keyFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(keyFile.Name())
+	caFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(caFile.Name())
+
+	certData := "cert"
+	keyData := "key"
+	caData := "ca"
+
+	config := newMergedConfig(certFile.Name(), certData, keyFile.Name(), keyData, caFile.Name(), caData, nil)
+
+	MinifyConfig(&config)
+	ShortenConfig(&config)
+
+	output, _ := yaml.Marshal(config)
+	fmt.Printf("%s", string(output))
+	// Output:
+	// clusters:
+	//   cow-cluster:
+	//     LocationOfOrigin: ""
+	//     certificate-authority-data: REDACTED
+	//     server: http://cow.org:8080
+	// contexts:
+	//   federal-context:
+	//     LocationOfOrigin: ""
+	//     cluster: cow-cluster
+	//     user: red-user
+	// current-context: federal-context
+	// preferences: {}
+	// users:
+	//   red-user:
+	//     LocationOfOrigin: ""
+	//     client-certificate-data: REDACTED
+	//     client-key-data: REDACTED
+	//     token: red-token
+}
+
+func TestShortenSuccess(t *testing.T) {
+	certFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(certFile.Name())
+	keyFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(keyFile.Name())
+	caFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(caFile.Name())
+
+	certData := "cert"
+	keyData := "key"
+	caData := "ca"
+
+	unchangingCluster := "chicken-cluster"
+	unchangingAuthInfo := "blue-user"
+	changingCluster := "cow-cluster"
+	changingAuthInfo := "red-user"
+
+	startingConfig := newMergedConfig(certFile.Name(), certData, keyFile.Name(), keyData, caFile.Name(), caData, t)
+	mutatingConfig := startingConfig
+
+	ShortenConfig(&mutatingConfig)
+
+	if len(mutatingConfig.Contexts) != 2 {
+		t.Errorf("unexpected contexts: %v", mutatingConfig.Contexts)
+	}
+	if !reflect.DeepEqual(startingConfig.Contexts, mutatingConfig.Contexts) {
+		t.Errorf("expected %v, got %v", startingConfig.Contexts, mutatingConfig.Contexts)
+	}
+
+	redacted := string(redactedBytes)
+	if len(mutatingConfig.Clusters) != 2 {
+		t.Errorf("unexpected clusters: %v", mutatingConfig.Clusters)
+	}
+	if !reflect.DeepEqual(startingConfig.Clusters[unchangingCluster], mutatingConfig.Clusters[unchangingCluster]) {
+		t.Errorf("expected %v, got %v", startingConfig.Clusters[unchangingCluster], mutatingConfig.Clusters[unchangingCluster])
+	}
+	if string(mutatingConfig.Clusters[changingCluster].CertificateAuthorityData) != redacted {
+		t.Errorf("expected %v, got %v", redacted, string(mutatingConfig.Clusters[changingCluster].CertificateAuthorityData))
+	}
+
+	if len(mutatingConfig.AuthInfos) != 2 {
+		t.Errorf("unexpected users: %v", mutatingConfig.AuthInfos)
+	}
+	if !reflect.DeepEqual(startingConfig.AuthInfos[unchangingAuthInfo], mutatingConfig.AuthInfos[unchangingAuthInfo]) {
+		t.Errorf("expected %v, got %v", startingConfig.AuthInfos[unchangingAuthInfo], mutatingConfig.AuthInfos[unchangingAuthInfo])
+	}
+	if string(mutatingConfig.AuthInfos[changingAuthInfo].ClientCertificateData) != redacted {
+		t.Errorf("expected %v, got %v", redacted, string(mutatingConfig.AuthInfos[changingAuthInfo].ClientCertificateData))
+	}
+	if string(mutatingConfig.AuthInfos[changingAuthInfo].ClientKeyData) != redacted {
+		t.Errorf("expected %v, got %v", redacted, string(mutatingConfig.AuthInfos[changingAuthInfo].ClientKeyData))
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api/types_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api/types_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"fmt"
+
+	"github.com/ghodss/yaml"
+)
+
+func ExampleEmptyConfig() {
+	defaultConfig := NewConfig()
+
+	output, err := yaml.Marshal(defaultConfig)
+	if err != nil {
+		fmt.Printf("Unexpected error: %v", err)
+	}
+
+	fmt.Printf("%v", string(output))
+	// Output:
+	// clusters: {}
+	// contexts: {}
+	// current-context: ""
+	// preferences: {}
+	// users: {}
+}
+
+func ExampleOfOptionsConfig() {
+	defaultConfig := NewConfig()
+	defaultConfig.Preferences.Colors = true
+	defaultConfig.Clusters["alfa"] = &Cluster{
+		Server:                "https://alfa.org:8080",
+		APIVersion:            "v1beta2",
+		InsecureSkipTLSVerify: true,
+		CertificateAuthority:  "path/to/my/cert-ca-filename",
+	}
+	defaultConfig.Clusters["bravo"] = &Cluster{
+		Server:                "https://bravo.org:8080",
+		APIVersion:            "v1beta1",
+		InsecureSkipTLSVerify: false,
+	}
+	defaultConfig.AuthInfos["white-mage-via-cert"] = &AuthInfo{
+		ClientCertificate: "path/to/my/client-cert-filename",
+		ClientKey:         "path/to/my/client-key-filename",
+	}
+	defaultConfig.AuthInfos["red-mage-via-token"] = &AuthInfo{
+		Token: "my-secret-token",
+	}
+	defaultConfig.Contexts["bravo-as-black-mage"] = &Context{
+		Cluster:   "bravo",
+		AuthInfo:  "black-mage-via-file",
+		Namespace: "yankee",
+	}
+	defaultConfig.Contexts["alfa-as-black-mage"] = &Context{
+		Cluster:   "alfa",
+		AuthInfo:  "black-mage-via-file",
+		Namespace: "zulu",
+	}
+	defaultConfig.Contexts["alfa-as-white-mage"] = &Context{
+		Cluster:  "alfa",
+		AuthInfo: "white-mage-via-cert",
+	}
+	defaultConfig.CurrentContext = "alfa-as-white-mage"
+
+	output, err := yaml.Marshal(defaultConfig)
+	if err != nil {
+		fmt.Printf("Unexpected error: %v", err)
+	}
+
+	fmt.Printf("%v", string(output))
+	// Output:
+	// clusters:
+	//   alfa:
+	//     LocationOfOrigin: ""
+	//     api-version: v1beta2
+	//     certificate-authority: path/to/my/cert-ca-filename
+	//     insecure-skip-tls-verify: true
+	//     server: https://alfa.org:8080
+	//   bravo:
+	//     LocationOfOrigin: ""
+	//     api-version: v1beta1
+	//     server: https://bravo.org:8080
+	// contexts:
+	//   alfa-as-black-mage:
+	//     LocationOfOrigin: ""
+	//     cluster: alfa
+	//     namespace: zulu
+	//     user: black-mage-via-file
+	//   alfa-as-white-mage:
+	//     LocationOfOrigin: ""
+	//     cluster: alfa
+	//     user: white-mage-via-cert
+	//   bravo-as-black-mage:
+	//     LocationOfOrigin: ""
+	//     cluster: bravo
+	//     namespace: yankee
+	//     user: black-mage-via-file
+	// current-context: alfa-as-white-mage
+	// preferences:
+	//   colors: true
+	// users:
+	//   red-mage-via-token:
+	//     LocationOfOrigin: ""
+	//     token: my-secret-token
+	//   white-mage-via-cert:
+	//     LocationOfOrigin: ""
+	//     client-certificate: path/to/my/client-cert-filename
+	//     client-key: path/to/my/client-key-filename
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/clientcmd/client_config_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/clientcmd/client_config_test.go
@@ -1,0 +1,254 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clientcmd
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api/testapi"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
+)
+
+func createValidTestConfig() *clientcmdapi.Config {
+	const (
+		server = "https://anything.com:8080"
+		token  = "the-token"
+	)
+
+	config := clientcmdapi.NewConfig()
+	config.Clusters["clean"] = &clientcmdapi.Cluster{
+		Server:     server,
+		APIVersion: testapi.Default.Version(),
+	}
+	config.AuthInfos["clean"] = &clientcmdapi.AuthInfo{
+		Token: token,
+	}
+	config.Contexts["clean"] = &clientcmdapi.Context{
+		Cluster:  "clean",
+		AuthInfo: "clean",
+	}
+	config.CurrentContext = "clean"
+
+	return config
+}
+
+func TestMergeContext(t *testing.T) {
+	const namespace = "overriden-namespace"
+
+	config := createValidTestConfig()
+	clientBuilder := NewNonInteractiveClientConfig(*config, "clean", &ConfigOverrides{})
+
+	_, overridden, err := clientBuilder.Namespace()
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	if overridden {
+		t.Error("Expected namespace to not be overridden")
+	}
+
+	clientBuilder = NewNonInteractiveClientConfig(*config, "clean", &ConfigOverrides{
+		Context: clientcmdapi.Context{
+			Namespace: namespace,
+		},
+	})
+
+	actual, overridden, err := clientBuilder.Namespace()
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	if !overridden {
+		t.Error("Expected namespace to be overridden")
+	}
+
+	matchStringArg(namespace, actual, t)
+}
+
+func TestCertificateData(t *testing.T) {
+	caData := []byte("ca-data")
+	certData := []byte("cert-data")
+	keyData := []byte("key-data")
+
+	config := clientcmdapi.NewConfig()
+	config.Clusters["clean"] = &clientcmdapi.Cluster{
+		Server:                   "https://localhost:8443",
+		APIVersion:               testapi.Default.Version(),
+		CertificateAuthorityData: caData,
+	}
+	config.AuthInfos["clean"] = &clientcmdapi.AuthInfo{
+		ClientCertificateData: certData,
+		ClientKeyData:         keyData,
+	}
+	config.Contexts["clean"] = &clientcmdapi.Context{
+		Cluster:  "clean",
+		AuthInfo: "clean",
+	}
+	config.CurrentContext = "clean"
+
+	clientBuilder := NewNonInteractiveClientConfig(*config, "clean", &ConfigOverrides{})
+
+	clientConfig, err := clientBuilder.ClientConfig()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Make sure cert data gets into config (will override file paths)
+	matchByteArg(caData, clientConfig.TLSClientConfig.CAData, t)
+	matchByteArg(certData, clientConfig.TLSClientConfig.CertData, t)
+	matchByteArg(keyData, clientConfig.TLSClientConfig.KeyData, t)
+}
+
+func TestBasicAuthData(t *testing.T) {
+	username := "myuser"
+	password := "mypass"
+
+	config := clientcmdapi.NewConfig()
+	config.Clusters["clean"] = &clientcmdapi.Cluster{
+		Server:     "https://localhost:8443",
+		APIVersion: testapi.Default.Version(),
+	}
+	config.AuthInfos["clean"] = &clientcmdapi.AuthInfo{
+		Username: username,
+		Password: password,
+	}
+	config.Contexts["clean"] = &clientcmdapi.Context{
+		Cluster:  "clean",
+		AuthInfo: "clean",
+	}
+	config.CurrentContext = "clean"
+
+	clientBuilder := NewNonInteractiveClientConfig(*config, "clean", &ConfigOverrides{})
+
+	clientConfig, err := clientBuilder.ClientConfig()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	// Make sure basic auth data gets into config
+	matchStringArg(username, clientConfig.Username, t)
+	matchStringArg(password, clientConfig.Password, t)
+}
+
+func TestCreateClean(t *testing.T) {
+	config := createValidTestConfig()
+	clientBuilder := NewNonInteractiveClientConfig(*config, "clean", &ConfigOverrides{})
+
+	clientConfig, err := clientBuilder.ClientConfig()
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	matchStringArg(config.Clusters["clean"].Server, clientConfig.Host, t)
+	matchStringArg("", clientConfig.Prefix, t)
+	matchStringArg(config.Clusters["clean"].APIVersion, clientConfig.Version, t)
+	matchBoolArg(config.Clusters["clean"].InsecureSkipTLSVerify, clientConfig.Insecure, t)
+	matchStringArg(config.AuthInfos["clean"].Token, clientConfig.BearerToken, t)
+}
+
+func TestCreateCleanWithPrefix(t *testing.T) {
+	tt := []struct {
+		server string
+		host   string
+		prefix string
+	}{
+		{"https://anything.com:8080/foo/bar", "https://anything.com:8080", "/foo/bar"},
+		{"http://anything.com:8080/foo/bar", "http://anything.com:8080", "/foo/bar"},
+		{"http://anything.com:8080/foo/bar/", "http://anything.com:8080", "/foo/bar/"},
+		{"http://anything.com:8080/", "http://anything.com:8080/", ""},
+		{"http://anything.com:8080//", "http://anything.com:8080", "//"},
+		{"anything.com:8080/foo/bar", "anything.com:8080/foo/bar", ""},
+		{"anything.com:8080", "anything.com:8080", ""},
+		{"anything.com", "anything.com", ""},
+		{"anything", "anything", ""},
+	}
+
+	// WARNING: EnvVarCluster.Server is set during package loading time and can not be overriden by os.Setenv inside this test
+	EnvVarCluster.Server = ""
+	tt = append(tt, struct{ server, host, prefix string }{"", "http://localhost:8080", ""})
+
+	for _, tc := range tt {
+		config := createValidTestConfig()
+
+		cleanConfig := config.Clusters["clean"]
+		cleanConfig.Server = tc.server
+		config.Clusters["clean"] = cleanConfig
+
+		clientBuilder := NewNonInteractiveClientConfig(*config, "clean", &ConfigOverrides{})
+
+		clientConfig, err := clientBuilder.ClientConfig()
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+
+		matchStringArg(tc.host, clientConfig.Host, t)
+		matchStringArg(tc.prefix, clientConfig.Prefix, t)
+	}
+}
+
+func TestCreateCleanDefault(t *testing.T) {
+	config := createValidTestConfig()
+	clientBuilder := NewDefaultClientConfig(*config, &ConfigOverrides{})
+
+	clientConfig, err := clientBuilder.ClientConfig()
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	matchStringArg(config.Clusters["clean"].Server, clientConfig.Host, t)
+	matchStringArg(config.Clusters["clean"].APIVersion, clientConfig.Version, t)
+	matchBoolArg(config.Clusters["clean"].InsecureSkipTLSVerify, clientConfig.Insecure, t)
+	matchStringArg(config.AuthInfos["clean"].Token, clientConfig.BearerToken, t)
+}
+
+func TestCreateMissingContext(t *testing.T) {
+	const expectedErrorContains = "Context was not found for specified context"
+	config := createValidTestConfig()
+	clientBuilder := NewNonInteractiveClientConfig(*config, "not-present", &ConfigOverrides{})
+
+	clientConfig, err := clientBuilder.ClientConfig()
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	expectedConfig := &client.Config{Host: clientConfig.Host}
+
+	if !reflect.DeepEqual(expectedConfig, clientConfig) {
+		t.Errorf("Expected %#v, got %#v", expectedConfig, clientConfig)
+	}
+
+}
+
+func matchBoolArg(expected, got bool, t *testing.T) {
+	if expected != got {
+		t.Errorf("Expected %v, got %v", expected, got)
+	}
+}
+
+func matchStringArg(expected, got string, t *testing.T) {
+	if expected != got {
+		t.Errorf("Expected %q, got %q", expected, got)
+	}
+}
+
+func matchByteArg(expected, got []byte, t *testing.T) {
+	if !reflect.DeepEqual(expected, got) {
+		t.Errorf("Expected %v, got %v", expected, got)
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/clientcmd/doc.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/clientcmd/doc.go
@@ -19,13 +19,19 @@ Package clientcmd provides one stop shopping for building a working client from 
 from a .kubeconfig file, from command line flags, or from any merged combination.
 
 Sample usage from merged .kubeconfig files (local directory, home directory)
-	loadingRules := clientcmd.NewKubeConfigLoadingRules()
+
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	// if you want to change the loading rules (which files in which order), you can do so here
 
 	configOverrides := &clientcmd.ConfigOverrides{}
 	// if you want to change override values or bind them to flags, there are methods to help you
 
-	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingKubeConfig(loadingRules, configOverrides)
-	kubeConfig.Client()
+	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
+	config, err := kubeConfig.ClientConfig()
+	if err != nil {
+		// Do something
+	}
+	client, err := unversioned.New(config)
+	// ...
 */
 package clientcmd

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/clientcmd/loader.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/clientcmd/loader.go
@@ -36,11 +36,14 @@ import (
 const (
 	RecommendedConfigPathFlag   = "kubeconfig"
 	RecommendedConfigPathEnvVar = "KUBECONFIG"
-	RecommendedHomeFileName     = "/.kube/config"
+	RecommendedHomeDir          = ".kube"
+	RecommendedFileName         = "config"
+	RecommendedSchemaName       = "schema"
 )
 
 var OldRecommendedHomeFile = path.Join(os.Getenv("HOME"), "/.kube/.kubeconfig")
-var RecommendedHomeFile = path.Join(os.Getenv("HOME"), RecommendedHomeFileName)
+var RecommendedHomeFile = path.Join(os.Getenv("HOME"), RecommendedHomeDir, RecommendedFileName)
+var RecommendedSchemaFile = path.Join(os.Getenv("HOME"), RecommendedHomeDir, RecommendedSchemaName)
 
 // ClientConfigLoadingRules is an ExplicitPath and string slice of specific locations that are used for merging together a Config
 // Callers can put the chain together however they want, but we'd recommend:

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/clientcmd/loader_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/clientcmd/loader_test.go
@@ -1,0 +1,535 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clientcmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/ghodss/yaml"
+
+	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
+	clientcmdlatest "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api/latest"
+)
+
+var (
+	testConfigAlfa = clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"red-user": {Token: "red-token"}},
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"cow-cluster": {Server: "http://cow.org:8080"}},
+		Contexts: map[string]*clientcmdapi.Context{
+			"federal-context": {AuthInfo: "red-user", Cluster: "cow-cluster", Namespace: "hammer-ns"}},
+	}
+	testConfigBravo = clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"black-user": {Token: "black-token"}},
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"pig-cluster": {Server: "http://pig.org:8080"}},
+		Contexts: map[string]*clientcmdapi.Context{
+			"queen-anne-context": {AuthInfo: "black-user", Cluster: "pig-cluster", Namespace: "saw-ns"}},
+	}
+	testConfigCharlie = clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"green-user": {Token: "green-token"}},
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"horse-cluster": {Server: "http://horse.org:8080"}},
+		Contexts: map[string]*clientcmdapi.Context{
+			"shaker-context": {AuthInfo: "green-user", Cluster: "horse-cluster", Namespace: "chisel-ns"}},
+	}
+	testConfigDelta = clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"blue-user": {Token: "blue-token"}},
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"chicken-cluster": {Server: "http://chicken.org:8080"}},
+		Contexts: map[string]*clientcmdapi.Context{
+			"gothic-context": {AuthInfo: "blue-user", Cluster: "chicken-cluster", Namespace: "plane-ns"}},
+	}
+
+	testConfigConflictAlfa = clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"red-user":    {Token: "a-different-red-token"},
+			"yellow-user": {Token: "yellow-token"}},
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"cow-cluster":    {Server: "http://a-different-cow.org:8080", InsecureSkipTLSVerify: true},
+			"donkey-cluster": {Server: "http://donkey.org:8080", InsecureSkipTLSVerify: true}},
+		CurrentContext: "federal-context",
+	}
+)
+
+func TestNonExistentCommandLineFile(t *testing.T) {
+	loadingRules := ClientConfigLoadingRules{
+		ExplicitPath: "bogus_file",
+	}
+
+	_, err := loadingRules.Load()
+	if err == nil {
+		t.Fatalf("Expected error for missing command-line file, got none")
+	}
+	if !strings.Contains(err.Error(), "bogus_file") {
+		t.Fatalf("Expected error about 'bogus_file', got %s", err.Error())
+	}
+}
+
+func TestToleratingMissingFiles(t *testing.T) {
+	loadingRules := ClientConfigLoadingRules{
+		Precedence: []string{"bogus1", "bogus2", "bogus3"},
+	}
+
+	_, err := loadingRules.Load()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+}
+
+func TestErrorReadingFile(t *testing.T) {
+	commandLineFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(commandLineFile.Name())
+
+	if err := ioutil.WriteFile(commandLineFile.Name(), []byte("bogus value"), 0644); err != nil {
+		t.Fatalf("Error creating tempfile: %v", err)
+	}
+
+	loadingRules := ClientConfigLoadingRules{
+		ExplicitPath: commandLineFile.Name(),
+	}
+
+	_, err := loadingRules.Load()
+	if err == nil {
+		t.Fatalf("Expected error for unloadable file, got none")
+	}
+	if !strings.Contains(err.Error(), commandLineFile.Name()) {
+		t.Fatalf("Expected error about '%s', got %s", commandLineFile.Name(), err.Error())
+	}
+}
+
+func TestErrorReadingNonFile(t *testing.T) {
+	tmpdir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("Couldn't create tmpdir")
+	}
+	defer os.Remove(tmpdir)
+
+	loadingRules := ClientConfigLoadingRules{
+		ExplicitPath: tmpdir,
+	}
+
+	_, err = loadingRules.Load()
+	if err == nil {
+		t.Fatalf("Expected error for non-file, got none")
+	}
+	if !strings.Contains(err.Error(), tmpdir) {
+		t.Fatalf("Expected error about '%s', got %s", tmpdir, err.Error())
+	}
+}
+
+func TestConflictingCurrentContext(t *testing.T) {
+	commandLineFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(commandLineFile.Name())
+	envVarFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(envVarFile.Name())
+
+	mockCommandLineConfig := clientcmdapi.Config{
+		CurrentContext: "any-context-value",
+	}
+	mockEnvVarConfig := clientcmdapi.Config{
+		CurrentContext: "a-different-context",
+	}
+
+	WriteToFile(mockCommandLineConfig, commandLineFile.Name())
+	WriteToFile(mockEnvVarConfig, envVarFile.Name())
+
+	loadingRules := ClientConfigLoadingRules{
+		ExplicitPath: commandLineFile.Name(),
+		Precedence:   []string{envVarFile.Name()},
+	}
+
+	mergedConfig, err := loadingRules.Load()
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	if mergedConfig.CurrentContext != mockCommandLineConfig.CurrentContext {
+		t.Errorf("expected %v, got %v", mockCommandLineConfig.CurrentContext, mergedConfig.CurrentContext)
+	}
+}
+
+func TestResolveRelativePaths(t *testing.T) {
+	pathResolutionConfig1 := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"relative-user-1": {ClientCertificate: "relative/client/cert", ClientKey: "../relative/client/key"},
+			"absolute-user-1": {ClientCertificate: "/absolute/client/cert", ClientKey: "/absolute/client/key"},
+		},
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"relative-server-1": {CertificateAuthority: "../relative/ca"},
+			"absolute-server-1": {CertificateAuthority: "/absolute/ca"},
+		},
+	}
+	pathResolutionConfig2 := clientcmdapi.Config{
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			"relative-user-2": {ClientCertificate: "relative/client/cert2", ClientKey: "../relative/client/key2"},
+			"absolute-user-2": {ClientCertificate: "/absolute/client/cert2", ClientKey: "/absolute/client/key2"},
+		},
+		Clusters: map[string]*clientcmdapi.Cluster{
+			"relative-server-2": {CertificateAuthority: "../relative/ca2"},
+			"absolute-server-2": {CertificateAuthority: "/absolute/ca2"},
+		},
+	}
+
+	configDir1, _ := ioutil.TempDir("", "")
+	configFile1 := path.Join(configDir1, ".kubeconfig")
+	configDir1, _ = filepath.Abs(configDir1)
+	defer os.Remove(configFile1)
+	configDir2, _ := ioutil.TempDir("", "")
+	configDir2, _ = ioutil.TempDir(configDir2, "")
+	configFile2 := path.Join(configDir2, ".kubeconfig")
+	configDir2, _ = filepath.Abs(configDir2)
+	defer os.Remove(configFile2)
+
+	WriteToFile(pathResolutionConfig1, configFile1)
+	WriteToFile(pathResolutionConfig2, configFile2)
+
+	loadingRules := ClientConfigLoadingRules{
+		Precedence: []string{configFile1, configFile2},
+	}
+
+	mergedConfig, err := loadingRules.Load()
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	foundClusterCount := 0
+	for key, cluster := range mergedConfig.Clusters {
+		if key == "relative-server-1" {
+			foundClusterCount++
+			matchStringArg(path.Join(configDir1, pathResolutionConfig1.Clusters["relative-server-1"].CertificateAuthority), cluster.CertificateAuthority, t)
+		}
+		if key == "relative-server-2" {
+			foundClusterCount++
+			matchStringArg(path.Join(configDir2, pathResolutionConfig2.Clusters["relative-server-2"].CertificateAuthority), cluster.CertificateAuthority, t)
+		}
+		if key == "absolute-server-1" {
+			foundClusterCount++
+			matchStringArg(pathResolutionConfig1.Clusters["absolute-server-1"].CertificateAuthority, cluster.CertificateAuthority, t)
+		}
+		if key == "absolute-server-2" {
+			foundClusterCount++
+			matchStringArg(pathResolutionConfig2.Clusters["absolute-server-2"].CertificateAuthority, cluster.CertificateAuthority, t)
+		}
+	}
+	if foundClusterCount != 4 {
+		t.Errorf("Expected 4 clusters, found %v: %v", foundClusterCount, mergedConfig.Clusters)
+	}
+
+	foundAuthInfoCount := 0
+	for key, authInfo := range mergedConfig.AuthInfos {
+		if key == "relative-user-1" {
+			foundAuthInfoCount++
+			matchStringArg(path.Join(configDir1, pathResolutionConfig1.AuthInfos["relative-user-1"].ClientCertificate), authInfo.ClientCertificate, t)
+			matchStringArg(path.Join(configDir1, pathResolutionConfig1.AuthInfos["relative-user-1"].ClientKey), authInfo.ClientKey, t)
+		}
+		if key == "relative-user-2" {
+			foundAuthInfoCount++
+			matchStringArg(path.Join(configDir2, pathResolutionConfig2.AuthInfos["relative-user-2"].ClientCertificate), authInfo.ClientCertificate, t)
+			matchStringArg(path.Join(configDir2, pathResolutionConfig2.AuthInfos["relative-user-2"].ClientKey), authInfo.ClientKey, t)
+		}
+		if key == "absolute-user-1" {
+			foundAuthInfoCount++
+			matchStringArg(pathResolutionConfig1.AuthInfos["absolute-user-1"].ClientCertificate, authInfo.ClientCertificate, t)
+			matchStringArg(pathResolutionConfig1.AuthInfos["absolute-user-1"].ClientKey, authInfo.ClientKey, t)
+		}
+		if key == "absolute-user-2" {
+			foundAuthInfoCount++
+			matchStringArg(pathResolutionConfig2.AuthInfos["absolute-user-2"].ClientCertificate, authInfo.ClientCertificate, t)
+			matchStringArg(pathResolutionConfig2.AuthInfos["absolute-user-2"].ClientKey, authInfo.ClientKey, t)
+		}
+	}
+	if foundAuthInfoCount != 4 {
+		t.Errorf("Expected 4 users, found %v: %v", foundAuthInfoCount, mergedConfig.AuthInfos)
+	}
+
+}
+
+func TestMigratingFile(t *testing.T) {
+	sourceFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(sourceFile.Name())
+	destinationFile, _ := ioutil.TempFile("", "")
+	// delete the file so that we'll write to it
+	os.Remove(destinationFile.Name())
+
+	WriteToFile(testConfigAlfa, sourceFile.Name())
+
+	loadingRules := ClientConfigLoadingRules{
+		MigrationRules: map[string]string{destinationFile.Name(): sourceFile.Name()},
+	}
+
+	if _, err := loadingRules.Load(); err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+
+	// the load should have recreated this file
+	defer os.Remove(destinationFile.Name())
+
+	sourceContent, err := ioutil.ReadFile(sourceFile.Name())
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+	destinationContent, err := ioutil.ReadFile(destinationFile.Name())
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+
+	if !reflect.DeepEqual(sourceContent, destinationContent) {
+		t.Errorf("source and destination do not match")
+	}
+}
+
+func TestMigratingFileLeaveExistingFileAlone(t *testing.T) {
+	sourceFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(sourceFile.Name())
+	destinationFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(destinationFile.Name())
+
+	WriteToFile(testConfigAlfa, sourceFile.Name())
+
+	loadingRules := ClientConfigLoadingRules{
+		MigrationRules: map[string]string{destinationFile.Name(): sourceFile.Name()},
+	}
+
+	if _, err := loadingRules.Load(); err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+
+	destinationContent, err := ioutil.ReadFile(destinationFile.Name())
+	if err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+
+	if len(destinationContent) > 0 {
+		t.Errorf("destination should not have been touched")
+	}
+}
+
+func TestMigratingFileSourceMissingSkip(t *testing.T) {
+	sourceFilename := "some-missing-file"
+	destinationFile, _ := ioutil.TempFile("", "")
+	// delete the file so that we'll write to it
+	os.Remove(destinationFile.Name())
+
+	loadingRules := ClientConfigLoadingRules{
+		MigrationRules: map[string]string{destinationFile.Name(): sourceFilename},
+	}
+
+	if _, err := loadingRules.Load(); err != nil {
+		t.Errorf("unexpected error %v", err)
+	}
+
+	if _, err := os.Stat(destinationFile.Name()); !os.IsNotExist(err) {
+		t.Errorf("destination should not exist")
+	}
+}
+
+func ExampleNoMergingOnExplicitPaths() {
+	commandLineFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(commandLineFile.Name())
+	envVarFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(envVarFile.Name())
+
+	WriteToFile(testConfigAlfa, commandLineFile.Name())
+	WriteToFile(testConfigConflictAlfa, envVarFile.Name())
+
+	loadingRules := ClientConfigLoadingRules{
+		ExplicitPath: commandLineFile.Name(),
+		Precedence:   []string{envVarFile.Name()},
+	}
+
+	mergedConfig, err := loadingRules.Load()
+
+	json, err := clientcmdlatest.Codec.Encode(mergedConfig)
+	if err != nil {
+		fmt.Printf("Unexpected error: %v", err)
+	}
+	output, err := yaml.JSONToYAML(json)
+	if err != nil {
+		fmt.Printf("Unexpected error: %v", err)
+	}
+
+	fmt.Printf("%v", string(output))
+	// Output:
+	// apiVersion: v1
+	// clusters:
+	// - cluster:
+	//     server: http://cow.org:8080
+	//   name: cow-cluster
+	// contexts:
+	// - context:
+	//     cluster: cow-cluster
+	//     namespace: hammer-ns
+	//     user: red-user
+	//   name: federal-context
+	// current-context: ""
+	// kind: Config
+	// preferences: {}
+	// users:
+	// - name: red-user
+	//   user:
+	//     token: red-token
+}
+
+func ExampleMergingSomeWithConflict() {
+	commandLineFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(commandLineFile.Name())
+	envVarFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(envVarFile.Name())
+
+	WriteToFile(testConfigAlfa, commandLineFile.Name())
+	WriteToFile(testConfigConflictAlfa, envVarFile.Name())
+
+	loadingRules := ClientConfigLoadingRules{
+		Precedence: []string{commandLineFile.Name(), envVarFile.Name()},
+	}
+
+	mergedConfig, err := loadingRules.Load()
+
+	json, err := clientcmdlatest.Codec.Encode(mergedConfig)
+	if err != nil {
+		fmt.Printf("Unexpected error: %v", err)
+	}
+	output, err := yaml.JSONToYAML(json)
+	if err != nil {
+		fmt.Printf("Unexpected error: %v", err)
+	}
+
+	fmt.Printf("%v", string(output))
+	// Output:
+	// apiVersion: v1
+	// clusters:
+	// - cluster:
+	//     server: http://cow.org:8080
+	//   name: cow-cluster
+	// - cluster:
+	//     insecure-skip-tls-verify: true
+	//     server: http://donkey.org:8080
+	//   name: donkey-cluster
+	// contexts:
+	// - context:
+	//     cluster: cow-cluster
+	//     namespace: hammer-ns
+	//     user: red-user
+	//   name: federal-context
+	// current-context: federal-context
+	// kind: Config
+	// preferences: {}
+	// users:
+	// - name: red-user
+	//   user:
+	//     token: red-token
+	// - name: yellow-user
+	//   user:
+	//     token: yellow-token
+}
+
+func ExampleMergingEverythingNoConflicts() {
+	commandLineFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(commandLineFile.Name())
+	envVarFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(envVarFile.Name())
+	currentDirFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(currentDirFile.Name())
+	homeDirFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(homeDirFile.Name())
+
+	WriteToFile(testConfigAlfa, commandLineFile.Name())
+	WriteToFile(testConfigBravo, envVarFile.Name())
+	WriteToFile(testConfigCharlie, currentDirFile.Name())
+	WriteToFile(testConfigDelta, homeDirFile.Name())
+
+	loadingRules := ClientConfigLoadingRules{
+		Precedence: []string{commandLineFile.Name(), envVarFile.Name(), currentDirFile.Name(), homeDirFile.Name()},
+	}
+
+	mergedConfig, err := loadingRules.Load()
+
+	json, err := clientcmdlatest.Codec.Encode(mergedConfig)
+	if err != nil {
+		fmt.Printf("Unexpected error: %v", err)
+	}
+	output, err := yaml.JSONToYAML(json)
+	if err != nil {
+		fmt.Printf("Unexpected error: %v", err)
+	}
+
+	fmt.Printf("%v", string(output))
+	// Output:
+	// 	apiVersion: v1
+	// clusters:
+	// - cluster:
+	//     server: http://chicken.org:8080
+	//   name: chicken-cluster
+	// - cluster:
+	//     server: http://cow.org:8080
+	//   name: cow-cluster
+	// - cluster:
+	//     server: http://horse.org:8080
+	//   name: horse-cluster
+	// - cluster:
+	//     server: http://pig.org:8080
+	//   name: pig-cluster
+	// contexts:
+	// - context:
+	//     cluster: cow-cluster
+	//     namespace: hammer-ns
+	//     user: red-user
+	//   name: federal-context
+	// - context:
+	//     cluster: chicken-cluster
+	//     namespace: plane-ns
+	//     user: blue-user
+	//   name: gothic-context
+	// - context:
+	//     cluster: pig-cluster
+	//     namespace: saw-ns
+	//     user: black-user
+	//   name: queen-anne-context
+	// - context:
+	//     cluster: horse-cluster
+	//     namespace: chisel-ns
+	//     user: green-user
+	//   name: shaker-context
+	// current-context: ""
+	// kind: Config
+	// preferences: {}
+	// users:
+	// - name: black-user
+	//   user:
+	//     token: black-token
+	// - name: blue-user
+	//   user:
+	//     token: blue-token
+	// - name: green-user
+	//   user:
+	//     token: green-token
+	// - name: red-user
+	//   user:
+	//     token: red-token
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/clientcmd/merged_client_builder.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/clientcmd/merged_client_builder.go
@@ -86,7 +86,7 @@ func (config DeferredLoadingClientConfig) ClientConfig() (*client.Config, error)
 	icc := inClusterClientConfig{}
 	defaultConfig, err := DefaultClientConfig.ClientConfig()
 	if icc.Possible() && err == nil && reflect.DeepEqual(mergedConfig, defaultConfig) {
-		glog.V(2).Info("no kubeconfig could be created, falling back to service account.")
+		glog.V(2).Info("No kubeconfig could be created, falling back to service account.")
 		return icc.ClientConfig()
 	}
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/clientcmd/validation_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/clientcmd/validation_test.go
@@ -1,0 +1,419 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clientcmd
+
+import (
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+
+	clientcmdapi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
+	"k8s.io/kubernetes/pkg/util/errors"
+)
+
+func TestConfirmUsableBadInfoButOkConfig(t *testing.T) {
+	config := clientcmdapi.NewConfig()
+	config.Clusters["missing ca"] = &clientcmdapi.Cluster{
+		Server:               "anything",
+		CertificateAuthority: "missing",
+	}
+	config.AuthInfos["error"] = &clientcmdapi.AuthInfo{
+		Username: "anything",
+		Token:    "here",
+	}
+	config.Contexts["dirty"] = &clientcmdapi.Context{
+		Cluster:  "missing ca",
+		AuthInfo: "error",
+	}
+	config.Clusters["clean"] = &clientcmdapi.Cluster{
+		Server: "anything",
+	}
+	config.AuthInfos["clean"] = &clientcmdapi.AuthInfo{
+		Token: "here",
+	}
+	config.Contexts["clean"] = &clientcmdapi.Context{
+		Cluster:  "clean",
+		AuthInfo: "clean",
+	}
+
+	badValidation := configValidationTest{
+		config:                 config,
+		expectedErrorSubstring: []string{"unable to read certificate-authority"},
+	}
+	okTest := configValidationTest{
+		config: config,
+	}
+
+	okTest.testConfirmUsable("clean", t)
+	badValidation.testConfig(t)
+}
+func TestConfirmUsableBadInfoConfig(t *testing.T) {
+	config := clientcmdapi.NewConfig()
+	config.Clusters["missing ca"] = &clientcmdapi.Cluster{
+		Server:               "anything",
+		CertificateAuthority: "missing",
+	}
+	config.AuthInfos["error"] = &clientcmdapi.AuthInfo{
+		Username: "anything",
+		Token:    "here",
+	}
+	config.Contexts["first"] = &clientcmdapi.Context{
+		Cluster:  "missing ca",
+		AuthInfo: "error",
+	}
+	test := configValidationTest{
+		config:                 config,
+		expectedErrorSubstring: []string{"unable to read certificate-authority"},
+	}
+
+	test.testConfirmUsable("first", t)
+}
+func TestConfirmUsableEmptyConfig(t *testing.T) {
+	config := clientcmdapi.NewConfig()
+	test := configValidationTest{
+		config:                 config,
+		expectedErrorSubstring: []string{"no context chosen"},
+	}
+
+	test.testConfirmUsable("", t)
+}
+func TestConfirmUsableMissingConfig(t *testing.T) {
+	config := clientcmdapi.NewConfig()
+	test := configValidationTest{
+		config:                 config,
+		expectedErrorSubstring: []string{"context was not found for"},
+	}
+
+	test.testConfirmUsable("not-here", t)
+}
+func TestValidateEmptyConfig(t *testing.T) {
+	config := clientcmdapi.NewConfig()
+	test := configValidationTest{
+		config: config,
+	}
+
+	test.testConfig(t)
+}
+func TestValidateMissingCurrentContextConfig(t *testing.T) {
+	config := clientcmdapi.NewConfig()
+	config.CurrentContext = "anything"
+	test := configValidationTest{
+		config:                 config,
+		expectedErrorSubstring: []string{"context was not found for specified "},
+	}
+
+	test.testConfig(t)
+}
+func TestIsContextNotFound(t *testing.T) {
+	config := clientcmdapi.NewConfig()
+	config.CurrentContext = "anything"
+
+	err := Validate(*config)
+	if !IsContextNotFound(err) {
+		t.Errorf("Expected context not found, but got %v", err)
+	}
+	if !IsConfigurationInvalid(err) {
+		t.Errorf("Expected configuration invalid, but got %v", err)
+	}
+}
+
+func TestIsConfigurationInvalid(t *testing.T) {
+	if newErrConfigurationInvalid([]error{}) != nil {
+		t.Errorf("unexpected error")
+	}
+	if newErrConfigurationInvalid([]error{ErrNoContext}) == ErrNoContext {
+		t.Errorf("unexpected error")
+	}
+	if newErrConfigurationInvalid([]error{ErrNoContext, ErrNoContext}) == nil {
+		t.Errorf("unexpected error")
+	}
+	if !IsConfigurationInvalid(newErrConfigurationInvalid([]error{ErrNoContext, ErrNoContext})) {
+		t.Errorf("unexpected error")
+	}
+}
+
+func TestValidateMissingReferencesConfig(t *testing.T) {
+	config := clientcmdapi.NewConfig()
+	config.CurrentContext = "anything"
+	config.Contexts["anything"] = &clientcmdapi.Context{Cluster: "missing", AuthInfo: "missing"}
+	test := configValidationTest{
+		config:                 config,
+		expectedErrorSubstring: []string{"user \"missing\" was not found for context \"anything\"", "cluster \"missing\" was not found for context \"anything\""},
+	}
+
+	test.testContext("anything", t)
+	test.testConfig(t)
+}
+func TestValidateEmptyContext(t *testing.T) {
+	config := clientcmdapi.NewConfig()
+	config.CurrentContext = "anything"
+	config.Contexts["anything"] = &clientcmdapi.Context{}
+	test := configValidationTest{
+		config:                 config,
+		expectedErrorSubstring: []string{"user was not specified for context \"anything\"", "cluster was not specified for context \"anything\""},
+	}
+
+	test.testContext("anything", t)
+	test.testConfig(t)
+}
+
+func TestValidateEmptyClusterInfo(t *testing.T) {
+	config := clientcmdapi.NewConfig()
+	config.Clusters["empty"] = &clientcmdapi.Cluster{}
+	test := configValidationTest{
+		config:                 config,
+		expectedErrorSubstring: []string{"no server found for"},
+	}
+
+	test.testCluster("empty", t)
+	test.testConfig(t)
+}
+func TestValidateMissingCAFileClusterInfo(t *testing.T) {
+	config := clientcmdapi.NewConfig()
+	config.Clusters["missing ca"] = &clientcmdapi.Cluster{
+		Server:               "anything",
+		CertificateAuthority: "missing",
+	}
+	test := configValidationTest{
+		config:                 config,
+		expectedErrorSubstring: []string{"unable to read certificate-authority"},
+	}
+
+	test.testCluster("missing ca", t)
+	test.testConfig(t)
+}
+func TestValidateCleanClusterInfo(t *testing.T) {
+	config := clientcmdapi.NewConfig()
+	config.Clusters["clean"] = &clientcmdapi.Cluster{
+		Server: "anything",
+	}
+	test := configValidationTest{
+		config: config,
+	}
+
+	test.testCluster("clean", t)
+	test.testConfig(t)
+}
+func TestValidateCleanWithCAClusterInfo(t *testing.T) {
+	tempFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(tempFile.Name())
+
+	config := clientcmdapi.NewConfig()
+	config.Clusters["clean"] = &clientcmdapi.Cluster{
+		Server:               "anything",
+		CertificateAuthority: tempFile.Name(),
+	}
+	test := configValidationTest{
+		config: config,
+	}
+
+	test.testCluster("clean", t)
+	test.testConfig(t)
+}
+
+func TestValidateEmptyAuthInfo(t *testing.T) {
+	config := clientcmdapi.NewConfig()
+	config.AuthInfos["error"] = &clientcmdapi.AuthInfo{}
+	test := configValidationTest{
+		config: config,
+	}
+
+	test.testAuthInfo("error", t)
+	test.testConfig(t)
+}
+func TestValidateCertFilesNotFoundAuthInfo(t *testing.T) {
+	config := clientcmdapi.NewConfig()
+	config.AuthInfos["error"] = &clientcmdapi.AuthInfo{
+		ClientCertificate: "missing",
+		ClientKey:         "missing",
+	}
+	test := configValidationTest{
+		config:                 config,
+		expectedErrorSubstring: []string{"unable to read client-cert", "unable to read client-key"},
+	}
+
+	test.testAuthInfo("error", t)
+	test.testConfig(t)
+}
+func TestValidateCertDataOverridesFiles(t *testing.T) {
+	tempFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(tempFile.Name())
+
+	config := clientcmdapi.NewConfig()
+	config.AuthInfos["clean"] = &clientcmdapi.AuthInfo{
+		ClientCertificate:     tempFile.Name(),
+		ClientCertificateData: []byte("certdata"),
+		ClientKey:             tempFile.Name(),
+		ClientKeyData:         []byte("keydata"),
+	}
+	test := configValidationTest{
+		config:                 config,
+		expectedErrorSubstring: []string{"client-cert-data and client-cert are both specified", "client-key-data and client-key are both specified"},
+	}
+
+	test.testAuthInfo("clean", t)
+	test.testConfig(t)
+}
+func TestValidateCleanCertFilesAuthInfo(t *testing.T) {
+	tempFile, _ := ioutil.TempFile("", "")
+	defer os.Remove(tempFile.Name())
+
+	config := clientcmdapi.NewConfig()
+	config.AuthInfos["clean"] = &clientcmdapi.AuthInfo{
+		ClientCertificate: tempFile.Name(),
+		ClientKey:         tempFile.Name(),
+	}
+	test := configValidationTest{
+		config: config,
+	}
+
+	test.testAuthInfo("clean", t)
+	test.testConfig(t)
+}
+func TestValidateCleanTokenAuthInfo(t *testing.T) {
+	config := clientcmdapi.NewConfig()
+	config.AuthInfos["clean"] = &clientcmdapi.AuthInfo{
+		Token: "any-value",
+	}
+	test := configValidationTest{
+		config: config,
+	}
+
+	test.testAuthInfo("clean", t)
+	test.testConfig(t)
+}
+
+func TestValidateMultipleMethodsAuthInfo(t *testing.T) {
+	config := clientcmdapi.NewConfig()
+	config.AuthInfos["error"] = &clientcmdapi.AuthInfo{
+		Token:    "token",
+		Username: "username",
+	}
+	test := configValidationTest{
+		config:                 config,
+		expectedErrorSubstring: []string{"more than one authentication method", "token", "basicAuth"},
+	}
+
+	test.testAuthInfo("error", t)
+	test.testConfig(t)
+}
+
+type configValidationTest struct {
+	config                 *clientcmdapi.Config
+	expectedErrorSubstring []string
+}
+
+func (c configValidationTest) testContext(contextName string, t *testing.T) {
+	errs := validateContext(contextName, *c.config.Contexts[contextName], *c.config)
+
+	if len(c.expectedErrorSubstring) != 0 {
+		if len(errs) == 0 {
+			t.Errorf("Expected error containing: %v", c.expectedErrorSubstring)
+		}
+		for _, curr := range c.expectedErrorSubstring {
+			if len(errs) != 0 && !strings.Contains(errors.NewAggregate(errs).Error(), curr) {
+				t.Errorf("Expected error containing: %v, but got %v", c.expectedErrorSubstring, errors.NewAggregate(errs))
+			}
+		}
+
+	} else {
+		if len(errs) != 0 {
+			t.Errorf("Unexpected error: %v", errors.NewAggregate(errs))
+		}
+	}
+}
+func (c configValidationTest) testConfirmUsable(contextName string, t *testing.T) {
+	err := ConfirmUsable(*c.config, contextName)
+
+	if len(c.expectedErrorSubstring) != 0 {
+		if err == nil {
+			t.Errorf("Expected error containing: %v", c.expectedErrorSubstring)
+		} else {
+			for _, curr := range c.expectedErrorSubstring {
+				if err != nil && !strings.Contains(err.Error(), curr) {
+					t.Errorf("Expected error containing: %v, but got %v", c.expectedErrorSubstring, err)
+				}
+			}
+		}
+	} else {
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	}
+}
+func (c configValidationTest) testConfig(t *testing.T) {
+	err := Validate(*c.config)
+
+	if len(c.expectedErrorSubstring) != 0 {
+		if err == nil {
+			t.Errorf("Expected error containing: %v", c.expectedErrorSubstring)
+		} else {
+			for _, curr := range c.expectedErrorSubstring {
+				if err != nil && !strings.Contains(err.Error(), curr) {
+					t.Errorf("Expected error containing: %v, but got %v", c.expectedErrorSubstring, err)
+				}
+			}
+			if !IsConfigurationInvalid(err) {
+				t.Errorf("all errors should be configuration invalid: %v", err)
+			}
+		}
+	} else {
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+	}
+}
+func (c configValidationTest) testCluster(clusterName string, t *testing.T) {
+	errs := validateClusterInfo(clusterName, *c.config.Clusters[clusterName])
+
+	if len(c.expectedErrorSubstring) != 0 {
+		if len(errs) == 0 {
+			t.Errorf("Expected error containing: %v", c.expectedErrorSubstring)
+		}
+		for _, curr := range c.expectedErrorSubstring {
+			if len(errs) != 0 && !strings.Contains(errors.NewAggregate(errs).Error(), curr) {
+				t.Errorf("Expected error containing: %v, but got %v", c.expectedErrorSubstring, errors.NewAggregate(errs))
+			}
+		}
+
+	} else {
+		if len(errs) != 0 {
+			t.Errorf("Unexpected error: %v", errors.NewAggregate(errs))
+		}
+	}
+}
+
+func (c configValidationTest) testAuthInfo(authInfoName string, t *testing.T) {
+	errs := validateAuthInfo(authInfoName, *c.config.AuthInfos[authInfoName])
+
+	if len(c.expectedErrorSubstring) != 0 {
+		if len(errs) == 0 {
+			t.Errorf("Expected error containing: %v", c.expectedErrorSubstring)
+		}
+		for _, curr := range c.expectedErrorSubstring {
+			if len(errs) != 0 && !strings.Contains(errors.NewAggregate(errs).Error(), curr) {
+				t.Errorf("Expected error containing: %v, but got %v", c.expectedErrorSubstring, errors.NewAggregate(errs))
+			}
+		}
+
+	} else {
+		if len(errs) != 0 {
+			t.Errorf("Unexpected error: %v", errors.NewAggregate(errs))
+		}
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/conditions.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/conditions.go
@@ -18,6 +18,7 @@ package unversioned
 
 import (
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apis/experimental"
 	"k8s.io/kubernetes/pkg/util/wait"
 )
 
@@ -39,5 +40,25 @@ func ControllerHasDesiredReplicas(c Interface, controller *api.ReplicationContro
 		// This will not be an issue once we've implemented graceful delete for rcs, but till then
 		// concurrent stop operations on the same rc might have unintended side effects.
 		return ctrl.Status.ObservedGeneration >= desiredGeneration && ctrl.Status.Replicas == ctrl.Spec.Replicas, nil
+	}
+}
+
+// JobHasDesiredParallelism returns a condition that will be true if the desired parallelism count
+// for a job equals the current active counts or is less by an appropriate successful/unsuccessful count.
+func JobHasDesiredParallelism(c Interface, job *experimental.Job) wait.ConditionFunc {
+
+	return func() (bool, error) {
+		job, err := c.Experimental().Jobs(job.Namespace).Get(job.Name)
+		if err != nil {
+			return false, err
+		}
+
+		// desired parallelism can be either the exact number, in which case return immediately
+		if job.Status.Active == *job.Spec.Parallelism {
+			return true, nil
+		}
+		// otherwise count successful
+		progress := *job.Spec.Completions - job.Status.Active - job.Status.Successful
+		return progress == 0, nil
 	}
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/containerinfo_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/containerinfo_test.go
@@ -1,0 +1,198 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	cadvisorApi "github.com/google/cadvisor/info/v1"
+	cadvisorApiTest "github.com/google/cadvisor/info/v1/test"
+)
+
+func testHTTPContainerInfoGetter(
+	req *cadvisorApi.ContainerInfoRequest,
+	cinfo *cadvisorApi.ContainerInfo,
+	podID string,
+	containerID string,
+	status int,
+	t *testing.T,
+) {
+	expectedPath := "/stats"
+	if len(podID) > 0 && len(containerID) > 0 {
+		expectedPath = path.Join(expectedPath, podID, containerID)
+	}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if status != 0 {
+			w.WriteHeader(status)
+		}
+		if strings.TrimRight(r.URL.Path, "/") != strings.TrimRight(expectedPath, "/") {
+			t.Fatalf("Received request to an invalid path. Should be %v. got %v",
+				expectedPath, r.URL.Path)
+		}
+
+		var receivedReq cadvisorApi.ContainerInfoRequest
+		err := json.NewDecoder(r.Body).Decode(&receivedReq)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Note: This will not make a deep copy of req.
+		// So changing req after Get*Info would be a race.
+		expectedReq := req
+		// Fill any empty fields with default value
+		if !expectedReq.Equals(receivedReq) {
+			t.Errorf("received wrong request")
+		}
+		err = json.NewEncoder(w).Encode(cinfo)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}))
+	defer ts.Close()
+	hostURL, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parts := strings.Split(hostURL.Host, ":")
+
+	port, err := strconv.Atoi(parts[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	containerInfoGetter := &HTTPContainerInfoGetter{
+		Client: http.DefaultClient,
+		Port:   port,
+	}
+
+	var receivedContainerInfo *cadvisorApi.ContainerInfo
+	if len(podID) > 0 && len(containerID) > 0 {
+		receivedContainerInfo, err = containerInfoGetter.GetContainerInfo(parts[0], podID, containerID, req)
+	} else {
+		receivedContainerInfo, err = containerInfoGetter.GetRootInfo(parts[0], req)
+	}
+	if status == 0 || status == http.StatusOK {
+		if err != nil {
+			t.Errorf("received unexpected error: %v", err)
+		}
+
+		if !receivedContainerInfo.Eq(cinfo) {
+			t.Error("received unexpected container info")
+		}
+	} else {
+		if err == nil {
+			t.Error("did not receive expected error.")
+		}
+	}
+}
+
+func TestHTTPContainerInfoGetterGetContainerInfoSuccessfully(t *testing.T) {
+	req := &cadvisorApi.ContainerInfoRequest{
+		NumStats: 10,
+	}
+	cinfo := cadvisorApiTest.GenerateRandomContainerInfo(
+		"dockerIDWhichWillNotBeChecked", // docker ID
+		2, // Number of cores
+		req,
+		1*time.Second,
+	)
+	testHTTPContainerInfoGetter(req, cinfo, "somePodID", "containerNameInK8S", 0, t)
+}
+
+func TestHTTPContainerInfoGetterGetRootInfoSuccessfully(t *testing.T) {
+	req := &cadvisorApi.ContainerInfoRequest{
+		NumStats: 10,
+	}
+	cinfo := cadvisorApiTest.GenerateRandomContainerInfo(
+		"dockerIDWhichWillNotBeChecked", // docker ID
+		2, // Number of cores
+		req,
+		1*time.Second,
+	)
+	testHTTPContainerInfoGetter(req, cinfo, "", "", 0, t)
+}
+
+func TestHTTPContainerInfoGetterGetContainerInfoWithError(t *testing.T) {
+	req := &cadvisorApi.ContainerInfoRequest{
+		NumStats: 10,
+	}
+	cinfo := cadvisorApiTest.GenerateRandomContainerInfo(
+		"dockerIDWhichWillNotBeChecked", // docker ID
+		2, // Number of cores
+		req,
+		1*time.Second,
+	)
+	testHTTPContainerInfoGetter(req, cinfo, "somePodID", "containerNameInK8S", http.StatusNotFound, t)
+}
+
+func TestHTTPContainerInfoGetterGetRootInfoWithError(t *testing.T) {
+	req := &cadvisorApi.ContainerInfoRequest{
+		NumStats: 10,
+	}
+	cinfo := cadvisorApiTest.GenerateRandomContainerInfo(
+		"dockerIDWhichWillNotBeChecked", // docker ID
+		2, // Number of cores
+		req,
+		1*time.Second,
+	)
+	testHTTPContainerInfoGetter(req, cinfo, "", "", http.StatusNotFound, t)
+}
+
+func TestHTTPGetMachineInfo(t *testing.T) {
+	mspec := &cadvisorApi.MachineInfo{
+		NumCores:       4,
+		MemoryCapacity: 2048,
+	}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		err := json.NewEncoder(w).Encode(mspec)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}))
+	defer ts.Close()
+	hostURL, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parts := strings.Split(hostURL.Host, ":")
+
+	port, err := strconv.Atoi(parts[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	containerInfoGetter := &HTTPContainerInfoGetter{
+		Client: http.DefaultClient,
+		Port:   port,
+	}
+
+	received, err := containerInfoGetter.GetMachineInfo(parts[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(received, mspec) {
+		t.Errorf("received wrong machine spec")
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/daemon_sets.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/daemon_sets.go
@@ -33,6 +33,7 @@ type DaemonSetInterface interface {
 	Get(name string) (*experimental.DaemonSet, error)
 	Create(ctrl *experimental.DaemonSet) (*experimental.DaemonSet, error)
 	Update(ctrl *experimental.DaemonSet) (*experimental.DaemonSet, error)
+	UpdateStatus(ctrl *experimental.DaemonSet) (*experimental.DaemonSet, error)
 	Delete(name string) error
 	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
 }
@@ -74,6 +75,13 @@ func (c *daemonSets) Create(daemon *experimental.DaemonSet) (result *experimenta
 func (c *daemonSets) Update(daemon *experimental.DaemonSet) (result *experimental.DaemonSet, err error) {
 	result = &experimental.DaemonSet{}
 	err = c.r.Put().Namespace(c.ns).Resource("daemonsets").Name(daemon.Name).Body(daemon).Do().Into(result)
+	return
+}
+
+// UpdateStatus updates an existing daemon set status
+func (c *daemonSets) UpdateStatus(daemon *experimental.DaemonSet) (result *experimental.DaemonSet, err error) {
+	result = &experimental.DaemonSet{}
+	err = c.r.Put().Namespace(c.ns).Resource("daemonsets").Name(daemon.Name).SubResource("status").Body(daemon).Do().Into(result)
 	return
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/daemon_sets_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/daemon_sets_test.go
@@ -1,0 +1,188 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/apis/experimental"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+func getDSResourceName() string {
+	return "daemonsets"
+}
+
+func TestListDaemonSets(t *testing.T) {
+	ns := api.NamespaceAll
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Experimental.ResourcePath(getDSResourceName(), ns, ""),
+		},
+		Response: Response{StatusCode: 200,
+			Body: &experimental.DaemonSetList{
+				Items: []experimental.DaemonSet{
+					{
+						ObjectMeta: api.ObjectMeta{
+							Name: "foo",
+							Labels: map[string]string{
+								"foo":  "bar",
+								"name": "baz",
+							},
+						},
+						Spec: experimental.DaemonSetSpec{
+							Template: &api.PodTemplateSpec{},
+						},
+					},
+				},
+			},
+		},
+	}
+	receivedDSs, err := c.Setup(t).Experimental().DaemonSets(ns).List(labels.Everything())
+	c.Validate(t, receivedDSs, err)
+
+}
+
+func TestGetDaemonSet(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request: testRequest{Method: "GET", Path: testapi.Experimental.ResourcePath(getDSResourceName(), ns, "foo"), Query: buildQueryValues(nil)},
+		Response: Response{
+			StatusCode: 200,
+			Body: &experimental.DaemonSet{
+				ObjectMeta: api.ObjectMeta{
+					Name: "foo",
+					Labels: map[string]string{
+						"foo":  "bar",
+						"name": "baz",
+					},
+				},
+				Spec: experimental.DaemonSetSpec{
+					Template: &api.PodTemplateSpec{},
+				},
+			},
+		},
+	}
+	receivedDaemonSet, err := c.Setup(t).Experimental().DaemonSets(ns).Get("foo")
+	c.Validate(t, receivedDaemonSet, err)
+}
+
+func TestGetDaemonSetWithNoName(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{Error: true}
+	receivedPod, err := c.Setup(t).Experimental().DaemonSets(ns).Get("")
+	if (err != nil) && (err.Error() != nameRequiredError) {
+		t.Errorf("Expected error: %v, but got %v", nameRequiredError, err)
+	}
+
+	c.Validate(t, receivedPod, err)
+}
+
+func TestUpdateDaemonSet(t *testing.T) {
+	ns := api.NamespaceDefault
+	requestDaemonSet := &experimental.DaemonSet{
+		ObjectMeta: api.ObjectMeta{Name: "foo", ResourceVersion: "1"},
+	}
+	c := &testClient{
+		Request: testRequest{Method: "PUT", Path: testapi.Experimental.ResourcePath(getDSResourceName(), ns, "foo"), Query: buildQueryValues(nil)},
+		Response: Response{
+			StatusCode: 200,
+			Body: &experimental.DaemonSet{
+				ObjectMeta: api.ObjectMeta{
+					Name: "foo",
+					Labels: map[string]string{
+						"foo":  "bar",
+						"name": "baz",
+					},
+				},
+				Spec: experimental.DaemonSetSpec{
+					Template: &api.PodTemplateSpec{},
+				},
+			},
+		},
+	}
+	receivedDaemonSet, err := c.Setup(t).Experimental().DaemonSets(ns).Update(requestDaemonSet)
+	c.Validate(t, receivedDaemonSet, err)
+}
+
+func TestUpdateDaemonSetUpdateStatus(t *testing.T) {
+	ns := api.NamespaceDefault
+	requestDaemonSet := &experimental.DaemonSet{
+		ObjectMeta: api.ObjectMeta{Name: "foo", ResourceVersion: "1"},
+	}
+	c := &testClient{
+		Request: testRequest{Method: "PUT", Path: testapi.Experimental.ResourcePath(getDSResourceName(), ns, "foo") + "/status", Query: buildQueryValues(nil)},
+		Response: Response{
+			StatusCode: 200,
+			Body: &experimental.DaemonSet{
+				ObjectMeta: api.ObjectMeta{
+					Name: "foo",
+					Labels: map[string]string{
+						"foo":  "bar",
+						"name": "baz",
+					},
+				},
+				Spec: experimental.DaemonSetSpec{
+					Template: &api.PodTemplateSpec{},
+				},
+				Status: experimental.DaemonSetStatus{},
+			},
+		},
+	}
+	receivedDaemonSet, err := c.Setup(t).Experimental().DaemonSets(ns).UpdateStatus(requestDaemonSet)
+	c.Validate(t, receivedDaemonSet, err)
+}
+
+func TestDeleteDaemon(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request:  testRequest{Method: "DELETE", Path: testapi.Experimental.ResourcePath(getDSResourceName(), ns, "foo"), Query: buildQueryValues(nil)},
+		Response: Response{StatusCode: 200},
+	}
+	err := c.Setup(t).Experimental().DaemonSets(ns).Delete("foo")
+	c.Validate(t, nil, err)
+}
+
+func TestCreateDaemonSet(t *testing.T) {
+	ns := api.NamespaceDefault
+	requestDaemonSet := &experimental.DaemonSet{
+		ObjectMeta: api.ObjectMeta{Name: "foo"},
+	}
+	c := &testClient{
+		Request: testRequest{Method: "POST", Path: testapi.Experimental.ResourcePath(getDSResourceName(), ns, ""), Body: requestDaemonSet, Query: buildQueryValues(nil)},
+		Response: Response{
+			StatusCode: 200,
+			Body: &experimental.DaemonSet{
+				ObjectMeta: api.ObjectMeta{
+					Name: "foo",
+					Labels: map[string]string{
+						"foo":  "bar",
+						"name": "baz",
+					},
+				},
+				Spec: experimental.DaemonSetSpec{
+					Template: &api.PodTemplateSpec{},
+				},
+			},
+		},
+	}
+	receivedDaemonSet, err := c.Setup(t).Experimental().DaemonSets(ns).Create(requestDaemonSet)
+	c.Validate(t, receivedDaemonSet, err)
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/deployment_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/deployment_test.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"net/url"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/apis/experimental"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+func getDeploymentsResoureName() string {
+	return "deployments"
+}
+
+func TestDeploymentCreate(t *testing.T) {
+	ns := api.NamespaceDefault
+	deployment := experimental.Deployment{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "abc",
+			Namespace: ns,
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "POST",
+			Path:   testapi.Experimental.ResourcePath(getDeploymentsResoureName(), ns, ""),
+			Query:  buildQueryValues(nil),
+			Body:   &deployment,
+		},
+		Response: Response{StatusCode: 200, Body: &deployment},
+	}
+
+	response, err := c.Setup(t).Deployments(ns).Create(&deployment)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	c.Validate(t, response, err)
+}
+
+func TestDeploymentGet(t *testing.T) {
+	ns := api.NamespaceDefault
+	deployment := &experimental.Deployment{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "abc",
+			Namespace: ns,
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Experimental.ResourcePath(getDeploymentsResoureName(), ns, "abc"),
+			Query:  buildQueryValues(nil),
+			Body:   nil,
+		},
+		Response: Response{StatusCode: 200, Body: deployment},
+	}
+
+	response, err := c.Setup(t).Deployments(ns).Get("abc")
+	c.Validate(t, response, err)
+}
+
+func TestDeploymentList(t *testing.T) {
+	ns := api.NamespaceDefault
+	deploymentList := &experimental.DeploymentList{
+		Items: []experimental.Deployment{
+			{
+				ObjectMeta: api.ObjectMeta{
+					Name:      "foo",
+					Namespace: ns,
+				},
+			},
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Experimental.ResourcePath(getDeploymentsResoureName(), ns, ""),
+			Query:  buildQueryValues(nil),
+			Body:   nil,
+		},
+		Response: Response{StatusCode: 200, Body: deploymentList},
+	}
+	response, err := c.Setup(t).Deployments(ns).List(labels.Everything(), fields.Everything())
+	c.Validate(t, response, err)
+}
+
+func TestDeploymentUpdate(t *testing.T) {
+	ns := api.NamespaceDefault
+	deployment := &experimental.Deployment{
+		ObjectMeta: api.ObjectMeta{
+			Name:            "abc",
+			Namespace:       ns,
+			ResourceVersion: "1",
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "PUT",
+			Path:   testapi.Experimental.ResourcePath(getDeploymentsResoureName(), ns, "abc"),
+			Query:  buildQueryValues(nil),
+		},
+		Response: Response{StatusCode: 200, Body: deployment},
+	}
+	response, err := c.Setup(t).Deployments(ns).Update(deployment)
+	c.Validate(t, response, err)
+}
+
+func TestDeploymentDelete(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request: testRequest{
+			Method: "DELETE",
+			Path:   testapi.Experimental.ResourcePath(getDeploymentsResoureName(), ns, "foo"),
+			Query:  buildQueryValues(nil),
+		},
+		Response: Response{StatusCode: 200},
+	}
+	err := c.Setup(t).Deployments(ns).Delete("foo", nil)
+	c.Validate(t, nil, err)
+}
+
+func TestDeploymentWatch(t *testing.T) {
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Experimental.ResourcePathWithPrefix("watch", getDeploymentsResoureName(), "", ""),
+			Query:  url.Values{"resourceVersion": []string{}},
+		},
+		Response: Response{StatusCode: 200},
+	}
+	_, err := c.Setup(t).Deployments(api.NamespaceAll).Watch(labels.Everything(), fields.Everything(), "")
+	c.Validate(t, nil, err)
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/doc.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/doc.go
@@ -15,14 +15,14 @@ limitations under the License.
 */
 
 /*
-Package client contains the implementation of the client side communication with the
+Package unversioned contains the implementation of the client side communication with the
 Kubernetes master. The Client class provides methods for reading, creating, updating,
 and deleting pods, replication controllers, daemons, services, and nodes.
 
 Most consumers should use the Config object to create a Client:
 
     import (
-      "k8s.io/kubernetes/pkg/client"
+      client "k8s.io/kubernetes/pkg/client/unversioned"
       "k8s.io/kubernetes/pkg/api"
       "k8s.io/kubernetes/pkg/fields"
       "k8s.io/kubernetes/pkg/labels"

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/endpoints_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/endpoints_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+func TestListEndpoints(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request: testRequest{Method: "GET", Path: testapi.Default.ResourcePath("endpoints", ns, ""), Query: buildQueryValues(nil)},
+		Response: Response{StatusCode: 200,
+			Body: &api.EndpointsList{
+				Items: []api.Endpoints{
+					{
+						ObjectMeta: api.ObjectMeta{Name: "endpoint-1"},
+						Subsets: []api.EndpointSubset{{
+							Addresses: []api.EndpointAddress{{IP: "10.245.1.2"}, {IP: "10.245.1.3"}},
+							Ports:     []api.EndpointPort{{Port: 8080}},
+						}},
+					},
+				},
+			},
+		},
+	}
+	receivedEndpointsList, err := c.Setup(t).Endpoints(ns).List(labels.Everything())
+	c.Validate(t, receivedEndpointsList, err)
+}
+
+func TestGetEndpoints(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request:  testRequest{Method: "GET", Path: testapi.Default.ResourcePath("endpoints", ns, "endpoint-1"), Query: buildQueryValues(nil)},
+		Response: Response{StatusCode: 200, Body: &api.Endpoints{ObjectMeta: api.ObjectMeta{Name: "endpoint-1"}}},
+	}
+	response, err := c.Setup(t).Endpoints(ns).Get("endpoint-1")
+	c.Validate(t, response, err)
+}
+
+func TestGetEndpointWithNoName(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{Error: true}
+	receivedPod, err := c.Setup(t).Endpoints(ns).Get("")
+	if (err != nil) && (err.Error() != nameRequiredError) {
+		t.Errorf("Expected error: %v, but got %v", nameRequiredError, err)
+	}
+
+	c.Validate(t, receivedPod, err)
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/events_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/events_test.go
@@ -1,0 +1,195 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"net/url"
+	"reflect"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+func TestEventSearch(t *testing.T) {
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePath("events", "baz", ""),
+			Query: url.Values{
+				api.FieldSelectorQueryParam(testapi.Default.Version()): []string{
+					getInvolvedObjectNameFieldLabel(testapi.Default.Version()) + "=foo,",
+					"involvedObject.namespace=baz,",
+					"involvedObject.kind=Pod",
+				},
+				api.LabelSelectorQueryParam(testapi.Default.Version()): []string{},
+			},
+		},
+		Response: Response{StatusCode: 200, Body: &api.EventList{}},
+	}
+	eventList, err := c.Setup(t).Events("baz").Search(
+		&api.Pod{
+			ObjectMeta: api.ObjectMeta{
+				Name:      "foo",
+				Namespace: "baz",
+				SelfLink:  testapi.Default.SelfLink("pods", ""),
+			},
+		},
+	)
+	c.Validate(t, eventList, err)
+}
+
+func TestEventCreate(t *testing.T) {
+	objReference := &api.ObjectReference{
+		Kind:            "foo",
+		Namespace:       "nm",
+		Name:            "objref1",
+		UID:             "uid",
+		APIVersion:      "apiv1",
+		ResourceVersion: "1",
+	}
+	timeStamp := unversioned.Now()
+	event := &api.Event{
+		ObjectMeta: api.ObjectMeta{
+			Namespace: api.NamespaceDefault,
+		},
+		InvolvedObject: *objReference,
+		FirstTimestamp: timeStamp,
+		LastTimestamp:  timeStamp,
+		Count:          1,
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "POST",
+			Path:   testapi.Default.ResourcePath("events", api.NamespaceDefault, ""),
+			Body:   event,
+		},
+		Response: Response{StatusCode: 200, Body: event},
+	}
+
+	response, err := c.Setup(t).Events(api.NamespaceDefault).Create(event)
+
+	if err != nil {
+		t.Fatalf("%v should be nil.", err)
+	}
+
+	if e, a := *objReference, response.InvolvedObject; !reflect.DeepEqual(e, a) {
+		t.Errorf("%#v != %#v.", e, a)
+	}
+}
+
+func TestEventGet(t *testing.T) {
+	objReference := &api.ObjectReference{
+		Kind:            "foo",
+		Namespace:       "nm",
+		Name:            "objref1",
+		UID:             "uid",
+		APIVersion:      "apiv1",
+		ResourceVersion: "1",
+	}
+	timeStamp := unversioned.Now()
+	event := &api.Event{
+		ObjectMeta: api.ObjectMeta{
+			Namespace: "other",
+		},
+		InvolvedObject: *objReference,
+		FirstTimestamp: timeStamp,
+		LastTimestamp:  timeStamp,
+		Count:          1,
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePath("events", "other", "1"),
+			Body:   nil,
+		},
+		Response: Response{StatusCode: 200, Body: event},
+	}
+
+	response, err := c.Setup(t).Events("other").Get("1")
+
+	if err != nil {
+		t.Fatalf("%v should be nil.", err)
+	}
+
+	if e, r := event.InvolvedObject, response.InvolvedObject; !reflect.DeepEqual(e, r) {
+		t.Errorf("%#v != %#v.", e, r)
+	}
+}
+
+func TestEventList(t *testing.T) {
+	ns := api.NamespaceDefault
+	objReference := &api.ObjectReference{
+		Kind:            "foo",
+		Namespace:       ns,
+		Name:            "objref1",
+		UID:             "uid",
+		APIVersion:      "apiv1",
+		ResourceVersion: "1",
+	}
+	timeStamp := unversioned.Now()
+	eventList := &api.EventList{
+		Items: []api.Event{
+			{
+				InvolvedObject: *objReference,
+				FirstTimestamp: timeStamp,
+				LastTimestamp:  timeStamp,
+				Count:          1,
+			},
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePath("events", ns, ""),
+			Body:   nil,
+		},
+		Response: Response{StatusCode: 200, Body: eventList},
+	}
+	response, err := c.Setup(t).Events(ns).List(labels.Everything(),
+		fields.Everything())
+
+	if err != nil {
+		t.Errorf("%#v should be nil.", err)
+	}
+
+	if len(response.Items) != 1 {
+		t.Errorf("%#v response.Items should have len 1.", response.Items)
+	}
+
+	responseEvent := response.Items[0]
+	if e, r := eventList.Items[0].InvolvedObject,
+		responseEvent.InvolvedObject; !reflect.DeepEqual(e, r) {
+		t.Errorf("%#v != %#v.", e, r)
+	}
+}
+
+func TestEventDelete(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request: testRequest{
+			Method: "DELETE",
+			Path:   testapi.Default.ResourcePath("events", ns, "foo"),
+		},
+		Response: Response{StatusCode: 200},
+	}
+	err := c.Setup(t).Events(ns).Delete("foo")
+	c.Validate(t, nil, err)
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/experimental.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/experimental.go
@@ -37,6 +37,7 @@ type ExperimentalInterface interface {
 	DaemonSetsNamespacer
 	DeploymentsNamespacer
 	JobsNamespacer
+	IngressNamespacer
 }
 
 // ExperimentalClient is used to interact with experimental Kubernetes features.
@@ -95,6 +96,10 @@ func (c *ExperimentalClient) Jobs(namespace string) JobInterface {
 	return newJobs(c, namespace)
 }
 
+func (c *ExperimentalClient) Ingress(namespace string) IngressInterface {
+	return newIngress(c, namespace)
+}
+
 // NewExperimental creates a new ExperimentalClient for the given config. This client
 // provides access to experimental Kubernetes features.
 // Experimental features are not supported and may be changed or removed in
@@ -129,22 +134,21 @@ func setExperimentalDefaults(config *Config) error {
 	if err != nil {
 		return err
 	}
-	config.Prefix = "apis/" + g.Group
+	config.Prefix = "apis/"
 	if config.UserAgent == "" {
 		config.UserAgent = DefaultKubernetesUserAgent()
 	}
-	if config.Version == "" {
-		config.Version = g.Version
-	}
+	// TODO: Unconditionally set the config.Version, until we fix the config.
+	//if config.Version == "" {
+	config.Version = g.GroupVersion
+	//}
 
 	versionInterfaces, err := g.InterfacesFor(config.Version)
 	if err != nil {
 		return fmt.Errorf("Experimental API version '%s' is not recognized (valid values: %s)",
 			config.Version, strings.Join(latest.GroupOrDie("experimental").Versions, ", "))
 	}
-	if config.Codec == nil {
-		config.Codec = versionInterfaces.Codec
-	}
+	config.Codec = versionInterfaces.Codec
 	if config.QPS == 0 {
 		config.QPS = 5
 	}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/flags_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/flags_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/kubernetes/pkg/util/sets"
+)
+
+type fakeFlagSet struct {
+	t   *testing.T
+	set sets.String
+}
+
+func (f *fakeFlagSet) StringVar(p *string, name, value, usage string) {
+	if p == nil {
+		f.t.Errorf("unexpected nil pointer")
+	}
+	if usage == "" {
+		f.t.Errorf("unexpected empty usage")
+	}
+	f.set.Insert(name)
+}
+
+func (f *fakeFlagSet) BoolVar(p *bool, name string, value bool, usage string) {
+	if p == nil {
+		f.t.Errorf("unexpected nil pointer")
+	}
+	if usage == "" {
+		f.t.Errorf("unexpected empty usage")
+	}
+	f.set.Insert(name)
+}
+
+func (f *fakeFlagSet) UintVar(p *uint, name string, value uint, usage string) {
+	if p == nil {
+		f.t.Errorf("unexpected nil pointer")
+	}
+	if usage == "" {
+		f.t.Errorf("unexpected empty usage")
+	}
+	f.set.Insert(name)
+}
+
+func (f *fakeFlagSet) DurationVar(p *time.Duration, name string, value time.Duration, usage string) {
+	if p == nil {
+		f.t.Errorf("unexpected nil pointer")
+	}
+	if usage == "" {
+		f.t.Errorf("unexpected empty usage")
+	}
+	f.set.Insert(name)
+}
+
+func (f *fakeFlagSet) IntVar(p *int, name string, value int, usage string) {
+	if p == nil {
+		f.t.Errorf("unexpected nil pointer")
+	}
+	if usage == "" {
+		f.t.Errorf("unexpected empty usage")
+	}
+	f.set.Insert(name)
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/helper.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/helper.go
@@ -100,6 +100,9 @@ type KubeletConfig struct {
 	// TLSClientConfig contains settings to enable transport layer security
 	TLSClientConfig
 
+	// Server requires Bearer authentication
+	BearerToken string
+
 	// HTTPTimeout is used by the client to timeout http requests to Kubelet.
 	HTTPTimeout time.Duration
 
@@ -228,9 +231,11 @@ func NegotiateVersion(client *Client, c *Config, version string, clientRegistere
 		if serverVersions.Has(clientVersion) {
 			// Version was not explicitly requested in command config (--api-version).
 			// Ok to fall back to a supported version with a warning.
-			if len(version) != 0 {
-				glog.Warningf("Server does not support API version '%s'. Falling back to '%s'.", version, clientVersion)
-			}
+			// TODO: caesarxuchao: enable the warning message when we have
+			// proper fix. Please refer to issue #14895.
+			// if len(version) != 0 {
+			// 	glog.Warningf("Server does not support API version '%s'. Falling back to '%s'.", version, clientVersion)
+			// }
 			return clientVersion, nil
 		}
 	}
@@ -259,7 +264,7 @@ func InClusterConfig() (*Config, error) {
 	tlsClientConfig := TLSClientConfig{}
 	rootCAFile := "/var/run/secrets/kubernetes.io/serviceaccount/" + api.ServiceAccountRootCAKey
 	if _, err := util.CertPoolFromFile(rootCAFile); err != nil {
-		glog.Errorf("expected to load root CA config from %s, but got err: %v", rootCAFile, err)
+		glog.Errorf("Expected to load root CA config from %s, but got err: %v", rootCAFile, err)
 	} else {
 		tlsClientConfig.CAFile = rootCAFile
 	}
@@ -378,15 +383,9 @@ func tlsTransportFor(config *Config) (http.RoundTripper, error) {
 	}
 
 	// Cache a single transport for these options
-	tlsTransports[key] = &http.Transport{
+	tlsTransports[key] = util.SetTransportDefaults(&http.Transport{
 		TLSClientConfig: tlsConfig,
-		Proxy:           http.ProxyFromEnvironment,
-		Dial: (&net.Dialer{
-			Timeout:   30 * time.Second,
-			KeepAlive: 30 * time.Second,
-		}).Dial,
-		TLSHandshakeTimeout: 10 * time.Second,
-	}
+	})
 	return tlsTransports[key], nil
 }
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/helper_blackbox_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/helper_blackbox_test.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/client/unversioned/fake"
+)
+
+func objBody(object interface{}) io.ReadCloser {
+	output, err := json.MarshalIndent(object, "", "")
+	if err != nil {
+		panic(err)
+	}
+	return ioutil.NopCloser(bytes.NewReader([]byte(output)))
+}
+
+func TestNegotiateVersion(t *testing.T) {
+	tests := []struct {
+		name, version, expectedVersion string
+		serverVersions                 []string
+		clientVersions                 []string
+		config                         *unversioned.Config
+		expectErr                      bool
+	}{
+		{
+			name:            "server supports client default",
+			version:         "version1",
+			config:          &unversioned.Config{},
+			serverVersions:  []string{"version1", testapi.Default.Version()},
+			clientVersions:  []string{"version1", testapi.Default.Version()},
+			expectedVersion: "version1",
+			expectErr:       false,
+		},
+		{
+			name:            "server falls back to client supported",
+			version:         testapi.Default.Version(),
+			config:          &unversioned.Config{},
+			serverVersions:  []string{"version1"},
+			clientVersions:  []string{"version1", testapi.Default.Version()},
+			expectedVersion: "version1",
+			expectErr:       false,
+		},
+		{
+			name:            "explicit version supported",
+			version:         "",
+			config:          &unversioned.Config{Version: testapi.Default.Version()},
+			serverVersions:  []string{"version1", testapi.Default.Version()},
+			clientVersions:  []string{"version1", testapi.Default.Version()},
+			expectedVersion: testapi.Default.Version(),
+			expectErr:       false,
+		},
+		{
+			name:            "explicit version not supported",
+			version:         "",
+			config:          &unversioned.Config{Version: testapi.Default.Version()},
+			serverVersions:  []string{"version1"},
+			clientVersions:  []string{"version1", testapi.Default.Version()},
+			expectedVersion: "",
+			expectErr:       true,
+		},
+	}
+	codec := testapi.Default.Codec()
+
+	for _, test := range tests {
+		fakeClient := &fake.RESTClient{
+			Codec: codec,
+			Resp: &http.Response{
+				StatusCode: 200,
+				Body:       objBody(&api.APIVersions{Versions: test.serverVersions}),
+			},
+			Client: fake.HTTPClientFunc(func(req *http.Request) (*http.Response, error) {
+				return &http.Response{StatusCode: 200, Body: objBody(&api.APIVersions{Versions: test.serverVersions})}, nil
+			}),
+		}
+		c := unversioned.NewOrDie(test.config)
+		c.Client = fakeClient.Client
+		response, err := unversioned.NegotiateVersion(c, test.config, test.version, test.clientVersions)
+		if err == nil && test.expectErr {
+			t.Errorf("expected error, got nil for [%s].", test.name)
+		}
+		if err != nil && !test.expectErr {
+			t.Errorf("unexpected error for [%s]: %v.", test.name, err)
+		}
+		if response != test.expectedVersion {
+			t.Errorf("expected version %s, got %s.", test.expectedVersion, response)
+		}
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/helper_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/helper_test.go
@@ -1,0 +1,376 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api/testapi"
+)
+
+const (
+	rootCACert = `-----BEGIN CERTIFICATE-----
+MIIC4DCCAcqgAwIBAgIBATALBgkqhkiG9w0BAQswIzEhMB8GA1UEAwwYMTAuMTMu
+MTI5LjEwNkAxNDIxMzU5MDU4MB4XDTE1MDExNTIxNTczN1oXDTE2MDExNTIxNTcz
+OFowIzEhMB8GA1UEAwwYMTAuMTMuMTI5LjEwNkAxNDIxMzU5MDU4MIIBIjANBgkq
+hkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAunDRXGwsiYWGFDlWH6kjGun+PshDGeZX
+xtx9lUnL8pIRWH3wX6f13PO9sktaOWW0T0mlo6k2bMlSLlSZgG9H6og0W6gLS3vq
+s4VavZ6DbXIwemZG2vbRwsvR+t4G6Nbwelm6F8RFnA1Fwt428pavmNQ/wgYzo+T1
+1eS+HiN4ACnSoDSx3QRWcgBkB1g6VReofVjx63i0J+w8Q/41L9GUuLqquFxu6ZnH
+60vTB55lHgFiDLjA1FkEz2dGvGh/wtnFlRvjaPC54JH2K1mPYAUXTreoeJtLJKX0
+ycoiyB24+zGCniUmgIsmQWRPaOPircexCp1BOeze82BT1LCZNTVaxQIDAQABoyMw
+ITAOBgNVHQ8BAf8EBAMCAKQwDwYDVR0TAQH/BAUwAwEB/zALBgkqhkiG9w0BAQsD
+ggEBADMxsUuAFlsYDpF4fRCzXXwrhbtj4oQwcHpbu+rnOPHCZupiafzZpDu+rw4x
+YGPnCb594bRTQn4pAu3Ac18NbLD5pV3uioAkv8oPkgr8aUhXqiv7KdDiaWm6sbAL
+EHiXVBBAFvQws10HMqMoKtO8f1XDNAUkWduakR/U6yMgvOPwS7xl0eUTqyRB6zGb
+K55q2dejiFWaFqB/y78txzvz6UlOZKE44g2JAVoJVM6kGaxh33q8/FmrL4kuN3ut
+W+MmJCVDvd4eEqPwbp7146ZWTqpIJ8lvA6wuChtqV8lhAPka2hD/LMqY8iXNmfXD
+uml0obOEy+ON91k+SWTJ3ggmF/U=
+-----END CERTIFICATE-----`
+
+	certData = `-----BEGIN CERTIFICATE-----
+MIIC6jCCAdSgAwIBAgIBCzALBgkqhkiG9w0BAQswIzEhMB8GA1UEAwwYMTAuMTMu
+MTI5LjEwNkAxNDIxMzU5MDU4MB4XDTE1MDExNTIyMDEzMVoXDTE2MDExNTIyMDEz
+MlowGzEZMBcGA1UEAxMQb3BlbnNoaWZ0LWNsaWVudDCCASIwDQYJKoZIhvcNAQEB
+BQADggEPADCCAQoCggEBAKtdhz0+uCLXw5cSYns9rU/XifFSpb/x24WDdrm72S/v
+b9BPYsAStiP148buylr1SOuNi8sTAZmlVDDIpIVwMLff+o2rKYDicn9fjbrTxTOj
+lI4pHJBH+JU3AJ0tbajupioh70jwFS0oYpwtneg2zcnE2Z4l6mhrj2okrc5Q1/X2
+I2HChtIU4JYTisObtin10QKJX01CLfYXJLa8upWzKZ4/GOcHG+eAV3jXWoXidtjb
+1Usw70amoTZ6mIVCkiu1QwCoa8+ycojGfZhvqMsAp1536ZcCul+Na+AbCv4zKS7F
+kQQaImVrXdUiFansIoofGlw/JNuoKK6ssVpS5Ic3pgcCAwEAAaM1MDMwDgYDVR0P
+AQH/BAQDAgCgMBMGA1UdJQQMMAoGCCsGAQUFBwMCMAwGA1UdEwEB/wQCMAAwCwYJ
+KoZIhvcNAQELA4IBAQCKLREH7bXtXtZ+8vI6cjD7W3QikiArGqbl36bAhhWsJLp/
+p/ndKz39iFNaiZ3GlwIURWOOKx3y3GA0x9m8FR+Llthf0EQ8sUjnwaknWs0Y6DQ3
+jjPFZOpV3KPCFrdMJ3++E3MgwFC/Ih/N2ebFX9EcV9Vcc6oVWMdwT0fsrhu683rq
+6GSR/3iVX1G/pmOiuaR0fNUaCyCfYrnI4zHBDgSfnlm3vIvN2lrsR/DQBakNL8DJ
+HBgKxMGeUPoneBv+c8DMXIL0EhaFXRlBv9QW45/GiAIOuyFJ0i6hCtGZpJjq4OpQ
+BRjCI+izPzFTjsxD4aORE+WOkyWFCGPWKfNejfw0
+-----END CERTIFICATE-----`
+
+	keyData = `-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEAq12HPT64ItfDlxJiez2tT9eJ8VKlv/HbhYN2ubvZL+9v0E9i
+wBK2I/Xjxu7KWvVI642LyxMBmaVUMMikhXAwt9/6jaspgOJyf1+NutPFM6OUjikc
+kEf4lTcAnS1tqO6mKiHvSPAVLShinC2d6DbNycTZniXqaGuPaiStzlDX9fYjYcKG
+0hTglhOKw5u2KfXRAolfTUIt9hcktry6lbMpnj8Y5wcb54BXeNdaheJ22NvVSzDv
+RqahNnqYhUKSK7VDAKhrz7JyiMZ9mG+oywCnXnfplwK6X41r4BsK/jMpLsWRBBoi
+ZWtd1SIVqewiih8aXD8k26gorqyxWlLkhzemBwIDAQABAoIBAD2XYRs3JrGHQUpU
+FkdbVKZkvrSY0vAZOqBTLuH0zUv4UATb8487anGkWBjRDLQCgxH+jucPTrztekQK
+aW94clo0S3aNtV4YhbSYIHWs1a0It0UdK6ID7CmdWkAj6s0T8W8lQT7C46mWYVLm
+5mFnCTHi6aB42jZrqmEpC7sivWwuU0xqj3Ml8kkxQCGmyc9JjmCB4OrFFC8NNt6M
+ObvQkUI6Z3nO4phTbpxkE1/9dT0MmPIF7GhHVzJMS+EyyRYUDllZ0wvVSOM3qZT0
+JMUaBerkNwm9foKJ1+dv2nMKZZbJajv7suUDCfU44mVeaEO+4kmTKSGCGjjTBGkr
+7L1ySDECgYEA5ElIMhpdBzIivCuBIH8LlUeuzd93pqssO1G2Xg0jHtfM4tz7fyeI
+cr90dc8gpli24dkSxzLeg3Tn3wIj/Bu64m2TpZPZEIlukYvgdgArmRIPQVxerYey
+OkrfTNkxU1HXsYjLCdGcGXs5lmb+K/kuTcFxaMOs7jZi7La+jEONwf8CgYEAwCs/
+rUOOA0klDsWWisbivOiNPII79c9McZCNBqncCBfMUoiGe8uWDEO4TFHN60vFuVk9
+8PkwpCfvaBUX+ajvbafIfHxsnfk1M04WLGCeqQ/ym5Q4sQoQOcC1b1y9qc/xEWfg
+nIUuia0ukYRpl7qQa3tNg+BNFyjypW8zukUAC/kCgYB1/Kojuxx5q5/oQVPrx73k
+2bevD+B3c+DYh9MJqSCNwFtUpYIWpggPxoQan4LwdsmO0PKzocb/ilyNFj4i/vII
+NToqSc/WjDFpaDIKyuu9oWfhECye45NqLWhb/6VOuu4QA/Nsj7luMhIBehnEAHW+
+GkzTKM8oD1PxpEG3nPKXYQKBgQC6AuMPRt3XBl1NkCrpSBy/uObFlFaP2Enpf39S
+3OZ0Gv0XQrnSaL1kP8TMcz68rMrGX8DaWYsgytstR4W+jyy7WvZwsUu+GjTJ5aMG
+77uEcEBpIi9CBzivfn7hPccE8ZgqPf+n4i6q66yxBJflW5xhvafJqDtW2LcPNbW/
+bvzdmQKBgExALRUXpq+5dbmkdXBHtvXdRDZ6rVmrnjy4nI5bPw+1GqQqk6uAR6B/
+F6NmLCQOO4PDG/cuatNHIr2FrwTmGdEL6ObLUGWn9Oer9gJhHVqqsY5I4sEPo4XX
+stR0Yiw0buV6DL/moUO0HIM9Bjh96HJp+LxiIS6UCdIhMPp5HoQa
+-----END RSA PRIVATE KEY-----`
+)
+
+func TestTransportFor(t *testing.T) {
+	testCases := map[string]struct {
+		Config  *Config
+		Err     bool
+		TLS     bool
+		Default bool
+	}{
+		"default transport": {
+			Default: true,
+			Config:  &Config{},
+		},
+
+		"ca transport": {
+			TLS: true,
+			Config: &Config{
+				TLSClientConfig: TLSClientConfig{
+					CAData: []byte(rootCACert),
+				},
+			},
+		},
+		"bad ca file transport": {
+			Err: true,
+			Config: &Config{
+				TLSClientConfig: TLSClientConfig{
+					CAFile: "invalid file",
+				},
+			},
+		},
+		"ca data overriding bad ca file transport": {
+			TLS: true,
+			Config: &Config{
+				TLSClientConfig: TLSClientConfig{
+					CAData: []byte(rootCACert),
+					CAFile: "invalid file",
+				},
+			},
+		},
+
+		"cert transport": {
+			TLS: true,
+			Config: &Config{
+				TLSClientConfig: TLSClientConfig{
+					CertData: []byte(certData),
+					KeyData:  []byte(keyData),
+					CAData:   []byte(rootCACert),
+				},
+			},
+		},
+		"bad cert data transport": {
+			Err: true,
+			Config: &Config{
+				TLSClientConfig: TLSClientConfig{
+					CertData: []byte(certData),
+					KeyData:  []byte("bad key data"),
+					CAData:   []byte(rootCACert),
+				},
+			},
+		},
+		"bad file cert transport": {
+			Err: true,
+			Config: &Config{
+				TLSClientConfig: TLSClientConfig{
+					CertData: []byte(certData),
+					KeyFile:  "invalid file",
+					CAData:   []byte(rootCACert),
+				},
+			},
+		},
+		"key data overriding bad file cert transport": {
+			TLS: true,
+			Config: &Config{
+				TLSClientConfig: TLSClientConfig{
+					CertData: []byte(certData),
+					KeyData:  []byte(keyData),
+					KeyFile:  "invalid file",
+					CAData:   []byte(rootCACert),
+				},
+			},
+		},
+	}
+	for k, testCase := range testCases {
+		transport, err := TransportFor(testCase.Config)
+		switch {
+		case testCase.Err && err == nil:
+			t.Errorf("%s: unexpected non-error", k)
+			continue
+		case !testCase.Err && err != nil:
+			t.Errorf("%s: unexpected error: %v", k, err)
+			continue
+		}
+
+		switch {
+		case testCase.Default && transport != http.DefaultTransport:
+			t.Errorf("%s: expected the default transport, got %#v", k, transport)
+			continue
+		case !testCase.Default && transport == http.DefaultTransport:
+			t.Errorf("%s: expected non-default transport, got %#v", k, transport)
+			continue
+		}
+
+		// We only know how to check TLSConfig on http.Transports
+		if transport, ok := transport.(*http.Transport); ok {
+			switch {
+			case testCase.TLS && transport.TLSClientConfig == nil:
+				t.Errorf("%s: expected TLSClientConfig, got %#v", k, transport)
+				continue
+			case !testCase.TLS && transport.TLSClientConfig != nil:
+				t.Errorf("%s: expected no TLSClientConfig, got %#v", k, transport)
+				continue
+			}
+		}
+	}
+}
+
+func TestTLSTransportCache(t *testing.T) {
+	// Empty the cache
+	tlsTransports = map[string]*http.Transport{}
+	// Construct several transports (Insecure=true to force a transport with custom tls settings)
+	identicalConfigurations := map[string]*Config{
+		"empty":          {Insecure: true},
+		"host":           {Insecure: true, Host: "foo"},
+		"prefix":         {Insecure: true, Prefix: "foo"},
+		"version":        {Insecure: true, Version: "foo"},
+		"codec":          {Insecure: true, Codec: testapi.Default.Codec()},
+		"basic":          {Insecure: true, Username: "bob", Password: "password"},
+		"bearer":         {Insecure: true, BearerToken: "token"},
+		"user agent":     {Insecure: true, UserAgent: "useragent"},
+		"wrap transport": {Insecure: true, WrapTransport: func(http.RoundTripper) http.RoundTripper { return nil }},
+		"qps/burst":      {Insecure: true, QPS: 1.0, Burst: 10},
+	}
+	for k, v := range identicalConfigurations {
+		if _, err := TransportFor(v); err != nil {
+			t.Errorf("Unexpected error for %q: %v", k, err)
+		}
+	}
+	if len(tlsTransports) != 1 {
+		t.Errorf("Expected 1 cached transport, got %d", len(tlsTransports))
+	}
+
+	// Empty the cache
+	tlsTransports = map[string]*http.Transport{}
+	// Construct several transports with custom TLS settings
+	// (no normalization is performed on ca/cert/key data, so appending a newline lets us test "different" content)
+	uniqueConfigurations := map[string]*Config{
+		"insecure":                {Insecure: true},
+		"cadata 1":                {TLSClientConfig: TLSClientConfig{CAData: []byte(rootCACert)}},
+		"cadata 2":                {TLSClientConfig: TLSClientConfig{CAData: []byte(rootCACert + "\n")}},
+		"cert 1, key 1":           {TLSClientConfig: TLSClientConfig{CertData: []byte(certData), KeyData: []byte(keyData)}},
+		"cert 1, key 2":           {TLSClientConfig: TLSClientConfig{CertData: []byte(certData), KeyData: []byte(keyData + "\n")}},
+		"cert 2, key 1":           {TLSClientConfig: TLSClientConfig{CertData: []byte(certData + "\n"), KeyData: []byte(keyData)}},
+		"cert 2, key 2":           {TLSClientConfig: TLSClientConfig{CertData: []byte(certData + "\n"), KeyData: []byte(keyData + "\n")}},
+		"cadata 1, cert 1, key 1": {TLSClientConfig: TLSClientConfig{CAData: []byte(rootCACert), CertData: []byte(certData), KeyData: []byte(keyData)}},
+	}
+	for k, v := range uniqueConfigurations {
+		if _, err := TransportFor(v); err != nil {
+			t.Errorf("Unexpected error for %q: %v", k, err)
+		}
+	}
+	// All custom configs should result in a cache entry
+	if len(tlsTransports) != len(uniqueConfigurations) {
+		t.Errorf("Expected %d cached transports, got %d", len(uniqueConfigurations), len(tlsTransports))
+	}
+
+	// Empty the cache
+	tlsTransports = map[string]*http.Transport{}
+	if _, err := TransportFor(&Config{}); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	// A client config with no TLS options should use http.DefaultTransport, not a cached custom transport
+	if len(tlsTransports) != 0 {
+		t.Errorf("Expected no cached transports, got %d", len(tlsTransports))
+	}
+}
+
+func TestIsConfigTransportTLS(t *testing.T) {
+	testCases := []struct {
+		Config       *Config
+		TransportTLS bool
+	}{
+		{
+			Config:       &Config{},
+			TransportTLS: false,
+		},
+		{
+			Config: &Config{
+				Host: "https://localhost",
+			},
+			TransportTLS: true,
+		},
+		{
+			Config: &Config{
+				Host: "localhost",
+				TLSClientConfig: TLSClientConfig{
+					CertFile: "foo",
+				},
+			},
+			TransportTLS: true,
+		},
+		{
+			Config: &Config{
+				Host: "///:://localhost",
+				TLSClientConfig: TLSClientConfig{
+					CertFile: "foo",
+				},
+			},
+			TransportTLS: false,
+		},
+		{
+			Config: &Config{
+				Host:     "1.2.3.4:567",
+				Insecure: true,
+			},
+			TransportTLS: true,
+		},
+	}
+	for _, testCase := range testCases {
+		if err := SetKubernetesDefaults(testCase.Config); err != nil {
+			t.Errorf("setting defaults failed for %#v: %v", testCase.Config, err)
+			continue
+		}
+		useTLS := IsConfigTransportTLS(*testCase.Config)
+		if testCase.TransportTLS != useTLS {
+			t.Errorf("expected %v for %#v", testCase.TransportTLS, testCase.Config)
+		}
+	}
+}
+
+func TestSetKubernetesDefaults(t *testing.T) {
+	testCases := []struct {
+		Config Config
+		After  Config
+		Err    bool
+	}{
+		{
+			Config{},
+			Config{
+				Prefix:  "/api",
+				Version: testapi.Default.Version(),
+				Codec:   testapi.Default.Codec(),
+				QPS:     5,
+				Burst:   10,
+			},
+			false,
+		},
+		{
+			Config{
+				Version: "not_an_api",
+			},
+			Config{},
+			true,
+		},
+	}
+	for _, testCase := range testCases {
+		val := &testCase.Config
+		err := SetKubernetesDefaults(val)
+		val.UserAgent = ""
+		switch {
+		case err == nil && testCase.Err:
+			t.Errorf("expected error but was nil")
+			continue
+		case err != nil && !testCase.Err:
+			t.Errorf("unexpected error %v", err)
+			continue
+		case err != nil:
+			continue
+		}
+		if !reflect.DeepEqual(*val, testCase.After) {
+			t.Errorf("unexpected result object: %#v", val)
+		}
+	}
+}
+
+func TestSetKubernetesDefaultsUserAgent(t *testing.T) {
+	config := &Config{}
+	if err := SetKubernetesDefaults(config); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !strings.Contains(config.UserAgent, "kubernetes/") {
+		t.Errorf("no user agent set: %#v", config)
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/horizontalpodautoscaler_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/horizontalpodautoscaler_test.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"net/url"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/apis/experimental"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+func getHorizontalPodAutoscalersResoureName() string {
+	return "horizontalpodautoscalers"
+}
+
+func TestHorizontalPodAutoscalerCreate(t *testing.T) {
+	ns := api.NamespaceDefault
+	horizontalPodAutoscaler := experimental.HorizontalPodAutoscaler{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "abc",
+			Namespace: ns,
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "POST",
+			Path:   testapi.Experimental.ResourcePath(getHorizontalPodAutoscalersResoureName(), ns, ""),
+			Query:  buildQueryValues(nil),
+			Body:   &horizontalPodAutoscaler,
+		},
+		Response: Response{StatusCode: 200, Body: &horizontalPodAutoscaler},
+	}
+
+	response, err := c.Setup(t).Experimental().HorizontalPodAutoscalers(ns).Create(&horizontalPodAutoscaler)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	c.Validate(t, response, err)
+}
+
+func TestHorizontalPodAutoscalerGet(t *testing.T) {
+	ns := api.NamespaceDefault
+	horizontalPodAutoscaler := &experimental.HorizontalPodAutoscaler{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "abc",
+			Namespace: ns,
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Experimental.ResourcePath(getHorizontalPodAutoscalersResoureName(), ns, "abc"),
+			Query:  buildQueryValues(nil),
+			Body:   nil,
+		},
+		Response: Response{StatusCode: 200, Body: horizontalPodAutoscaler},
+	}
+
+	response, err := c.Setup(t).Experimental().HorizontalPodAutoscalers(ns).Get("abc")
+	c.Validate(t, response, err)
+}
+
+func TestHorizontalPodAutoscalerList(t *testing.T) {
+	ns := api.NamespaceDefault
+	horizontalPodAutoscalerList := &experimental.HorizontalPodAutoscalerList{
+		Items: []experimental.HorizontalPodAutoscaler{
+			{
+				ObjectMeta: api.ObjectMeta{
+					Name:      "foo",
+					Namespace: ns,
+				},
+			},
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Experimental.ResourcePath(getHorizontalPodAutoscalersResoureName(), ns, ""),
+			Query:  buildQueryValues(nil),
+			Body:   nil,
+		},
+		Response: Response{StatusCode: 200, Body: horizontalPodAutoscalerList},
+	}
+	response, err := c.Setup(t).Experimental().HorizontalPodAutoscalers(ns).List(labels.Everything(), fields.Everything())
+	c.Validate(t, response, err)
+}
+
+func TestHorizontalPodAutoscalerUpdate(t *testing.T) {
+	ns := api.NamespaceDefault
+	horizontalPodAutoscaler := &experimental.HorizontalPodAutoscaler{
+		ObjectMeta: api.ObjectMeta{
+			Name:            "abc",
+			Namespace:       ns,
+			ResourceVersion: "1",
+		},
+	}
+	c := &testClient{
+		Request:  testRequest{Method: "PUT", Path: testapi.Experimental.ResourcePath(getHorizontalPodAutoscalersResoureName(), ns, "abc"), Query: buildQueryValues(nil)},
+		Response: Response{StatusCode: 200, Body: horizontalPodAutoscaler},
+	}
+	response, err := c.Setup(t).Experimental().HorizontalPodAutoscalers(ns).Update(horizontalPodAutoscaler)
+	c.Validate(t, response, err)
+}
+
+func TestHorizontalPodAutoscalerDelete(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request:  testRequest{Method: "DELETE", Path: testapi.Experimental.ResourcePath(getHorizontalPodAutoscalersResoureName(), ns, "foo"), Query: buildQueryValues(nil)},
+		Response: Response{StatusCode: 200},
+	}
+	err := c.Setup(t).Experimental().HorizontalPodAutoscalers(ns).Delete("foo", nil)
+	c.Validate(t, nil, err)
+}
+
+func TestHorizontalPodAutoscalerWatch(t *testing.T) {
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Experimental.ResourcePathWithPrefix("watch", getHorizontalPodAutoscalersResoureName(), "", ""),
+			Query:  url.Values{"resourceVersion": []string{}}},
+		Response: Response{StatusCode: 200},
+	}
+	_, err := c.Setup(t).Experimental().HorizontalPodAutoscalers(api.NamespaceAll).Watch(labels.Everything(), fields.Everything(), "")
+	c.Validate(t, nil, err)
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/ingress.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/ingress.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apis/experimental"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+// IngressNamespacer has methods to work with Ingress resources in a namespace
+type IngressNamespacer interface {
+	Ingress(namespace string) IngressInterface
+}
+
+// IngressInterface exposes methods to work on Ingress resources.
+type IngressInterface interface {
+	List(label labels.Selector, field fields.Selector) (*experimental.IngressList, error)
+	Get(name string) (*experimental.Ingress, error)
+	Create(ingress *experimental.Ingress) (*experimental.Ingress, error)
+	Update(ingress *experimental.Ingress) (*experimental.Ingress, error)
+	Delete(name string, options *api.DeleteOptions) error
+	Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error)
+	UpdateStatus(ingress *experimental.Ingress) (*experimental.Ingress, error)
+}
+
+// ingress implements IngressNamespacer interface
+type ingress struct {
+	r  *ExperimentalClient
+	ns string
+}
+
+// newIngress returns a ingress
+func newIngress(c *ExperimentalClient, namespace string) *ingress {
+	return &ingress{c, namespace}
+}
+
+// List returns a list of ingress that match the label and field selectors.
+func (c *ingress) List(label labels.Selector, field fields.Selector) (result *experimental.IngressList, err error) {
+	result = &experimental.IngressList{}
+	err = c.r.Get().Namespace(c.ns).Resource("ingress").LabelsSelectorParam(label).FieldsSelectorParam(field).Do().Into(result)
+	return
+}
+
+// Get returns information about a particular ingress.
+func (c *ingress) Get(name string) (result *experimental.Ingress, err error) {
+	result = &experimental.Ingress{}
+	err = c.r.Get().Namespace(c.ns).Resource("ingress").Name(name).Do().Into(result)
+	return
+}
+
+// Create creates a new ingress.
+func (c *ingress) Create(ingress *experimental.Ingress) (result *experimental.Ingress, err error) {
+	result = &experimental.Ingress{}
+	err = c.r.Post().Namespace(c.ns).Resource("ingress").Body(ingress).Do().Into(result)
+	return
+}
+
+// Update updates an existing ingress.
+func (c *ingress) Update(ingress *experimental.Ingress) (result *experimental.Ingress, err error) {
+	result = &experimental.Ingress{}
+	err = c.r.Put().Namespace(c.ns).Resource("ingress").Name(ingress.Name).Body(ingress).Do().Into(result)
+	return
+}
+
+// Delete deletes a ingress, returns error if one occurs.
+func (c *ingress) Delete(name string, options *api.DeleteOptions) (err error) {
+	if options == nil {
+		return c.r.Delete().Namespace(c.ns).Resource("ingress").Name(name).Do().Error()
+	}
+
+	body, err := api.Scheme.EncodeToVersion(options, c.r.APIVersion())
+	if err != nil {
+		return err
+	}
+	return c.r.Delete().Namespace(c.ns).Resource("ingress").Name(name).Body(body).Do().Error()
+}
+
+// Watch returns a watch.Interface that watches the requested ingress.
+func (c *ingress) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	return c.r.Get().
+		Prefix("watch").
+		Namespace(c.ns).
+		Resource("ingress").
+		Param("resourceVersion", resourceVersion).
+		LabelsSelectorParam(label).
+		FieldsSelectorParam(field).
+		Watch()
+}
+
+// UpdateStatus takes the name of the ingress and the new status.  Returns the server's representation of the ingress, and an error, if it occurs.
+func (c *ingress) UpdateStatus(ingress *experimental.Ingress) (result *experimental.Ingress, err error) {
+	result = &experimental.Ingress{}
+	err = c.r.Put().Namespace(c.ns).Resource("ingress").Name(ingress.Name).SubResource("status").Body(ingress).Do().Into(result)
+	return
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/ingress_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/ingress_test.go
@@ -1,0 +1,230 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/apis/experimental"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+func getIngressResourceName() string {
+	return "ingress"
+}
+
+func TestListIngress(t *testing.T) {
+	ns := api.NamespaceAll
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Experimental.ResourcePath(getIngressResourceName(), ns, ""),
+		},
+		Response: Response{StatusCode: 200,
+			Body: &experimental.IngressList{
+				Items: []experimental.Ingress{
+					{
+						ObjectMeta: api.ObjectMeta{
+							Name: "foo",
+							Labels: map[string]string{
+								"foo":  "bar",
+								"name": "baz",
+							},
+						},
+						Spec: experimental.IngressSpec{
+							Rules: []experimental.IngressRule{},
+						},
+					},
+				},
+			},
+		},
+	}
+	receivedIngressList, err := c.Setup(t).Experimental().Ingress(ns).List(labels.Everything(), fields.Everything())
+	c.Validate(t, receivedIngressList, err)
+}
+
+func TestGetIngress(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Experimental.ResourcePath(getIngressResourceName(), ns, "foo"),
+			Query:  buildQueryValues(nil),
+		},
+		Response: Response{
+			StatusCode: 200,
+			Body: &experimental.Ingress{
+				ObjectMeta: api.ObjectMeta{
+					Name: "foo",
+					Labels: map[string]string{
+						"foo":  "bar",
+						"name": "baz",
+					},
+				},
+				Spec: experimental.IngressSpec{
+					Rules: []experimental.IngressRule{},
+				},
+			},
+		},
+	}
+	receivedIngress, err := c.Setup(t).Experimental().Ingress(ns).Get("foo")
+	c.Validate(t, receivedIngress, err)
+}
+
+func TestGetIngressWithNoName(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{Error: true}
+	receivedIngress, err := c.Setup(t).Experimental().Ingress(ns).Get("")
+	if (err != nil) && (err.Error() != nameRequiredError) {
+		t.Errorf("Expected error: %v, but got %v", nameRequiredError, err)
+	}
+
+	c.Validate(t, receivedIngress, err)
+}
+
+func TestUpdateIngress(t *testing.T) {
+	ns := api.NamespaceDefault
+	requestIngress := &experimental.Ingress{
+		ObjectMeta: api.ObjectMeta{
+			Name:            "foo",
+			Namespace:       ns,
+			ResourceVersion: "1",
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "PUT",
+			Path:   testapi.Experimental.ResourcePath(getIngressResourceName(), ns, "foo"),
+			Query:  buildQueryValues(nil),
+		},
+		Response: Response{
+			StatusCode: 200,
+			Body: &experimental.Ingress{
+				ObjectMeta: api.ObjectMeta{
+					Name: "foo",
+					Labels: map[string]string{
+						"foo":  "bar",
+						"name": "baz",
+					},
+				},
+				Spec: experimental.IngressSpec{
+					Rules: []experimental.IngressRule{},
+				},
+			},
+		},
+	}
+	receivedIngress, err := c.Setup(t).Experimental().Ingress(ns).Update(requestIngress)
+	c.Validate(t, receivedIngress, err)
+}
+
+func TestUpdateIngressStatus(t *testing.T) {
+	ns := api.NamespaceDefault
+	lbStatus := api.LoadBalancerStatus{
+		Ingress: []api.LoadBalancerIngress{
+			{IP: "127.0.0.1"},
+		},
+	}
+	requestIngress := &experimental.Ingress{
+		ObjectMeta: api.ObjectMeta{
+			Name:            "foo",
+			Namespace:       ns,
+			ResourceVersion: "1",
+		},
+		Status: experimental.IngressStatus{
+			LoadBalancer: lbStatus,
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "PUT",
+			Path:   testapi.Experimental.ResourcePath(getIngressResourceName(), ns, "foo") + "/status",
+			Query:  buildQueryValues(nil),
+		},
+		Response: Response{
+			StatusCode: 200,
+			Body: &experimental.Ingress{
+				ObjectMeta: api.ObjectMeta{
+					Name: "foo",
+					Labels: map[string]string{
+						"foo":  "bar",
+						"name": "baz",
+					},
+				},
+				Spec: experimental.IngressSpec{
+					Rules: []experimental.IngressRule{},
+				},
+				Status: experimental.IngressStatus{
+					LoadBalancer: lbStatus,
+				},
+			},
+		},
+	}
+	receivedIngress, err := c.Setup(t).Experimental().Ingress(ns).UpdateStatus(requestIngress)
+	c.Validate(t, receivedIngress, err)
+}
+
+func TestDeleteIngress(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request: testRequest{
+			Method: "DELETE",
+			Path:   testapi.Experimental.ResourcePath(getIngressResourceName(), ns, "foo"),
+			Query:  buildQueryValues(nil),
+		},
+		Response: Response{StatusCode: 200},
+	}
+	err := c.Setup(t).Experimental().Ingress(ns).Delete("foo", nil)
+	c.Validate(t, nil, err)
+}
+
+func TestCreateIngress(t *testing.T) {
+	ns := api.NamespaceDefault
+	requestIngress := &experimental.Ingress{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "foo",
+			Namespace: ns,
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "POST",
+			Path:   testapi.Experimental.ResourcePath(getIngressResourceName(), ns, ""),
+			Body:   requestIngress,
+			Query:  buildQueryValues(nil),
+		},
+		Response: Response{
+			StatusCode: 200,
+			Body: &experimental.Ingress{
+				ObjectMeta: api.ObjectMeta{
+					Name: "foo",
+					Labels: map[string]string{
+						"foo":  "bar",
+						"name": "baz",
+					},
+				},
+				Spec: experimental.IngressSpec{
+					Rules: []experimental.IngressRule{},
+				},
+			},
+		},
+	}
+	receivedIngress, err := c.Setup(t).Experimental().Ingress(ns).Create(requestIngress)
+	c.Validate(t, receivedIngress, err)
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/jobs.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/jobs.go
@@ -18,6 +18,7 @@ package unversioned
 
 import (
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/latest"
 	"k8s.io/kubernetes/pkg/apis/experimental"
 	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/labels"
@@ -50,6 +51,9 @@ type jobs struct {
 func newJobs(c *ExperimentalClient, namespace string) *jobs {
 	return &jobs{c, namespace}
 }
+
+// Ensure statically that jobs implements JobInterface.
+var _ JobInterface = &jobs{}
 
 // List returns a list of jobs that match the label and field selectors.
 func (c *jobs) List(label labels.Selector, field fields.Selector) (result *experimental.JobList, err error) {
@@ -85,7 +89,7 @@ func (c *jobs) Delete(name string, options *api.DeleteOptions) (err error) {
 		return c.r.Delete().Namespace(c.ns).Resource("jobs").Name(name).Do().Error()
 	}
 
-	body, err := api.Scheme.EncodeToVersion(options, c.r.APIVersion())
+	body, err := api.Scheme.EncodeToVersion(options, latest.GroupOrDie("").GroupVersion)
 	if err != nil {
 		return err
 	}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/jobs_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/jobs_test.go
@@ -1,0 +1,222 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/apis/experimental"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+func getJobResourceName() string {
+	return "jobs"
+}
+
+func TestListJobs(t *testing.T) {
+	ns := api.NamespaceAll
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Experimental.ResourcePath(getJobResourceName(), ns, ""),
+		},
+		Response: Response{StatusCode: 200,
+			Body: &experimental.JobList{
+				Items: []experimental.Job{
+					{
+						ObjectMeta: api.ObjectMeta{
+							Name: "foo",
+							Labels: map[string]string{
+								"foo":  "bar",
+								"name": "baz",
+							},
+						},
+						Spec: experimental.JobSpec{
+							Template: &api.PodTemplateSpec{},
+						},
+					},
+				},
+			},
+		},
+	}
+	receivedJobList, err := c.Setup(t).Experimental().Jobs(ns).List(labels.Everything(), fields.Everything())
+	c.Validate(t, receivedJobList, err)
+}
+
+func TestGetJob(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Experimental.ResourcePath(getJobResourceName(), ns, "foo"),
+			Query:  buildQueryValues(nil),
+		},
+		Response: Response{
+			StatusCode: 200,
+			Body: &experimental.Job{
+				ObjectMeta: api.ObjectMeta{
+					Name: "foo",
+					Labels: map[string]string{
+						"foo":  "bar",
+						"name": "baz",
+					},
+				},
+				Spec: experimental.JobSpec{
+					Template: &api.PodTemplateSpec{},
+				},
+			},
+		},
+	}
+	receivedJob, err := c.Setup(t).Experimental().Jobs(ns).Get("foo")
+	c.Validate(t, receivedJob, err)
+}
+
+func TestGetJobWithNoName(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{Error: true}
+	receivedJob, err := c.Setup(t).Experimental().Jobs(ns).Get("")
+	if (err != nil) && (err.Error() != nameRequiredError) {
+		t.Errorf("Expected error: %v, but got %v", nameRequiredError, err)
+	}
+
+	c.Validate(t, receivedJob, err)
+}
+
+func TestUpdateJob(t *testing.T) {
+	ns := api.NamespaceDefault
+	requestJob := &experimental.Job{
+		ObjectMeta: api.ObjectMeta{
+			Name:            "foo",
+			Namespace:       ns,
+			ResourceVersion: "1",
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "PUT",
+			Path:   testapi.Experimental.ResourcePath(getJobResourceName(), ns, "foo"),
+			Query:  buildQueryValues(nil),
+		},
+		Response: Response{
+			StatusCode: 200,
+			Body: &experimental.Job{
+				ObjectMeta: api.ObjectMeta{
+					Name: "foo",
+					Labels: map[string]string{
+						"foo":  "bar",
+						"name": "baz",
+					},
+				},
+				Spec: experimental.JobSpec{
+					Template: &api.PodTemplateSpec{},
+				},
+			},
+		},
+	}
+	receivedJob, err := c.Setup(t).Experimental().Jobs(ns).Update(requestJob)
+	c.Validate(t, receivedJob, err)
+}
+
+func TestUpdateJobStatus(t *testing.T) {
+	ns := api.NamespaceDefault
+	requestJob := &experimental.Job{
+		ObjectMeta: api.ObjectMeta{
+			Name:            "foo",
+			Namespace:       ns,
+			ResourceVersion: "1",
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "PUT",
+			Path:   testapi.Experimental.ResourcePath(getJobResourceName(), ns, "foo") + "/status",
+			Query:  buildQueryValues(nil),
+		},
+		Response: Response{
+			StatusCode: 200,
+			Body: &experimental.Job{
+				ObjectMeta: api.ObjectMeta{
+					Name: "foo",
+					Labels: map[string]string{
+						"foo":  "bar",
+						"name": "baz",
+					},
+				},
+				Spec: experimental.JobSpec{
+					Template: &api.PodTemplateSpec{},
+				},
+				Status: experimental.JobStatus{
+					Active: 1,
+				},
+			},
+		},
+	}
+	receivedJob, err := c.Setup(t).Experimental().Jobs(ns).UpdateStatus(requestJob)
+	c.Validate(t, receivedJob, err)
+}
+
+func TestDeleteJob(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request: testRequest{
+			Method: "DELETE",
+			Path:   testapi.Experimental.ResourcePath(getJobResourceName(), ns, "foo"),
+			Query:  buildQueryValues(nil),
+		},
+		Response: Response{StatusCode: 200},
+	}
+	err := c.Setup(t).Experimental().Jobs(ns).Delete("foo", nil)
+	c.Validate(t, nil, err)
+}
+
+func TestCreateJob(t *testing.T) {
+	ns := api.NamespaceDefault
+	requestJob := &experimental.Job{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "foo",
+			Namespace: ns,
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "POST",
+			Path:   testapi.Experimental.ResourcePath(getJobResourceName(), ns, ""),
+			Body:   requestJob,
+			Query:  buildQueryValues(nil),
+		},
+		Response: Response{
+			StatusCode: 200,
+			Body: &experimental.Job{
+				ObjectMeta: api.ObjectMeta{
+					Name: "foo",
+					Labels: map[string]string{
+						"foo":  "bar",
+						"name": "baz",
+					},
+				},
+				Spec: experimental.JobSpec{
+					Template: &api.PodTemplateSpec{},
+				},
+			},
+		},
+	}
+	receivedJob, err := c.Setup(t).Experimental().Jobs(ns).Create(requestJob)
+	c.Validate(t, receivedJob, err)
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/kubelet_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/kubelet_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/probe"
+	"k8s.io/kubernetes/pkg/util"
+)
+
+func TestHTTPKubeletClient(t *testing.T) {
+	expectObj := probe.Success
+	body, err := json.Marshal(expectObj)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	fakeHandler := util.FakeHandler{
+		StatusCode:   200,
+		ResponseBody: string(body),
+	}
+	testServer := httptest.NewServer(&fakeHandler)
+	defer testServer.Close()
+
+	_, err = url.Parse(testServer.URL)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestNewKubeletClient(t *testing.T) {
+	config := &KubeletConfig{
+		EnableHttps: false,
+	}
+
+	client, err := NewKubeletClient(config)
+	if err != nil {
+		t.Errorf("Error while trying to create a client: %v", err)
+	}
+	if client == nil {
+		t.Error("client is nil.")
+	}
+}
+
+func TestNewKubeletClientTLSInvalid(t *testing.T) {
+	config := &KubeletConfig{
+		EnableHttps: true,
+		//Invalid certificate and key path
+		TLSClientConfig: TLSClientConfig{
+			CertFile: "../testdata/mycertinvalid.cer",
+			KeyFile:  "../testdata/mycertinvalid.key",
+			CAFile:   "../testdata/myCA.cer",
+		},
+	}
+
+	client, err := NewKubeletClient(config)
+	if err == nil {
+		t.Errorf("Expected an error")
+	}
+	if client != nil {
+		t.Error("client should be nil as we provided invalid cert file")
+	}
+}
+
+func TestNewKubeletClientTLSValid(t *testing.T) {
+	config := &KubeletConfig{
+		EnableHttps: true,
+		TLSClientConfig: TLSClientConfig{
+			CertFile: "../testdata/mycertvalid.cer",
+			// TLS Configuration, only applies if EnableHttps is true.
+			KeyFile: "../testdata/mycertvalid.key",
+			// TLS Configuration, only applies if EnableHttps is true.
+			CAFile: "../testdata/myCA.cer",
+		},
+	}
+
+	client, err := NewKubeletClient(config)
+	if err != nil {
+		t.Errorf("Not expecting an error #%v", err)
+	}
+	if client == nil {
+		t.Error("client should not be nil")
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/limit_ranges_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/limit_ranges_test.go
@@ -1,0 +1,212 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"net/url"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+func getLimitRangesResourceName() string {
+	return "limitranges"
+}
+
+func TestLimitRangeCreate(t *testing.T) {
+	ns := api.NamespaceDefault
+	limitRange := &api.LimitRange{
+		ObjectMeta: api.ObjectMeta{
+			Name: "abc",
+		},
+		Spec: api.LimitRangeSpec{
+			Limits: []api.LimitRangeItem{
+				{
+					Type: api.LimitTypePod,
+					Max: api.ResourceList{
+						api.ResourceCPU:    resource.MustParse("100"),
+						api.ResourceMemory: resource.MustParse("10000"),
+					},
+					Min: api.ResourceList{
+						api.ResourceCPU:    resource.MustParse("0"),
+						api.ResourceMemory: resource.MustParse("100"),
+					},
+				},
+			},
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "POST",
+			Path:   testapi.Default.ResourcePath(getLimitRangesResourceName(), ns, ""),
+			Query:  buildQueryValues(nil),
+			Body:   limitRange,
+		},
+		Response: Response{StatusCode: 200, Body: limitRange},
+	}
+
+	response, err := c.Setup(t).LimitRanges(ns).Create(limitRange)
+	c.Validate(t, response, err)
+}
+
+func TestLimitRangeGet(t *testing.T) {
+	ns := api.NamespaceDefault
+	limitRange := &api.LimitRange{
+		ObjectMeta: api.ObjectMeta{
+			Name: "abc",
+		},
+		Spec: api.LimitRangeSpec{
+			Limits: []api.LimitRangeItem{
+				{
+					Type: api.LimitTypePod,
+					Max: api.ResourceList{
+						api.ResourceCPU:    resource.MustParse("100"),
+						api.ResourceMemory: resource.MustParse("10000"),
+					},
+					Min: api.ResourceList{
+						api.ResourceCPU:    resource.MustParse("0"),
+						api.ResourceMemory: resource.MustParse("100"),
+					},
+				},
+			},
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePath(getLimitRangesResourceName(), ns, "abc"),
+			Query:  buildQueryValues(nil),
+			Body:   nil,
+		},
+		Response: Response{StatusCode: 200, Body: limitRange},
+	}
+
+	response, err := c.Setup(t).LimitRanges(ns).Get("abc")
+	c.Validate(t, response, err)
+}
+
+func TestLimitRangeList(t *testing.T) {
+	ns := api.NamespaceDefault
+
+	limitRangeList := &api.LimitRangeList{
+		Items: []api.LimitRange{
+			{
+				ObjectMeta: api.ObjectMeta{Name: "foo"},
+			},
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePath(getLimitRangesResourceName(), ns, ""),
+			Query:  buildQueryValues(nil),
+			Body:   nil,
+		},
+		Response: Response{StatusCode: 200, Body: limitRangeList},
+	}
+	response, err := c.Setup(t).LimitRanges(ns).List(labels.Everything())
+	c.Validate(t, response, err)
+}
+
+func TestLimitRangeUpdate(t *testing.T) {
+	ns := api.NamespaceDefault
+	limitRange := &api.LimitRange{
+		ObjectMeta: api.ObjectMeta{
+			Name:            "abc",
+			ResourceVersion: "1",
+		},
+		Spec: api.LimitRangeSpec{
+			Limits: []api.LimitRangeItem{
+				{
+					Type: api.LimitTypePod,
+					Max: api.ResourceList{
+						api.ResourceCPU:    resource.MustParse("100"),
+						api.ResourceMemory: resource.MustParse("10000"),
+					},
+					Min: api.ResourceList{
+						api.ResourceCPU:    resource.MustParse("0"),
+						api.ResourceMemory: resource.MustParse("100"),
+					},
+				},
+			},
+		},
+	}
+	c := &testClient{
+		Request:  testRequest{Method: "PUT", Path: testapi.Default.ResourcePath(getLimitRangesResourceName(), ns, "abc"), Query: buildQueryValues(nil)},
+		Response: Response{StatusCode: 200, Body: limitRange},
+	}
+	response, err := c.Setup(t).LimitRanges(ns).Update(limitRange)
+	c.Validate(t, response, err)
+}
+
+func TestInvalidLimitRangeUpdate(t *testing.T) {
+	ns := api.NamespaceDefault
+	limitRange := &api.LimitRange{
+		ObjectMeta: api.ObjectMeta{
+			Name: "abc",
+		},
+		Spec: api.LimitRangeSpec{
+			Limits: []api.LimitRangeItem{
+				{
+					Type: api.LimitTypePod,
+					Max: api.ResourceList{
+						api.ResourceCPU:    resource.MustParse("100"),
+						api.ResourceMemory: resource.MustParse("10000"),
+					},
+					Min: api.ResourceList{
+						api.ResourceCPU:    resource.MustParse("0"),
+						api.ResourceMemory: resource.MustParse("100"),
+					},
+				},
+			},
+		},
+	}
+	c := &testClient{
+		Request:  testRequest{Method: "PUT", Path: testapi.Default.ResourcePath(getLimitRangesResourceName(), ns, "abc"), Query: buildQueryValues(nil)},
+		Response: Response{StatusCode: 200, Body: limitRange},
+	}
+	_, err := c.Setup(t).LimitRanges(ns).Update(limitRange)
+	if err == nil {
+		t.Errorf("Expected an error due to missing ResourceVersion")
+	}
+}
+
+func TestLimitRangeDelete(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request:  testRequest{Method: "DELETE", Path: testapi.Default.ResourcePath(getLimitRangesResourceName(), ns, "foo"), Query: buildQueryValues(nil)},
+		Response: Response{StatusCode: 200},
+	}
+	err := c.Setup(t).LimitRanges(ns).Delete("foo")
+	c.Validate(t, nil, err)
+}
+
+func TestLimitRangeWatch(t *testing.T) {
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePathWithPrefix("watch", getLimitRangesResourceName(), "", ""),
+			Query:  url.Values{"resourceVersion": []string{}}},
+		Response: Response{StatusCode: 200},
+	}
+	_, err := c.Setup(t).LimitRanges(api.NamespaceAll).Watch(labels.Everything(), fields.Everything(), "")
+	c.Validate(t, nil, err)
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/namespaces_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/namespaces_test.go
@@ -1,0 +1,179 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"net/url"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+func TestNamespaceCreate(t *testing.T) {
+	// we create a namespace relative to another namespace
+	namespace := &api.Namespace{
+		ObjectMeta: api.ObjectMeta{Name: "foo"},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "POST",
+			Path:   testapi.Default.ResourcePath("namespaces", "", ""),
+			Body:   namespace,
+		},
+		Response: Response{StatusCode: 200, Body: namespace},
+	}
+
+	// from the source ns, provision a new global namespace "foo"
+	response, err := c.Setup(t).Namespaces().Create(namespace)
+
+	if err != nil {
+		t.Errorf("%#v should be nil.", err)
+	}
+
+	if e, a := response.Name, namespace.Name; e != a {
+		t.Errorf("%#v != %#v.", e, a)
+	}
+}
+
+func TestNamespaceGet(t *testing.T) {
+	namespace := &api.Namespace{
+		ObjectMeta: api.ObjectMeta{Name: "foo"},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePath("namespaces", "", "foo"),
+			Body:   nil,
+		},
+		Response: Response{StatusCode: 200, Body: namespace},
+	}
+
+	response, err := c.Setup(t).Namespaces().Get("foo")
+
+	if err != nil {
+		t.Errorf("%#v should be nil.", err)
+	}
+
+	if e, r := response.Name, namespace.Name; e != r {
+		t.Errorf("%#v != %#v.", e, r)
+	}
+}
+
+func TestNamespaceList(t *testing.T) {
+	namespaceList := &api.NamespaceList{
+		Items: []api.Namespace{
+			{
+				ObjectMeta: api.ObjectMeta{Name: "foo"},
+			},
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePath("namespaces", "", ""),
+			Body:   nil,
+		},
+		Response: Response{StatusCode: 200, Body: namespaceList},
+	}
+	response, err := c.Setup(t).Namespaces().List(labels.Everything(), fields.Everything())
+
+	if err != nil {
+		t.Errorf("%#v should be nil.", err)
+	}
+
+	if len(response.Items) != 1 {
+		t.Errorf("%#v response.Items should have len 1.", response.Items)
+	}
+
+	responseNamespace := response.Items[0]
+	if e, r := responseNamespace.Name, "foo"; e != r {
+		t.Errorf("%#v != %#v.", e, r)
+	}
+}
+
+func TestNamespaceUpdate(t *testing.T) {
+	requestNamespace := &api.Namespace{
+		ObjectMeta: api.ObjectMeta{
+			Name:            "foo",
+			ResourceVersion: "1",
+			Labels: map[string]string{
+				"foo":  "bar",
+				"name": "baz",
+			},
+		},
+		Spec: api.NamespaceSpec{
+			Finalizers: []api.FinalizerName{api.FinalizerKubernetes},
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "PUT",
+			Path:   testapi.Default.ResourcePath("namespaces", "", "foo")},
+		Response: Response{StatusCode: 200, Body: requestNamespace},
+	}
+	receivedNamespace, err := c.Setup(t).Namespaces().Update(requestNamespace)
+	c.Validate(t, receivedNamespace, err)
+}
+
+func TestNamespaceFinalize(t *testing.T) {
+	requestNamespace := &api.Namespace{
+		ObjectMeta: api.ObjectMeta{
+			Name:            "foo",
+			ResourceVersion: "1",
+			Labels: map[string]string{
+				"foo":  "bar",
+				"name": "baz",
+			},
+		},
+		Spec: api.NamespaceSpec{
+			Finalizers: []api.FinalizerName{api.FinalizerKubernetes},
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "PUT",
+			Path:   testapi.Default.ResourcePath("namespaces", "", "foo") + "/finalize",
+		},
+		Response: Response{StatusCode: 200, Body: requestNamespace},
+	}
+	receivedNamespace, err := c.Setup(t).Namespaces().Finalize(requestNamespace)
+	c.Validate(t, receivedNamespace, err)
+}
+
+func TestNamespaceDelete(t *testing.T) {
+	c := &testClient{
+		Request:  testRequest{Method: "DELETE", Path: testapi.Default.ResourcePath("namespaces", "", "foo")},
+		Response: Response{StatusCode: 200},
+	}
+	err := c.Setup(t).Namespaces().Delete("foo")
+	c.Validate(t, nil, err)
+}
+
+func TestNamespaceWatch(t *testing.T) {
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePathWithPrefix("watch", "namespaces", "", ""),
+			Query:  url.Values{"resourceVersion": []string{}}},
+		Response: Response{StatusCode: 200},
+	}
+	_, err := c.Setup(t).Namespaces().Watch(labels.Everything(), fields.Everything(), "")
+	c.Validate(t, nil, err)
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/nodes_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/nodes_test.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"net/url"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+func getNodesResourceName() string {
+	return "nodes"
+}
+
+func TestListNodes(t *testing.T) {
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePath(getNodesResourceName(), "", ""),
+		},
+		Response: Response{StatusCode: 200, Body: &api.NodeList{ListMeta: unversioned.ListMeta{ResourceVersion: "1"}}},
+	}
+	response, err := c.Setup(t).Nodes().List(labels.Everything(), fields.Everything())
+	c.Validate(t, response, err)
+}
+
+func TestListNodesLabels(t *testing.T) {
+	labelSelectorQueryParamName := api.LabelSelectorQueryParam(testapi.Default.Version())
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePath(getNodesResourceName(), "", ""),
+			Query:  buildQueryValues(url.Values{labelSelectorQueryParamName: []string{"foo=bar,name=baz"}})},
+		Response: Response{
+			StatusCode: 200,
+			Body: &api.NodeList{
+				Items: []api.Node{
+					{
+						ObjectMeta: api.ObjectMeta{
+							Labels: map[string]string{
+								"foo":  "bar",
+								"name": "baz",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	c.Setup(t)
+	c.QueryValidator[labelSelectorQueryParamName] = validateLabels
+	selector := labels.Set{"foo": "bar", "name": "baz"}.AsSelector()
+	receivedNodeList, err := c.Nodes().List(selector, fields.Everything())
+	c.Validate(t, receivedNodeList, err)
+}
+
+func TestGetNode(t *testing.T) {
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePath(getNodesResourceName(), "", "1"),
+		},
+		Response: Response{StatusCode: 200, Body: &api.Node{ObjectMeta: api.ObjectMeta{Name: "node-1"}}},
+	}
+	response, err := c.Setup(t).Nodes().Get("1")
+	c.Validate(t, response, err)
+}
+
+func TestGetNodeWithNoName(t *testing.T) {
+	c := &testClient{Error: true}
+	receivedNode, err := c.Setup(t).Nodes().Get("")
+	if (err != nil) && (err.Error() != nameRequiredError) {
+		t.Errorf("Expected error: %v, but got %v", nameRequiredError, err)
+	}
+
+	c.Validate(t, receivedNode, err)
+}
+
+func TestCreateNode(t *testing.T) {
+	requestNode := &api.Node{
+		ObjectMeta: api.ObjectMeta{
+			Name: "node-1",
+		},
+		Status: api.NodeStatus{
+			Capacity: api.ResourceList{
+				api.ResourceCPU:    resource.MustParse("1000m"),
+				api.ResourceMemory: resource.MustParse("1Mi"),
+			},
+		},
+		Spec: api.NodeSpec{
+			Unschedulable: false,
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "POST",
+			Path:   testapi.Default.ResourcePath(getNodesResourceName(), "", ""),
+			Body:   requestNode},
+		Response: Response{
+			StatusCode: 200,
+			Body:       requestNode,
+		},
+	}
+	receivedNode, err := c.Setup(t).Nodes().Create(requestNode)
+	c.Validate(t, receivedNode, err)
+}
+
+func TestDeleteNode(t *testing.T) {
+	c := &testClient{
+		Request: testRequest{
+			Method: "DELETE",
+			Path:   testapi.Default.ResourcePath(getNodesResourceName(), "", "foo"),
+		},
+		Response: Response{StatusCode: 200},
+	}
+	err := c.Setup(t).Nodes().Delete("foo")
+	c.Validate(t, nil, err)
+}
+
+func TestUpdateNode(t *testing.T) {
+	requestNode := &api.Node{
+		ObjectMeta: api.ObjectMeta{
+			Name:            "foo",
+			ResourceVersion: "1",
+		},
+		Status: api.NodeStatus{
+			Capacity: api.ResourceList{
+				api.ResourceCPU:    resource.MustParse("1000m"),
+				api.ResourceMemory: resource.MustParse("1Mi"),
+			},
+		},
+		Spec: api.NodeSpec{
+			Unschedulable: true,
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "PUT",
+			Path:   testapi.Default.ResourcePath(getNodesResourceName(), "", "foo"),
+		},
+		Response: Response{StatusCode: 200, Body: requestNode},
+	}
+	response, err := c.Setup(t).Nodes().Update(requestNode)
+	c.Validate(t, response, err)
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/persistentvolume_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/persistentvolume_test.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"net/url"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+func getPersistentVolumesResoureName() string {
+	return "persistentvolumes"
+}
+
+func TestPersistentVolumeCreate(t *testing.T) {
+	pv := &api.PersistentVolume{
+		ObjectMeta: api.ObjectMeta{
+			Name: "abc",
+		},
+		Spec: api.PersistentVolumeSpec{
+			Capacity: api.ResourceList{
+				api.ResourceName(api.ResourceStorage): resource.MustParse("10G"),
+			},
+			PersistentVolumeSource: api.PersistentVolumeSource{
+				HostPath: &api.HostPathVolumeSource{Path: "/foo"},
+			},
+		},
+	}
+
+	c := &testClient{
+		Request: testRequest{
+			Method: "POST",
+			Path:   testapi.Default.ResourcePath(getPersistentVolumesResoureName(), "", ""),
+			Query:  buildQueryValues(nil),
+			Body:   pv,
+		},
+		Response: Response{StatusCode: 200, Body: pv},
+	}
+
+	response, err := c.Setup(t).PersistentVolumes().Create(pv)
+	c.Validate(t, response, err)
+}
+
+func TestPersistentVolumeGet(t *testing.T) {
+	persistentVolume := &api.PersistentVolume{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "abc",
+			Namespace: "foo",
+		},
+		Spec: api.PersistentVolumeSpec{
+			Capacity: api.ResourceList{
+				api.ResourceName(api.ResourceStorage): resource.MustParse("10G"),
+			},
+			PersistentVolumeSource: api.PersistentVolumeSource{
+				HostPath: &api.HostPathVolumeSource{Path: "/foo"},
+			},
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePath(getPersistentVolumesResoureName(), "", "abc"),
+			Query:  buildQueryValues(nil),
+			Body:   nil,
+		},
+		Response: Response{StatusCode: 200, Body: persistentVolume},
+	}
+
+	response, err := c.Setup(t).PersistentVolumes().Get("abc")
+	c.Validate(t, response, err)
+}
+
+func TestPersistentVolumeList(t *testing.T) {
+	persistentVolumeList := &api.PersistentVolumeList{
+		Items: []api.PersistentVolume{
+			{
+				ObjectMeta: api.ObjectMeta{Name: "foo"},
+			},
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePath(getPersistentVolumesResoureName(), "", ""),
+			Query:  buildQueryValues(nil),
+			Body:   nil,
+		},
+		Response: Response{StatusCode: 200, Body: persistentVolumeList},
+	}
+	response, err := c.Setup(t).PersistentVolumes().List(labels.Everything(), fields.Everything())
+	c.Validate(t, response, err)
+}
+
+func TestPersistentVolumeUpdate(t *testing.T) {
+	persistentVolume := &api.PersistentVolume{
+		ObjectMeta: api.ObjectMeta{
+			Name:            "abc",
+			ResourceVersion: "1",
+		},
+		Spec: api.PersistentVolumeSpec{
+			Capacity: api.ResourceList{
+				api.ResourceName(api.ResourceStorage): resource.MustParse("10G"),
+			},
+			PersistentVolumeSource: api.PersistentVolumeSource{
+				HostPath: &api.HostPathVolumeSource{Path: "/foo"},
+			},
+		},
+	}
+	c := &testClient{
+		Request:  testRequest{Method: "PUT", Path: testapi.Default.ResourcePath(getPersistentVolumesResoureName(), "", "abc"), Query: buildQueryValues(nil)},
+		Response: Response{StatusCode: 200, Body: persistentVolume},
+	}
+	response, err := c.Setup(t).PersistentVolumes().Update(persistentVolume)
+	c.Validate(t, response, err)
+}
+
+func TestPersistentVolumeStatusUpdate(t *testing.T) {
+	persistentVolume := &api.PersistentVolume{
+		ObjectMeta: api.ObjectMeta{
+			Name:            "abc",
+			ResourceVersion: "1",
+		},
+		Spec: api.PersistentVolumeSpec{
+			Capacity: api.ResourceList{
+				api.ResourceName(api.ResourceStorage): resource.MustParse("10G"),
+			},
+			PersistentVolumeSource: api.PersistentVolumeSource{
+				HostPath: &api.HostPathVolumeSource{Path: "/foo"},
+			},
+		},
+		Status: api.PersistentVolumeStatus{
+			Phase:   api.VolumeBound,
+			Message: "foo",
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "PUT",
+			Path:   testapi.Default.ResourcePath(getPersistentVolumesResoureName(), "", "abc") + "/status",
+			Query:  buildQueryValues(nil)},
+		Response: Response{StatusCode: 200, Body: persistentVolume},
+	}
+	response, err := c.Setup(t).PersistentVolumes().UpdateStatus(persistentVolume)
+	c.Validate(t, response, err)
+}
+
+func TestPersistentVolumeDelete(t *testing.T) {
+	c := &testClient{
+		Request:  testRequest{Method: "DELETE", Path: testapi.Default.ResourcePath(getPersistentVolumesResoureName(), "", "foo"), Query: buildQueryValues(nil)},
+		Response: Response{StatusCode: 200},
+	}
+	err := c.Setup(t).PersistentVolumes().Delete("foo")
+	c.Validate(t, nil, err)
+}
+
+func TestPersistentVolumeWatch(t *testing.T) {
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePathWithPrefix("watch", getPersistentVolumesResoureName(), "", ""),
+			Query:  url.Values{"resourceVersion": []string{}}},
+		Response: Response{StatusCode: 200},
+	}
+	_, err := c.Setup(t).PersistentVolumes().Watch(labels.Everything(), fields.Everything(), "")
+	c.Validate(t, nil, err)
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/persistentvolumeclaim_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/persistentvolumeclaim_test.go
@@ -1,0 +1,202 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"net/url"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+func getPersistentVolumeClaimsResoureName() string {
+	return "persistentvolumeclaims"
+}
+
+func TestPersistentVolumeClaimCreate(t *testing.T) {
+	ns := api.NamespaceDefault
+	pv := &api.PersistentVolumeClaim{
+		ObjectMeta: api.ObjectMeta{
+			Name: "abc",
+		},
+		Spec: api.PersistentVolumeClaimSpec{
+			AccessModes: []api.PersistentVolumeAccessMode{
+				api.ReadWriteOnce,
+				api.ReadOnlyMany,
+			},
+			Resources: api.ResourceRequirements{
+				Requests: api.ResourceList{
+					api.ResourceName(api.ResourceStorage): resource.MustParse("10G"),
+				},
+			},
+		},
+	}
+
+	c := &testClient{
+		Request: testRequest{
+			Method: "POST",
+			Path:   testapi.Default.ResourcePath(getPersistentVolumeClaimsResoureName(), ns, ""),
+			Query:  buildQueryValues(nil),
+			Body:   pv,
+		},
+		Response: Response{StatusCode: 200, Body: pv},
+	}
+
+	response, err := c.Setup(t).PersistentVolumeClaims(ns).Create(pv)
+	c.Validate(t, response, err)
+}
+
+func TestPersistentVolumeClaimGet(t *testing.T) {
+	ns := api.NamespaceDefault
+	persistentVolumeClaim := &api.PersistentVolumeClaim{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "abc",
+			Namespace: "foo",
+		},
+		Spec: api.PersistentVolumeClaimSpec{
+			AccessModes: []api.PersistentVolumeAccessMode{
+				api.ReadWriteOnce,
+				api.ReadOnlyMany,
+			},
+			Resources: api.ResourceRequirements{
+				Requests: api.ResourceList{
+					api.ResourceName(api.ResourceStorage): resource.MustParse("10G"),
+				},
+			},
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePath(getPersistentVolumeClaimsResoureName(), ns, "abc"),
+			Query:  buildQueryValues(nil),
+			Body:   nil,
+		},
+		Response: Response{StatusCode: 200, Body: persistentVolumeClaim},
+	}
+
+	response, err := c.Setup(t).PersistentVolumeClaims(ns).Get("abc")
+	c.Validate(t, response, err)
+}
+
+func TestPersistentVolumeClaimList(t *testing.T) {
+	ns := api.NamespaceDefault
+	persistentVolumeList := &api.PersistentVolumeClaimList{
+		Items: []api.PersistentVolumeClaim{
+			{
+				ObjectMeta: api.ObjectMeta{Name: "foo", Namespace: "ns"},
+			},
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePath(getPersistentVolumeClaimsResoureName(), ns, ""),
+			Query:  buildQueryValues(nil),
+			Body:   nil,
+		},
+		Response: Response{StatusCode: 200, Body: persistentVolumeList},
+	}
+	response, err := c.Setup(t).PersistentVolumeClaims(ns).List(labels.Everything(), fields.Everything())
+	c.Validate(t, response, err)
+}
+
+func TestPersistentVolumeClaimUpdate(t *testing.T) {
+	ns := api.NamespaceDefault
+	persistentVolumeClaim := &api.PersistentVolumeClaim{
+		ObjectMeta: api.ObjectMeta{
+			Name:            "abc",
+			ResourceVersion: "1",
+		},
+		Spec: api.PersistentVolumeClaimSpec{
+			AccessModes: []api.PersistentVolumeAccessMode{
+				api.ReadWriteOnce,
+				api.ReadOnlyMany,
+			},
+			Resources: api.ResourceRequirements{
+				Requests: api.ResourceList{
+					api.ResourceName(api.ResourceStorage): resource.MustParse("10G"),
+				},
+			},
+		},
+	}
+	c := &testClient{
+		Request:  testRequest{Method: "PUT", Path: testapi.Default.ResourcePath(getPersistentVolumeClaimsResoureName(), ns, "abc"), Query: buildQueryValues(nil)},
+		Response: Response{StatusCode: 200, Body: persistentVolumeClaim},
+	}
+	response, err := c.Setup(t).PersistentVolumeClaims(ns).Update(persistentVolumeClaim)
+	c.Validate(t, response, err)
+}
+
+func TestPersistentVolumeClaimStatusUpdate(t *testing.T) {
+	ns := api.NamespaceDefault
+	persistentVolumeClaim := &api.PersistentVolumeClaim{
+		ObjectMeta: api.ObjectMeta{
+			Name:            "abc",
+			ResourceVersion: "1",
+		},
+		Spec: api.PersistentVolumeClaimSpec{
+			AccessModes: []api.PersistentVolumeAccessMode{
+				api.ReadWriteOnce,
+				api.ReadOnlyMany,
+			},
+			Resources: api.ResourceRequirements{
+				Requests: api.ResourceList{
+					api.ResourceName(api.ResourceStorage): resource.MustParse("10G"),
+				},
+			},
+		},
+		Status: api.PersistentVolumeClaimStatus{
+			Phase: api.ClaimBound,
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "PUT",
+			Path:   testapi.Default.ResourcePath(getPersistentVolumeClaimsResoureName(), ns, "abc") + "/status",
+			Query:  buildQueryValues(nil)},
+		Response: Response{StatusCode: 200, Body: persistentVolumeClaim},
+	}
+	response, err := c.Setup(t).PersistentVolumeClaims(ns).UpdateStatus(persistentVolumeClaim)
+	c.Validate(t, response, err)
+}
+
+func TestPersistentVolumeClaimDelete(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request:  testRequest{Method: "DELETE", Path: testapi.Default.ResourcePath(getPersistentVolumeClaimsResoureName(), ns, "foo"), Query: buildQueryValues(nil)},
+		Response: Response{StatusCode: 200},
+	}
+	err := c.Setup(t).PersistentVolumeClaims(ns).Delete("foo")
+	c.Validate(t, nil, err)
+}
+
+func TestPersistentVolumeClaimWatch(t *testing.T) {
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePathWithPrefix("watch", getPersistentVolumeClaimsResoureName(), "", ""),
+			Query:  url.Values{"resourceVersion": []string{}}},
+		Response: Response{StatusCode: 200},
+	}
+	_, err := c.Setup(t).PersistentVolumeClaims(api.NamespaceAll).Watch(labels.Everything(), fields.Everything(), "")
+	c.Validate(t, nil, err)
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/pod_templates_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/pod_templates_test.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"net/url"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+func getPodTemplatesResoureName() string {
+	return "podtemplates"
+}
+
+func TestPodTemplateCreate(t *testing.T) {
+	ns := api.NamespaceDefault
+	podTemplate := api.PodTemplate{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "abc",
+			Namespace: ns,
+		},
+		Template: api.PodTemplateSpec{},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "POST",
+			Path:   testapi.Default.ResourcePath(getPodTemplatesResoureName(), ns, ""),
+			Query:  buildQueryValues(nil),
+			Body:   &podTemplate,
+		},
+		Response: Response{StatusCode: 200, Body: &podTemplate},
+	}
+
+	response, err := c.Setup(t).PodTemplates(ns).Create(&podTemplate)
+	c.Validate(t, response, err)
+}
+
+func TestPodTemplateGet(t *testing.T) {
+	ns := api.NamespaceDefault
+	podTemplate := &api.PodTemplate{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "abc",
+			Namespace: ns,
+		},
+		Template: api.PodTemplateSpec{},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePath(getPodTemplatesResoureName(), ns, "abc"),
+			Query:  buildQueryValues(nil),
+			Body:   nil,
+		},
+		Response: Response{StatusCode: 200, Body: podTemplate},
+	}
+
+	response, err := c.Setup(t).PodTemplates(ns).Get("abc")
+	c.Validate(t, response, err)
+}
+
+func TestPodTemplateList(t *testing.T) {
+	ns := api.NamespaceDefault
+	podTemplateList := &api.PodTemplateList{
+		Items: []api.PodTemplate{
+			{
+				ObjectMeta: api.ObjectMeta{
+					Name:      "foo",
+					Namespace: ns,
+				},
+			},
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePath(getPodTemplatesResoureName(), ns, ""),
+			Query:  buildQueryValues(nil),
+			Body:   nil,
+		},
+		Response: Response{StatusCode: 200, Body: podTemplateList},
+	}
+	response, err := c.Setup(t).PodTemplates(ns).List(labels.Everything(), fields.Everything())
+	c.Validate(t, response, err)
+}
+
+func TestPodTemplateUpdate(t *testing.T) {
+	ns := api.NamespaceDefault
+	podTemplate := &api.PodTemplate{
+		ObjectMeta: api.ObjectMeta{
+			Name:            "abc",
+			Namespace:       ns,
+			ResourceVersion: "1",
+		},
+		Template: api.PodTemplateSpec{},
+	}
+	c := &testClient{
+		Request:  testRequest{Method: "PUT", Path: testapi.Default.ResourcePath(getPodTemplatesResoureName(), ns, "abc"), Query: buildQueryValues(nil)},
+		Response: Response{StatusCode: 200, Body: podTemplate},
+	}
+	response, err := c.Setup(t).PodTemplates(ns).Update(podTemplate)
+	c.Validate(t, response, err)
+}
+
+func TestPodTemplateDelete(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request:  testRequest{Method: "DELETE", Path: testapi.Default.ResourcePath(getPodTemplatesResoureName(), ns, "foo"), Query: buildQueryValues(nil)},
+		Response: Response{StatusCode: 200},
+	}
+	err := c.Setup(t).PodTemplates(ns).Delete("foo", nil)
+	c.Validate(t, nil, err)
+}
+
+func TestPodTemplateWatch(t *testing.T) {
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePathWithPrefix("watch", getPodTemplatesResoureName(), "", ""),
+			Query:  url.Values{"resourceVersion": []string{}}},
+		Response: Response{StatusCode: 200},
+	}
+	_, err := c.Setup(t).PodTemplates(api.NamespaceAll).Watch(labels.Everything(), fields.Everything(), "")
+	c.Validate(t, nil, err)
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/pods_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/pods_test.go
@@ -1,0 +1,188 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"net/url"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+func TestListEmptyPods(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request:  testRequest{Method: "GET", Path: testapi.Default.ResourcePath("pods", ns, ""), Query: buildQueryValues(nil)},
+		Response: Response{StatusCode: 200, Body: &api.PodList{}},
+	}
+	podList, err := c.Setup(t).Pods(ns).List(labels.Everything(), fields.Everything())
+	c.Validate(t, podList, err)
+}
+
+func TestListPods(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request: testRequest{Method: "GET", Path: testapi.Default.ResourcePath("pods", ns, ""), Query: buildQueryValues(nil)},
+		Response: Response{StatusCode: 200,
+			Body: &api.PodList{
+				Items: []api.Pod{
+					{
+						Status: api.PodStatus{
+							Phase: api.PodRunning,
+						},
+						ObjectMeta: api.ObjectMeta{
+							Labels: map[string]string{
+								"foo":  "bar",
+								"name": "baz",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	receivedPodList, err := c.Setup(t).Pods(ns).List(labels.Everything(), fields.Everything())
+	c.Validate(t, receivedPodList, err)
+}
+
+func TestListPodsLabels(t *testing.T) {
+	ns := api.NamespaceDefault
+	labelSelectorQueryParamName := api.LabelSelectorQueryParam(testapi.Default.Version())
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePath("pods", ns, ""),
+			Query:  buildQueryValues(url.Values{labelSelectorQueryParamName: []string{"foo=bar,name=baz"}})},
+		Response: Response{
+			StatusCode: 200,
+			Body: &api.PodList{
+				Items: []api.Pod{
+					{
+						Status: api.PodStatus{
+							Phase: api.PodRunning,
+						},
+						ObjectMeta: api.ObjectMeta{
+							Labels: map[string]string{
+								"foo":  "bar",
+								"name": "baz",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	c.Setup(t)
+	c.QueryValidator[labelSelectorQueryParamName] = validateLabels
+	selector := labels.Set{"foo": "bar", "name": "baz"}.AsSelector()
+	receivedPodList, err := c.Pods(ns).List(selector, fields.Everything())
+	c.Validate(t, receivedPodList, err)
+}
+
+func TestGetPod(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request: testRequest{Method: "GET", Path: testapi.Default.ResourcePath("pods", ns, "foo"), Query: buildQueryValues(nil)},
+		Response: Response{
+			StatusCode: 200,
+			Body: &api.Pod{
+				Status: api.PodStatus{
+					Phase: api.PodRunning,
+				},
+				ObjectMeta: api.ObjectMeta{
+					Labels: map[string]string{
+						"foo":  "bar",
+						"name": "baz",
+					},
+				},
+			},
+		},
+	}
+	receivedPod, err := c.Setup(t).Pods(ns).Get("foo")
+	c.Validate(t, receivedPod, err)
+}
+
+func TestGetPodWithNoName(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{Error: true}
+	receivedPod, err := c.Setup(t).Pods(ns).Get("")
+	if (err != nil) && (err.Error() != nameRequiredError) {
+		t.Errorf("Expected error: %v, but got %v", nameRequiredError, err)
+	}
+
+	c.Validate(t, receivedPod, err)
+}
+
+func TestDeletePod(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request:  testRequest{Method: "DELETE", Path: testapi.Default.ResourcePath("pods", ns, "foo"), Query: buildQueryValues(nil)},
+		Response: Response{StatusCode: 200},
+	}
+	err := c.Setup(t).Pods(ns).Delete("foo", nil)
+	c.Validate(t, nil, err)
+}
+
+func TestCreatePod(t *testing.T) {
+	ns := api.NamespaceDefault
+	requestPod := &api.Pod{
+		Status: api.PodStatus{
+			Phase: api.PodRunning,
+		},
+		ObjectMeta: api.ObjectMeta{
+			Labels: map[string]string{
+				"foo":  "bar",
+				"name": "baz",
+			},
+		},
+	}
+	c := &testClient{
+		Request: testRequest{Method: "POST", Path: testapi.Default.ResourcePath("pods", ns, ""), Query: buildQueryValues(nil), Body: requestPod},
+		Response: Response{
+			StatusCode: 200,
+			Body:       requestPod,
+		},
+	}
+	receivedPod, err := c.Setup(t).Pods(ns).Create(requestPod)
+	c.Validate(t, receivedPod, err)
+}
+
+func TestUpdatePod(t *testing.T) {
+	ns := api.NamespaceDefault
+	requestPod := &api.Pod{
+		ObjectMeta: api.ObjectMeta{
+			Name:            "foo",
+			ResourceVersion: "1",
+			Labels: map[string]string{
+				"foo":  "bar",
+				"name": "baz",
+			},
+		},
+		Status: api.PodStatus{
+			Phase: api.PodRunning,
+		},
+	}
+	c := &testClient{
+		Request:  testRequest{Method: "PUT", Path: testapi.Default.ResourcePath("pods", ns, "foo"), Query: buildQueryValues(nil)},
+		Response: Response{StatusCode: 200, Body: requestPod},
+	}
+	receivedPod, err := c.Setup(t).Pods(ns).Update(requestPod)
+	c.Validate(t, receivedPod, err)
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/portforward/portforward_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/portforward/portforward_test.go
@@ -1,0 +1,392 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package portforward
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/kubelet"
+	"k8s.io/kubernetes/pkg/types"
+)
+
+func TestParsePortsAndNew(t *testing.T) {
+	tests := []struct {
+		input            []string
+		expected         []ForwardedPort
+		expectParseError bool
+		expectNewError   bool
+	}{
+		{input: []string{}, expectNewError: true},
+		{input: []string{"a"}, expectParseError: true, expectNewError: true},
+		{input: []string{":a"}, expectParseError: true, expectNewError: true},
+		{input: []string{"-1"}, expectParseError: true, expectNewError: true},
+		{input: []string{"65536"}, expectParseError: true, expectNewError: true},
+		{input: []string{"0"}, expectParseError: true, expectNewError: true},
+		{input: []string{"0:0"}, expectParseError: true, expectNewError: true},
+		{input: []string{"a:5000"}, expectParseError: true, expectNewError: true},
+		{input: []string{"5000:a"}, expectParseError: true, expectNewError: true},
+		{
+			input: []string{"5000", "5000:5000", "8888:5000", "5000:8888", ":5000", "0:5000"},
+			expected: []ForwardedPort{
+				{5000, 5000},
+				{5000, 5000},
+				{8888, 5000},
+				{5000, 8888},
+				{0, 5000},
+				{0, 5000},
+			},
+		},
+	}
+
+	for i, test := range tests {
+		parsed, err := parsePorts(test.input)
+		haveError := err != nil
+		if e, a := test.expectParseError, haveError; e != a {
+			t.Fatalf("%d: parsePorts: error expected=%t, got %t: %s", i, e, a, err)
+		}
+
+		expectedRequest := &client.Request{}
+		expectedConfig := &client.Config{}
+		expectedStopChan := make(chan struct{})
+		pf, err := New(expectedRequest, expectedConfig, test.input, expectedStopChan)
+		haveError = err != nil
+		if e, a := test.expectNewError, haveError; e != a {
+			t.Fatalf("%d: New: error expected=%t, got %t: %s", i, e, a, err)
+		}
+
+		if test.expectParseError || test.expectNewError {
+			continue
+		}
+
+		for pi, expectedPort := range test.expected {
+			if e, a := expectedPort.Local, parsed[pi].Local; e != a {
+				t.Fatalf("%d: local expected: %d, got: %d", i, e, a)
+			}
+			if e, a := expectedPort.Remote, parsed[pi].Remote; e != a {
+				t.Fatalf("%d: remote expected: %d, got: %d", i, e, a)
+			}
+		}
+
+		if e, a := expectedRequest, pf.req; e != a {
+			t.Fatalf("%d: req: expected %#v, got %#v", i, e, a)
+		}
+		if e, a := expectedConfig, pf.config; e != a {
+			t.Fatalf("%d: config: expected %#v, got %#v", i, e, a)
+		}
+		if e, a := test.expected, pf.ports; !reflect.DeepEqual(e, a) {
+			t.Fatalf("%d: ports: expected %#v, got %#v", i, e, a)
+		}
+		if e, a := expectedStopChan, pf.stopChan; e != a {
+			t.Fatalf("%d: stopChan: expected %#v, got %#v", i, e, a)
+		}
+		if pf.Ready == nil {
+			t.Fatalf("%d: Ready should be non-nil", i)
+		}
+	}
+}
+
+type GetListenerTestCase struct {
+	Hostname                string
+	Protocol                string
+	ShouldRaiseError        bool
+	ExpectedListenerAddress string
+}
+
+func TestGetListener(t *testing.T) {
+	var pf PortForwarder
+	testCases := []GetListenerTestCase{
+		{
+			Hostname:                "localhost",
+			Protocol:                "tcp4",
+			ShouldRaiseError:        false,
+			ExpectedListenerAddress: "127.0.0.1",
+		},
+		{
+			Hostname:                "127.0.0.1",
+			Protocol:                "tcp4",
+			ShouldRaiseError:        false,
+			ExpectedListenerAddress: "127.0.0.1",
+		},
+		{
+			Hostname:                "[::1]",
+			Protocol:                "tcp6",
+			ShouldRaiseError:        false,
+			ExpectedListenerAddress: "::1",
+		},
+		{
+			Hostname:         "[::1]",
+			Protocol:         "tcp4",
+			ShouldRaiseError: true,
+		},
+		{
+			Hostname:         "127.0.0.1",
+			Protocol:         "tcp6",
+			ShouldRaiseError: true,
+		},
+		{
+			// IPv6 address must be put into brackets. This test reveals this.
+			Hostname:         "::1",
+			Protocol:         "tcp6",
+			ShouldRaiseError: true,
+		},
+	}
+
+	for i, testCase := range testCases {
+		expectedListenerPort := "12345"
+		listener, err := pf.getListener(testCase.Protocol, testCase.Hostname, &ForwardedPort{12345, 12345})
+		if err != nil && strings.Contains(err.Error(), "cannot assign requested address") {
+			t.Logf("Can't test #%d: %v", i, err)
+			continue
+		}
+		errorRaised := err != nil
+
+		if testCase.ShouldRaiseError != errorRaised {
+			t.Errorf("Test case #%d failed: Data %v an error has been raised(%t) where it should not (or reciprocally): %v", i, testCase, testCase.ShouldRaiseError, err)
+			continue
+		}
+		if errorRaised {
+			continue
+		}
+
+		if listener == nil {
+			t.Errorf("Test case #%d did not raise an error but failed in initializing listener", i)
+			continue
+		}
+
+		host, port, _ := net.SplitHostPort(listener.Addr().String())
+		t.Logf("Asked a %s forward for: %s:%v, got listener %s:%s, expected: %s", testCase.Protocol, testCase.Hostname, 12345, host, port, expectedListenerPort)
+		if host != testCase.ExpectedListenerAddress {
+			t.Errorf("Test case #%d failed: Listener does not listen on exepected address: asked %v got %v", i, testCase.ExpectedListenerAddress, host)
+		}
+		if port != expectedListenerPort {
+			t.Errorf("Test case #%d failed: Listener does not listen on exepected port: asked %v got %v", i, expectedListenerPort, port)
+
+		}
+		listener.Close()
+
+	}
+}
+
+// fakePortForwarder simulates port forwarding for testing. It implements
+// kubelet.PortForwarder.
+type fakePortForwarder struct {
+	lock sync.Mutex
+	// stores data received from the stream per port
+	received map[uint16]string
+	// data to be sent to the stream per port
+	send map[uint16]string
+}
+
+var _ kubelet.PortForwarder = &fakePortForwarder{}
+
+func (pf *fakePortForwarder) PortForward(name string, uid types.UID, port uint16, stream io.ReadWriteCloser) error {
+	defer stream.Close()
+
+	var wg sync.WaitGroup
+
+	// client -> server
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		// copy from stream into a buffer
+		received := new(bytes.Buffer)
+		io.Copy(received, stream)
+
+		// store the received content
+		pf.lock.Lock()
+		pf.received[port] = received.String()
+		pf.lock.Unlock()
+	}()
+
+	// server -> client
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		// send the hardcoded data to the stream
+		io.Copy(stream, strings.NewReader(pf.send[port]))
+	}()
+
+	wg.Wait()
+
+	return nil
+}
+
+// fakePortForwardServer creates an HTTP server that can handle port forwarding
+// requests.
+func fakePortForwardServer(t *testing.T, testName string, serverSends, expectedFromClient map[uint16]string) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		pf := &fakePortForwarder{
+			received: make(map[uint16]string),
+			send:     serverSends,
+		}
+		kubelet.ServePortForward(w, req, pf, "pod", "uid", 0, 10*time.Second)
+
+		for port, expected := range expectedFromClient {
+			actual, ok := pf.received[port]
+			if !ok {
+				t.Errorf("%s: server didn't receive any data for port %d", testName, port)
+				continue
+			}
+
+			if expected != actual {
+				t.Errorf("%s: server expected to receive %q, got %q for port %d", testName, expected, actual, port)
+			}
+		}
+
+		for port, actual := range pf.received {
+			if _, ok := expectedFromClient[port]; !ok {
+				t.Errorf("%s: server unexpectedly received %q for port %d", testName, actual, port)
+			}
+		}
+	})
+}
+
+func TestForwardPorts(t *testing.T) {
+	tests := map[string]struct {
+		ports       []string
+		clientSends map[uint16]string
+		serverSends map[uint16]string
+	}{
+		"forward 1 port with no data either direction": {
+			ports: []string{"5000"},
+		},
+		"forward 2 ports with bidirectional data": {
+			ports: []string{"5001", "6000"},
+			clientSends: map[uint16]string{
+				5001: "abcd",
+				6000: "ghij",
+			},
+			serverSends: map[uint16]string{
+				5001: "1234",
+				6000: "5678",
+			},
+		},
+	}
+
+	for testName, test := range tests {
+		server := httptest.NewServer(fakePortForwardServer(t, testName, test.serverSends, test.clientSends))
+		url, _ := url.ParseRequestURI(server.URL)
+		c := client.NewRESTClient(url, "x", nil, -1, -1)
+		req := c.Post().Resource("testing")
+
+		conf := &client.Config{
+			Host: server.URL,
+		}
+
+		stopChan := make(chan struct{}, 1)
+
+		pf, err := New(req, conf, test.ports, stopChan)
+		if err != nil {
+			t.Fatalf("%s: unexpected error calling New: %v", testName, err)
+		}
+
+		doneChan := make(chan error)
+		go func() {
+			doneChan <- pf.ForwardPorts()
+		}()
+		<-pf.Ready
+
+		for port, data := range test.clientSends {
+			clientConn, err := net.Dial("tcp", fmt.Sprintf("localhost:%d", port))
+			if err != nil {
+				t.Errorf("%s: error dialing %d: %s", testName, port, err)
+				server.Close()
+				continue
+			}
+			defer clientConn.Close()
+
+			n, err := clientConn.Write([]byte(data))
+			if err != nil && err != io.EOF {
+				t.Errorf("%s: Error sending data '%s': %s", testName, data, err)
+				server.Close()
+				continue
+			}
+			if n == 0 {
+				t.Errorf("%s: unexpected write of 0 bytes", testName)
+				server.Close()
+				continue
+			}
+			b := make([]byte, 4)
+			n, err = clientConn.Read(b)
+			if err != nil && err != io.EOF {
+				t.Errorf("%s: Error reading data: %s", testName, err)
+				server.Close()
+				continue
+			}
+			if !bytes.Equal([]byte(test.serverSends[port]), b) {
+				t.Errorf("%s: expected to read '%s', got '%s'", testName, test.serverSends[port], b)
+				server.Close()
+				continue
+			}
+		}
+		// tell r.ForwardPorts to stop
+		close(stopChan)
+
+		// wait for r.ForwardPorts to actually return
+		err = <-doneChan
+		if err != nil {
+			t.Errorf("%s: unexpected error: %s", testName, err)
+		}
+		server.Close()
+	}
+
+}
+
+func TestForwardPortsReturnsErrorWhenAllBindsFailed(t *testing.T) {
+	server := httptest.NewServer(fakePortForwardServer(t, "allBindsFailed", nil, nil))
+	defer server.Close()
+	url, _ := url.ParseRequestURI(server.URL)
+	c := client.NewRESTClient(url, "x", nil, -1, -1)
+	req := c.Post().Resource("testing")
+
+	conf := &client.Config{
+		Host: server.URL,
+	}
+
+	stopChan1 := make(chan struct{}, 1)
+	defer close(stopChan1)
+
+	pf1, err := New(req, conf, []string{"5555"}, stopChan1)
+	if err != nil {
+		t.Fatalf("error creating pf1: %v", err)
+	}
+	go pf1.ForwardPorts()
+	<-pf1.Ready
+
+	stopChan2 := make(chan struct{}, 1)
+	pf2, err := New(&client.Request{}, &client.Config{}, []string{"5555"}, stopChan2)
+	if err != nil {
+		t.Fatalf("error creating pf2: %v", err)
+	}
+	if err := pf2.ForwardPorts(); err == nil {
+		t.Fatal("expected non-nil error for pf2.ForwardPorts")
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/remotecommand/remotecommand_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/remotecommand/remotecommand_test.go
@@ -1,0 +1,303 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remotecommand
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/util/httpstream"
+	"k8s.io/kubernetes/pkg/util/httpstream/spdy"
+)
+
+func fakeExecServer(t *testing.T, i int, stdinData, stdoutData, stderrData, errorData string, tty bool, messageCount int) http.HandlerFunc {
+	// error + stdin + stdout
+	expectedStreams := 3
+	if !tty {
+		// stderr
+		expectedStreams++
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		streamCh := make(chan httpstream.Stream)
+
+		upgrader := spdy.NewResponseUpgrader()
+		conn := upgrader.UpgradeResponse(w, req, func(stream httpstream.Stream) error {
+			streamCh <- stream
+			return nil
+		})
+		// from this point on, we can no longer call methods on w
+		if conn == nil {
+			// The upgrader is responsible for notifying the client of any errors that
+			// occurred during upgrading. All we can do is return here at this point
+			// if we weren't successful in upgrading.
+			return
+		}
+		defer conn.Close()
+
+		var errorStream, stdinStream, stdoutStream, stderrStream httpstream.Stream
+		receivedStreams := 0
+	WaitForStreams:
+		for {
+			select {
+			case stream := <-streamCh:
+				streamType := stream.Headers().Get(api.StreamType)
+				switch streamType {
+				case api.StreamTypeError:
+					errorStream = stream
+					receivedStreams++
+				case api.StreamTypeStdin:
+					stdinStream = stream
+					receivedStreams++
+				case api.StreamTypeStdout:
+					stdoutStream = stream
+					receivedStreams++
+				case api.StreamTypeStderr:
+					stderrStream = stream
+					receivedStreams++
+				default:
+					t.Errorf("%d: unexpected stream type: %q", i, streamType)
+				}
+
+				if receivedStreams == expectedStreams {
+					break WaitForStreams
+				}
+			}
+		}
+
+		if len(errorData) > 0 {
+			n, err := fmt.Fprint(errorStream, errorData)
+			if err != nil {
+				t.Errorf("%d: error writing to errorStream: %v", i, err)
+			}
+			if e, a := len(errorData), n; e != a {
+				t.Errorf("%d: expected to write %d bytes to errorStream, but only wrote %d", i, e, a)
+			}
+			errorStream.Close()
+		}
+
+		if len(stdoutData) > 0 {
+			for j := 0; j < messageCount; j++ {
+				n, err := fmt.Fprint(stdoutStream, stdoutData)
+				if err != nil {
+					t.Errorf("%d: error writing to stdoutStream: %v", i, err)
+				}
+				if e, a := len(stdoutData), n; e != a {
+					t.Errorf("%d: expected to write %d bytes to stdoutStream, but only wrote %d", i, e, a)
+				}
+			}
+			stdoutStream.Close()
+		}
+		if len(stderrData) > 0 {
+			for j := 0; j < messageCount; j++ {
+				n, err := fmt.Fprint(stderrStream, stderrData)
+				if err != nil {
+					t.Errorf("%d: error writing to stderrStream: %v", i, err)
+				}
+				if e, a := len(stderrData), n; e != a {
+					t.Errorf("%d: expected to write %d bytes to stderrStream, but only wrote %d", i, e, a)
+				}
+			}
+			stderrStream.Close()
+		}
+		if len(stdinData) > 0 {
+			data := make([]byte, len(stdinData))
+			for j := 0; j < messageCount; j++ {
+				n, err := io.ReadFull(stdinStream, data)
+				if err != nil {
+					t.Errorf("%d: error reading stdin stream: %v", i, err)
+				}
+				if e, a := len(stdinData), n; e != a {
+					t.Errorf("%d: expected to read %d bytes from stdinStream, but only read %d", i, e, a)
+				}
+				if e, a := stdinData, string(data); e != a {
+					t.Errorf("%d: stdin: expected %q, got %q", i, e, a)
+				}
+			}
+			stdinStream.Close()
+		}
+	})
+}
+
+func TestRequestExecuteRemoteCommand(t *testing.T) {
+	testCases := []struct {
+		Stdin        string
+		Stdout       string
+		Stderr       string
+		Error        string
+		Tty          bool
+		MessageCount int
+	}{
+		{
+			Error: "bail",
+		},
+		{
+			Stdin:  "a",
+			Stdout: "b",
+			Stderr: "c",
+			// TODO bump this to a larger number such as 100 once
+			// https://github.com/docker/spdystream/issues/55 is fixed and the Godep
+			// is bumped. Sending multiple messages over stdin/stdout/stderr results
+			// in more frames being spread across multiple spdystream frame workers.
+			// This makes it more likely that the spdystream bug will be encountered,
+			// where streams are closed as soon as a goaway frame is received, and
+			// any pending frames that haven't been processed yet may not be
+			// delivered (it's a race).
+			MessageCount: 1,
+		},
+		{
+			Stdin:  "a",
+			Stdout: "b",
+			Tty:    true,
+		},
+	}
+
+	for i, testCase := range testCases {
+		localOut := &bytes.Buffer{}
+		localErr := &bytes.Buffer{}
+
+		server := httptest.NewServer(fakeExecServer(t, i, testCase.Stdin, testCase.Stdout, testCase.Stderr, testCase.Error, testCase.Tty, testCase.MessageCount))
+
+		url, _ := url.ParseRequestURI(server.URL)
+		c := client.NewRESTClient(url, "x", nil, -1, -1)
+		req := c.Post().Resource("testing")
+
+		conf := &client.Config{
+			Host: server.URL,
+		}
+		e := New(req, conf, []string{"ls", "/"}, strings.NewReader(strings.Repeat(testCase.Stdin, testCase.MessageCount)), localOut, localErr, testCase.Tty)
+		err := e.Execute()
+		hasErr := err != nil
+
+		if len(testCase.Error) > 0 {
+			if !hasErr {
+				t.Errorf("%d: expected an error", i)
+			} else {
+				if e, a := testCase.Error, err.Error(); !strings.Contains(a, e) {
+					t.Errorf("%d: expected error stream read '%v', got '%v'", i, e, a)
+				}
+			}
+
+			server.Close()
+			continue
+		}
+
+		if hasErr {
+			t.Errorf("%d: unexpected error: %v", i, err)
+			server.Close()
+			continue
+		}
+
+		if len(testCase.Stdout) > 0 {
+			if e, a := strings.Repeat(testCase.Stdout, testCase.MessageCount), localOut; e != a.String() {
+				t.Errorf("%d: expected stdout data '%s', got '%s'", i, e, a)
+			}
+		}
+
+		if testCase.Stderr != "" {
+			if e, a := strings.Repeat(testCase.Stderr, testCase.MessageCount), localErr; e != a.String() {
+				t.Errorf("%d: expected stderr data '%s', got '%s'", i, e, a)
+			}
+		}
+
+		server.Close()
+	}
+}
+
+// TODO: this test is largely cut and paste, refactor to share code
+func TestRequestAttachRemoteCommand(t *testing.T) {
+	testCases := []struct {
+		Stdin  string
+		Stdout string
+		Stderr string
+		Error  string
+		Tty    bool
+	}{
+		{
+			Error: "bail",
+		},
+		{
+			Stdin:  "a",
+			Stdout: "b",
+			Stderr: "c",
+		},
+		{
+			Stdin:  "a",
+			Stdout: "b",
+			Tty:    true,
+		},
+	}
+
+	for i, testCase := range testCases {
+		localOut := &bytes.Buffer{}
+		localErr := &bytes.Buffer{}
+
+		server := httptest.NewServer(fakeExecServer(t, i, testCase.Stdin, testCase.Stdout, testCase.Stderr, testCase.Error, testCase.Tty, 1))
+
+		url, _ := url.ParseRequestURI(server.URL)
+		c := client.NewRESTClient(url, "x", nil, -1, -1)
+		req := c.Post().Resource("testing")
+
+		conf := &client.Config{
+			Host: server.URL,
+		}
+		e := NewAttach(req, conf, strings.NewReader(testCase.Stdin), localOut, localErr, testCase.Tty)
+		err := e.Execute()
+		hasErr := err != nil
+
+		if len(testCase.Error) > 0 {
+			if !hasErr {
+				t.Errorf("%d: expected an error", i)
+			} else {
+				if e, a := testCase.Error, err.Error(); !strings.Contains(a, e) {
+					t.Errorf("%d: expected error stream read '%v', got '%v'", i, e, a)
+				}
+			}
+
+			server.Close()
+			continue
+		}
+
+		if hasErr {
+			t.Errorf("%d: unexpected error: %v", i, err)
+			server.Close()
+			continue
+		}
+
+		if len(testCase.Stdout) > 0 {
+			if e, a := testCase.Stdout, localOut; e != a.String() {
+				t.Errorf("%d: expected stdout data '%s', got '%s'", i, e, a)
+			}
+		}
+
+		if testCase.Stderr != "" {
+			if e, a := testCase.Stderr, localErr; e != a.String() {
+				t.Errorf("%d: expected stderr data '%s', got '%s'", i, e, a)
+			}
+		}
+
+		server.Close()
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/replication_controllers_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/replication_controllers_test.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+func getRCResourceName() string {
+	return "replicationcontrollers"
+}
+
+func TestListControllers(t *testing.T) {
+	ns := api.NamespaceAll
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePath(getRCResourceName(), ns, ""),
+		},
+		Response: Response{StatusCode: 200,
+			Body: &api.ReplicationControllerList{
+				Items: []api.ReplicationController{
+					{
+						ObjectMeta: api.ObjectMeta{
+							Name: "foo",
+							Labels: map[string]string{
+								"foo":  "bar",
+								"name": "baz",
+							},
+						},
+						Spec: api.ReplicationControllerSpec{
+							Replicas: 2,
+							Template: &api.PodTemplateSpec{},
+						},
+					},
+				},
+			},
+		},
+	}
+	receivedControllerList, err := c.Setup(t).ReplicationControllers(ns).List(labels.Everything())
+	c.Validate(t, receivedControllerList, err)
+
+}
+
+func TestGetController(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request: testRequest{Method: "GET", Path: testapi.Default.ResourcePath(getRCResourceName(), ns, "foo"), Query: buildQueryValues(nil)},
+		Response: Response{
+			StatusCode: 200,
+			Body: &api.ReplicationController{
+				ObjectMeta: api.ObjectMeta{
+					Name: "foo",
+					Labels: map[string]string{
+						"foo":  "bar",
+						"name": "baz",
+					},
+				},
+				Spec: api.ReplicationControllerSpec{
+					Replicas: 2,
+					Template: &api.PodTemplateSpec{},
+				},
+			},
+		},
+	}
+	receivedController, err := c.Setup(t).ReplicationControllers(ns).Get("foo")
+	c.Validate(t, receivedController, err)
+}
+
+func TestGetControllerWithNoName(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{Error: true}
+	receivedPod, err := c.Setup(t).ReplicationControllers(ns).Get("")
+	if (err != nil) && (err.Error() != nameRequiredError) {
+		t.Errorf("Expected error: %v, but got %v", nameRequiredError, err)
+	}
+
+	c.Validate(t, receivedPod, err)
+}
+
+func TestUpdateController(t *testing.T) {
+	ns := api.NamespaceDefault
+	requestController := &api.ReplicationController{
+		ObjectMeta: api.ObjectMeta{Name: "foo", ResourceVersion: "1"},
+	}
+	c := &testClient{
+		Request: testRequest{Method: "PUT", Path: testapi.Default.ResourcePath(getRCResourceName(), ns, "foo"), Query: buildQueryValues(nil)},
+		Response: Response{
+			StatusCode: 200,
+			Body: &api.ReplicationController{
+				ObjectMeta: api.ObjectMeta{
+					Name: "foo",
+					Labels: map[string]string{
+						"foo":  "bar",
+						"name": "baz",
+					},
+				},
+				Spec: api.ReplicationControllerSpec{
+					Replicas: 2,
+					Template: &api.PodTemplateSpec{},
+				},
+			},
+		},
+	}
+	receivedController, err := c.Setup(t).ReplicationControllers(ns).Update(requestController)
+	c.Validate(t, receivedController, err)
+}
+
+func TestDeleteController(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request:  testRequest{Method: "DELETE", Path: testapi.Default.ResourcePath(getRCResourceName(), ns, "foo"), Query: buildQueryValues(nil)},
+		Response: Response{StatusCode: 200},
+	}
+	err := c.Setup(t).ReplicationControllers(ns).Delete("foo")
+	c.Validate(t, nil, err)
+}
+
+func TestCreateController(t *testing.T) {
+	ns := api.NamespaceDefault
+	requestController := &api.ReplicationController{
+		ObjectMeta: api.ObjectMeta{Name: "foo"},
+	}
+	c := &testClient{
+		Request: testRequest{Method: "POST", Path: testapi.Default.ResourcePath(getRCResourceName(), ns, ""), Body: requestController, Query: buildQueryValues(nil)},
+		Response: Response{
+			StatusCode: 200,
+			Body: &api.ReplicationController{
+				ObjectMeta: api.ObjectMeta{
+					Name: "foo",
+					Labels: map[string]string{
+						"foo":  "bar",
+						"name": "baz",
+					},
+				},
+				Spec: api.ReplicationControllerSpec{
+					Replicas: 2,
+					Template: &api.PodTemplateSpec{},
+				},
+			},
+		},
+	}
+	receivedController, err := c.Setup(t).ReplicationControllers(ns).Create(requestController)
+	c.Validate(t, receivedController, err)
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/request.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/request.go
@@ -309,13 +309,13 @@ type versionToResourceToFieldMapping map[string]resourceTypeToFieldMapping
 func (v versionToResourceToFieldMapping) filterField(apiVersion, resourceType, field, value string) (newField, newValue string, err error) {
 	rMapping, ok := v[apiVersion]
 	if !ok {
-		glog.Warningf("field selector: %v - %v - %v - %v: need to check if this is versioned correctly.", apiVersion, resourceType, field, value)
+		glog.Warningf("Field selector: %v - %v - %v - %v: need to check if this is versioned correctly.", apiVersion, resourceType, field, value)
 		return field, value, nil
 	}
 	newField, newValue, err = rMapping.filterField(resourceType, field, value)
 	if err != nil {
 		// This is only a warning until we find and fix all of the client's usages.
-		glog.Warningf("field selector: %v - %v - %v - %v: need to check if this is versioned correctly.", apiVersion, resourceType, field, value)
+		glog.Warningf("Field selector: %v - %v - %v - %v: need to check if this is versioned correctly.", apiVersion, resourceType, field, value)
 		return field, value, nil
 	}
 	return newField, newValue, nil

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/request_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/request_test.go
@@ -1,0 +1,1268 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/base64"
+	"errors"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/kubernetes/pkg/api"
+	apierrors "k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util"
+	"k8s.io/kubernetes/pkg/util/httpstream"
+	"k8s.io/kubernetes/pkg/watch"
+	watchjson "k8s.io/kubernetes/pkg/watch/json"
+)
+
+func TestRequestWithErrorWontChange(t *testing.T) {
+	original := Request{
+		err:        errors.New("test"),
+		apiVersion: testapi.Default.Version(),
+	}
+	r := original
+	changed := r.Param("foo", "bar").
+		LabelsSelectorParam(labels.Set{"a": "b"}.AsSelector()).
+		UintParam("uint", 1).
+		AbsPath("/abs").
+		Prefix("test").
+		Suffix("testing").
+		Namespace("new").
+		Resource("foos").
+		Name("bars").
+		Body("foo").
+		Timeout(time.Millisecond)
+	if changed != &r {
+		t.Errorf("returned request should point to the same object")
+	}
+	if !reflect.DeepEqual(changed, &original) {
+		t.Errorf("expected %#v, got %#v", &original, changed)
+	}
+}
+
+func TestRequestPreservesBaseTrailingSlash(t *testing.T) {
+	r := &Request{baseURL: &url.URL{}, path: "/path/"}
+	if s := r.URL().String(); s != "/path/" {
+		t.Errorf("trailing slash should be preserved: %s", s)
+	}
+}
+
+func TestRequestAbsPathPreservesTrailingSlash(t *testing.T) {
+	r := (&Request{baseURL: &url.URL{}}).AbsPath("/foo/")
+	if s := r.URL().String(); s != "/foo/" {
+		t.Errorf("trailing slash should be preserved: %s", s)
+	}
+
+	r = (&Request{baseURL: &url.URL{}}).AbsPath("/foo/")
+	if s := r.URL().String(); s != "/foo/" {
+		t.Errorf("trailing slash should be preserved: %s", s)
+	}
+}
+
+func TestRequestAbsPathJoins(t *testing.T) {
+	r := (&Request{baseURL: &url.URL{}}).AbsPath("foo/bar", "baz")
+	if s := r.URL().String(); s != "foo/bar/baz" {
+		t.Errorf("trailing slash should be preserved: %s", s)
+	}
+}
+
+func TestRequestSetsNamespace(t *testing.T) {
+	r := (&Request{
+		baseURL: &url.URL{
+			Path: "/",
+		},
+	}).Namespace("foo")
+	if r.namespace == "" {
+		t.Errorf("namespace should be set: %#v", r)
+	}
+
+	if s := r.URL().String(); s != "namespaces/foo" {
+		t.Errorf("namespace should be in path: %s", s)
+	}
+}
+
+func TestRequestOrdersNamespaceInPath(t *testing.T) {
+	r := (&Request{
+		baseURL: &url.URL{},
+		path:    "/test/",
+	}).Name("bar").Resource("baz").Namespace("foo")
+	if s := r.URL().String(); s != "/test/namespaces/foo/baz/bar" {
+		t.Errorf("namespace should be in order in path: %s", s)
+	}
+}
+
+func TestRequestOrdersSubResource(t *testing.T) {
+	r := (&Request{
+		baseURL: &url.URL{},
+		path:    "/test/",
+	}).Name("bar").Resource("baz").Namespace("foo").Suffix("test").SubResource("a", "b")
+	if s := r.URL().String(); s != "/test/namespaces/foo/baz/bar/a/b/test" {
+		t.Errorf("namespace should be in order in path: %s", s)
+	}
+}
+
+func TestRequestSetTwiceError(t *testing.T) {
+	if (&Request{}).Name("bar").Name("baz").err == nil {
+		t.Errorf("setting name twice should result in error")
+	}
+	if (&Request{}).Namespace("bar").Namespace("baz").err == nil {
+		t.Errorf("setting namespace twice should result in error")
+	}
+	if (&Request{}).Resource("bar").Resource("baz").err == nil {
+		t.Errorf("setting resource twice should result in error")
+	}
+	if (&Request{}).SubResource("bar").SubResource("baz").err == nil {
+		t.Errorf("setting subresource twice should result in error")
+	}
+}
+
+func TestRequestParam(t *testing.T) {
+	r := (&Request{}).Param("foo", "a")
+	if !api.Semantic.DeepDerivative(r.params, url.Values{"foo": []string{"a"}}) {
+		t.Errorf("should have set a param: %#v", r)
+	}
+
+	r.Param("bar", "1")
+	r.Param("bar", "2")
+	if !api.Semantic.DeepDerivative(r.params, url.Values{"foo": []string{"a"}, "bar": []string{"1", "2"}}) {
+		t.Errorf("should have set a param: %#v", r)
+	}
+}
+
+func TestRequestURI(t *testing.T) {
+	r := (&Request{}).Param("foo", "a")
+	r.Prefix("other")
+	r.RequestURI("/test?foo=b&a=b&c=1&c=2")
+	if r.path != "/test" {
+		t.Errorf("path is wrong: %#v", r)
+	}
+	if !api.Semantic.DeepDerivative(r.params, url.Values{"a": []string{"b"}, "foo": []string{"b"}, "c": []string{"1", "2"}}) {
+		t.Errorf("should have set a param: %#v", r)
+	}
+}
+
+type NotAnAPIObject struct{}
+
+func (NotAnAPIObject) IsAnAPIObject() {}
+
+func TestRequestBody(t *testing.T) {
+	// test unknown type
+	r := (&Request{}).Body([]string{"test"})
+	if r.err == nil || r.body != nil {
+		t.Errorf("should have set err and left body nil: %#v", r)
+	}
+
+	// test error set when failing to read file
+	f, err := ioutil.TempFile("", "test")
+	if err != nil {
+		t.Fatalf("unable to create temp file")
+	}
+	os.Remove(f.Name())
+	r = (&Request{}).Body(f.Name())
+	if r.err == nil || r.body != nil {
+		t.Errorf("should have set err and left body nil: %#v", r)
+	}
+
+	// test unencodable api object
+	r = (&Request{codec: testapi.Default.Codec()}).Body(&NotAnAPIObject{})
+	if r.err == nil || r.body != nil {
+		t.Errorf("should have set err and left body nil: %#v", r)
+	}
+}
+
+func TestResultIntoWithErrReturnsErr(t *testing.T) {
+	res := Result{err: errors.New("test")}
+	if err := res.Into(&api.Pod{}); err != res.err {
+		t.Errorf("should have returned exact error from result")
+	}
+}
+
+func TestURLTemplate(t *testing.T) {
+	uri, _ := url.Parse("http://localhost")
+	r := NewRequest(nil, "POST", uri, "test", nil)
+	r.Prefix("pre1").Resource("r1").Namespace("ns").Name("nm").Param("p0", "v0")
+	full := r.URL()
+	if full.String() != "http://localhost/pre1/namespaces/ns/r1/nm?p0=v0" {
+		t.Errorf("unexpected initial URL: %s", full)
+	}
+	actual := r.finalURLTemplate()
+	expected := "http://localhost/pre1/namespaces/%7Bnamespace%7D/r1/%7Bname%7D?p0=%7Bvalue%7D"
+	if actual != expected {
+		t.Errorf("unexpected URL template: %s %s", actual, expected)
+	}
+	if r.URL().String() != full.String() {
+		t.Errorf("creating URL template changed request: %s -> %s", full.String(), r.URL().String())
+	}
+}
+
+func TestTransformResponse(t *testing.T) {
+	invalid := []byte("aaaaa")
+	uri, _ := url.Parse("http://localhost")
+	testCases := []struct {
+		Response *http.Response
+		Data     []byte
+		Created  bool
+		Error    bool
+		ErrFn    func(err error) bool
+	}{
+		{Response: &http.Response{StatusCode: 200}, Data: []byte{}},
+		{Response: &http.Response{StatusCode: 201}, Data: []byte{}, Created: true},
+		{Response: &http.Response{StatusCode: 199}, Error: true},
+		{Response: &http.Response{StatusCode: 500}, Error: true},
+		{Response: &http.Response{StatusCode: 422}, Error: true},
+		{Response: &http.Response{StatusCode: 409}, Error: true},
+		{Response: &http.Response{StatusCode: 404}, Error: true},
+		{Response: &http.Response{StatusCode: 401}, Error: true},
+		{
+			Response: &http.Response{
+				StatusCode: 401,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       ioutil.NopCloser(bytes.NewReader(invalid)),
+			},
+			Error: true,
+			ErrFn: func(err error) bool {
+				return err.Error() != "aaaaa" && apierrors.IsUnauthorized(err)
+			},
+		},
+		{
+			Response: &http.Response{
+				StatusCode: 401,
+				Header:     http.Header{"Content-Type": []string{"text/any"}},
+				Body:       ioutil.NopCloser(bytes.NewReader(invalid)),
+			},
+			Error: true,
+			ErrFn: func(err error) bool {
+				return strings.Contains(err.Error(), "server has asked for the client to provide") && apierrors.IsUnauthorized(err)
+			},
+		},
+		{Response: &http.Response{StatusCode: 403}, Error: true},
+		{Response: &http.Response{StatusCode: 200, Body: ioutil.NopCloser(bytes.NewReader(invalid))}, Data: invalid},
+		{Response: &http.Response{StatusCode: 200, Body: ioutil.NopCloser(bytes.NewReader(invalid))}, Data: invalid},
+	}
+	for i, test := range testCases {
+		r := NewRequest(nil, "", uri, testapi.Default.Version(), testapi.Default.Codec())
+		if test.Response.Body == nil {
+			test.Response.Body = ioutil.NopCloser(bytes.NewReader([]byte{}))
+		}
+		result := r.transformResponse(test.Response, &http.Request{})
+		response, created, err := result.body, result.statusCode == http.StatusCreated, result.err
+		hasErr := err != nil
+		if hasErr != test.Error {
+			t.Errorf("%d: unexpected error: %t %v", i, test.Error, err)
+		} else if hasErr && test.Response.StatusCode > 399 {
+			status, ok := err.(APIStatus)
+			if !ok {
+				t.Errorf("%d: response should have been transformable into APIStatus: %v", i, err)
+				continue
+			}
+			if status.Status().Code != test.Response.StatusCode {
+				t.Errorf("%d: status code did not match response: %#v", i, status.Status())
+			}
+		}
+		if test.ErrFn != nil && !test.ErrFn(err) {
+			t.Errorf("%d: error function did not match: %v", i, err)
+		}
+		if !(test.Data == nil && response == nil) && !api.Semantic.DeepDerivative(test.Data, response) {
+			t.Errorf("%d: unexpected response: %#v %#v", i, test.Data, response)
+		}
+		if test.Created != created {
+			t.Errorf("%d: expected created %t, got %t", i, test.Created, created)
+		}
+	}
+}
+
+func TestTransformUnstructuredError(t *testing.T) {
+	testCases := []struct {
+		Req *http.Request
+		Res *http.Response
+
+		Resource string
+		Name     string
+
+		ErrFn func(error) bool
+	}{
+		{
+			Resource: "foo",
+			Name:     "bar",
+			Req: &http.Request{
+				Method: "POST",
+			},
+			Res: &http.Response{
+				StatusCode: http.StatusConflict,
+				Body:       ioutil.NopCloser(bytes.NewReader(nil)),
+			},
+			ErrFn: apierrors.IsAlreadyExists,
+		},
+		{
+			Resource: "foo",
+			Name:     "bar",
+			Req: &http.Request{
+				Method: "PUT",
+			},
+			Res: &http.Response{
+				StatusCode: http.StatusConflict,
+				Body:       ioutil.NopCloser(bytes.NewReader(nil)),
+			},
+			ErrFn: apierrors.IsConflict,
+		},
+		{
+			Resource: "foo",
+			Name:     "bar",
+			Req:      &http.Request{},
+			Res: &http.Response{
+				StatusCode: http.StatusNotFound,
+				Body:       ioutil.NopCloser(bytes.NewReader(nil)),
+			},
+			ErrFn: apierrors.IsNotFound,
+		},
+		{
+			Req: &http.Request{},
+			Res: &http.Response{
+				StatusCode: http.StatusBadRequest,
+				Body:       ioutil.NopCloser(bytes.NewReader(nil)),
+			},
+			ErrFn: apierrors.IsBadRequest,
+		},
+	}
+
+	for _, testCase := range testCases {
+		r := &Request{
+			codec:        testapi.Default.Codec(),
+			resourceName: testCase.Name,
+			resource:     testCase.Resource,
+		}
+		result := r.transformResponse(testCase.Res, testCase.Req)
+		err := result.err
+		if !testCase.ErrFn(err) {
+			t.Errorf("unexpected error: %v", err)
+			continue
+		}
+		if len(testCase.Name) != 0 && !strings.Contains(err.Error(), testCase.Name) {
+			t.Errorf("unexpected error string: %s", err)
+		}
+		if len(testCase.Resource) != 0 && !strings.Contains(err.Error(), testCase.Resource) {
+			t.Errorf("unexpected error string: %s", err)
+		}
+	}
+}
+
+type clientFunc func(req *http.Request) (*http.Response, error)
+
+func (f clientFunc) Do(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestRequestWatch(t *testing.T) {
+	testCases := []struct {
+		Request *Request
+		Err     bool
+		ErrFn   func(error) bool
+		Empty   bool
+	}{
+		{
+			Request: &Request{err: errors.New("bail")},
+			Err:     true,
+		},
+		{
+			Request: &Request{baseURL: &url.URL{}, path: "%"},
+			Err:     true,
+		},
+		{
+			Request: &Request{
+				client: clientFunc(func(req *http.Request) (*http.Response, error) {
+					return nil, errors.New("err")
+				}),
+				baseURL: &url.URL{},
+			},
+			Err: true,
+		},
+		{
+			Request: &Request{
+				codec: testapi.Default.Codec(),
+				client: clientFunc(func(req *http.Request) (*http.Response, error) {
+					return &http.Response{StatusCode: http.StatusForbidden}, nil
+				}),
+				baseURL: &url.URL{},
+			},
+			Err: true,
+			ErrFn: func(err error) bool {
+				return apierrors.IsForbidden(err)
+			},
+		},
+		{
+			Request: &Request{
+				codec: testapi.Default.Codec(),
+				client: clientFunc(func(req *http.Request) (*http.Response, error) {
+					return &http.Response{StatusCode: http.StatusUnauthorized}, nil
+				}),
+				baseURL: &url.URL{},
+			},
+			Err: true,
+			ErrFn: func(err error) bool {
+				return apierrors.IsUnauthorized(err)
+			},
+		},
+		{
+			Request: &Request{
+				codec: testapi.Default.Codec(),
+				client: clientFunc(func(req *http.Request) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: http.StatusUnauthorized,
+						Body: ioutil.NopCloser(bytes.NewReader([]byte(runtime.EncodeOrDie(testapi.Default.Codec(), &unversioned.Status{
+							Status: unversioned.StatusFailure,
+							Reason: unversioned.StatusReasonUnauthorized,
+						})))),
+					}, nil
+				}),
+				baseURL: &url.URL{},
+			},
+			Err: true,
+			ErrFn: func(err error) bool {
+				return apierrors.IsUnauthorized(err)
+			},
+		},
+		{
+			Request: &Request{
+				client: clientFunc(func(req *http.Request) (*http.Response, error) {
+					return nil, io.EOF
+				}),
+				baseURL: &url.URL{},
+			},
+			Empty: true,
+		},
+		{
+			Request: &Request{
+				client: clientFunc(func(req *http.Request) (*http.Response, error) {
+					return nil, &url.Error{Err: io.EOF}
+				}),
+				baseURL: &url.URL{},
+			},
+			Empty: true,
+		},
+		{
+			Request: &Request{
+				client: clientFunc(func(req *http.Request) (*http.Response, error) {
+					return nil, errors.New("http: can't write HTTP request on broken connection")
+				}),
+				baseURL: &url.URL{},
+			},
+			Empty: true,
+		},
+		{
+			Request: &Request{
+				client: clientFunc(func(req *http.Request) (*http.Response, error) {
+					return nil, errors.New("foo: connection reset by peer")
+				}),
+				baseURL: &url.URL{},
+			},
+			Empty: true,
+		},
+	}
+	for i, testCase := range testCases {
+		watch, err := testCase.Request.Watch()
+		hasErr := err != nil
+		if hasErr != testCase.Err {
+			t.Errorf("%d: expected %t, got %t: %v", i, testCase.Err, hasErr, err)
+			continue
+		}
+		if testCase.ErrFn != nil && !testCase.ErrFn(err) {
+			t.Errorf("%d: error not valid: %v", i, err)
+		}
+		if hasErr && watch != nil {
+			t.Errorf("%d: watch should be nil when error is returned", i)
+			continue
+		}
+		if testCase.Empty {
+			_, ok := <-watch.ResultChan()
+			if ok {
+				t.Errorf("%d: expected the watch to be empty: %#v", i, watch)
+			}
+		}
+	}
+}
+
+func TestRequestStream(t *testing.T) {
+	testCases := []struct {
+		Request *Request
+		Err     bool
+	}{
+		{
+			Request: &Request{err: errors.New("bail")},
+			Err:     true,
+		},
+		{
+			Request: &Request{baseURL: &url.URL{}, path: "%"},
+			Err:     true,
+		},
+		{
+			Request: &Request{
+				client: clientFunc(func(req *http.Request) (*http.Response, error) {
+					return nil, errors.New("err")
+				}),
+				baseURL: &url.URL{},
+			},
+			Err: true,
+		},
+		{
+			Request: &Request{
+				client: clientFunc(func(req *http.Request) (*http.Response, error) {
+					return &http.Response{
+						StatusCode: http.StatusUnauthorized,
+						Body: ioutil.NopCloser(bytes.NewReader([]byte(runtime.EncodeOrDie(testapi.Default.Codec(), &unversioned.Status{
+							Status: unversioned.StatusFailure,
+							Reason: unversioned.StatusReasonUnauthorized,
+						})))),
+					}, nil
+				}),
+				codec:   testapi.Default.Codec(),
+				baseURL: &url.URL{},
+			},
+			Err: true,
+		},
+	}
+	for i, testCase := range testCases {
+		body, err := testCase.Request.Stream()
+		hasErr := err != nil
+		if hasErr != testCase.Err {
+			t.Errorf("%d: expected %t, got %t: %v", i, testCase.Err, hasErr, err)
+		}
+		if hasErr && body != nil {
+			t.Errorf("%d: body should be nil when error is returned", i)
+		}
+	}
+}
+
+type fakeUpgradeConnection struct{}
+
+func (c *fakeUpgradeConnection) CreateStream(headers http.Header) (httpstream.Stream, error) {
+	return nil, nil
+}
+func (c *fakeUpgradeConnection) Close() error {
+	return nil
+}
+func (c *fakeUpgradeConnection) CloseChan() <-chan bool {
+	return make(chan bool)
+}
+func (c *fakeUpgradeConnection) SetIdleTimeout(timeout time.Duration) {
+}
+
+type fakeUpgradeRoundTripper struct {
+	req  *http.Request
+	conn httpstream.Connection
+}
+
+func (f *fakeUpgradeRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	f.req = req
+	b := []byte{}
+	body := ioutil.NopCloser(bytes.NewReader(b))
+	resp := &http.Response{
+		StatusCode: 101,
+		Body:       body,
+	}
+	return resp, nil
+}
+
+func (f *fakeUpgradeRoundTripper) NewConnection(resp *http.Response) (httpstream.Connection, error) {
+	return f.conn, nil
+}
+
+func TestRequestUpgrade(t *testing.T) {
+	uri, _ := url.Parse("http://localhost/")
+	testCases := []struct {
+		Request          *Request
+		Config           *Config
+		RoundTripper     *fakeUpgradeRoundTripper
+		Err              bool
+		AuthBasicHeader  bool
+		AuthBearerHeader bool
+	}{
+		{
+			Request: &Request{err: errors.New("bail")},
+			Err:     true,
+		},
+		{
+			Request: &Request{},
+			Config: &Config{
+				TLSClientConfig: TLSClientConfig{
+					CAFile: "foo",
+				},
+				Insecure: true,
+			},
+			Err: true,
+		},
+		{
+			Request: &Request{},
+			Config: &Config{
+				Username:    "u",
+				Password:    "p",
+				BearerToken: "b",
+			},
+			Err: true,
+		},
+		{
+			Request: NewRequest(nil, "", uri, testapi.Default.Version(), testapi.Default.Codec()),
+			Config: &Config{
+				Username: "u",
+				Password: "p",
+			},
+			AuthBasicHeader: true,
+			Err:             false,
+		},
+		{
+			Request: NewRequest(nil, "", uri, testapi.Default.Version(), testapi.Default.Codec()),
+			Config: &Config{
+				BearerToken: "b",
+			},
+			AuthBearerHeader: true,
+			Err:              false,
+		},
+	}
+	for i, testCase := range testCases {
+		r := testCase.Request
+		rt := &fakeUpgradeRoundTripper{}
+		expectedConn := &fakeUpgradeConnection{}
+		conn, err := r.Upgrade(testCase.Config, func(config *tls.Config) httpstream.UpgradeRoundTripper {
+			rt.conn = expectedConn
+			return rt
+		})
+		_ = conn
+		hasErr := err != nil
+		if hasErr != testCase.Err {
+			t.Errorf("%d: expected %t, got %t: %v", i, testCase.Err, hasErr, r.err)
+		}
+		if testCase.Err {
+			continue
+		}
+
+		if testCase.AuthBasicHeader && !strings.Contains(rt.req.Header.Get("Authorization"), "Basic") {
+			t.Errorf("%d: expected basic auth header, got: %s", i, rt.req.Header.Get("Authorization"))
+		}
+
+		if testCase.AuthBearerHeader && !strings.Contains(rt.req.Header.Get("Authorization"), "Bearer") {
+			t.Errorf("%d: expected bearer auth header, got: %s", i, rt.req.Header.Get("Authorization"))
+		}
+
+		if e, a := expectedConn, conn; e != a {
+			t.Errorf("%d: conn: expected %#v, got %#v", i, e, a)
+		}
+	}
+}
+
+func TestRequestDo(t *testing.T) {
+	testCases := []struct {
+		Request *Request
+		Err     bool
+	}{
+		{
+			Request: &Request{err: errors.New("bail")},
+			Err:     true,
+		},
+		{
+			Request: &Request{baseURL: &url.URL{}, path: "%"},
+			Err:     true,
+		},
+		{
+			Request: &Request{
+				client: clientFunc(func(req *http.Request) (*http.Response, error) {
+					return nil, errors.New("err")
+				}),
+				baseURL: &url.URL{},
+			},
+			Err: true,
+		},
+	}
+	for i, testCase := range testCases {
+		body, err := testCase.Request.Do().Raw()
+		hasErr := err != nil
+		if hasErr != testCase.Err {
+			t.Errorf("%d: expected %t, got %t: %v", i, testCase.Err, hasErr, err)
+		}
+		if hasErr && body != nil {
+			t.Errorf("%d: body should be nil when error is returned", i)
+		}
+	}
+}
+
+func TestDoRequestNewWay(t *testing.T) {
+	reqBody := "request body"
+	expectedObj := &api.Service{Spec: api.ServiceSpec{Ports: []api.ServicePort{{
+		Protocol:   "TCP",
+		Port:       12345,
+		TargetPort: util.NewIntOrStringFromInt(12345),
+	}}}}
+	expectedBody, _ := testapi.Default.Codec().Encode(expectedObj)
+	fakeHandler := util.FakeHandler{
+		StatusCode:   200,
+		ResponseBody: string(expectedBody),
+		T:            t,
+	}
+	testServer := httptest.NewServer(&fakeHandler)
+	defer testServer.Close()
+	c := NewOrDie(&Config{Host: testServer.URL, Version: testapi.Default.Version(), Username: "user", Password: "pass"})
+	obj, err := c.Verb("POST").
+		Prefix("foo", "bar").
+		Suffix("baz").
+		Timeout(time.Second).
+		Body([]byte(reqBody)).
+		Do().Get()
+	if err != nil {
+		t.Errorf("Unexpected error: %v %#v", err, err)
+		return
+	}
+	if obj == nil {
+		t.Error("nil obj")
+	} else if !api.Semantic.DeepDerivative(expectedObj, obj) {
+		t.Errorf("Expected: %#v, got %#v", expectedObj, obj)
+	}
+	requestURL := testapi.Default.ResourcePathWithPrefix("foo/bar", "", "", "baz")
+	requestURL += "?timeout=1s"
+	fakeHandler.ValidateRequest(t, requestURL, "POST", &reqBody)
+	if fakeHandler.RequestReceived.Header["Authorization"] == nil {
+		t.Errorf("Request is missing authorization header: %#v", *fakeHandler.RequestReceived)
+	}
+}
+
+func TestCheckRetryClosesBody(t *testing.T) {
+	count := 0
+	ch := make(chan struct{})
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		count++
+		t.Logf("attempt %d", count)
+		if count >= 5 {
+			w.WriteHeader(http.StatusOK)
+			close(ch)
+			return
+		}
+		w.Header().Set("Retry-After", "0")
+		w.WriteHeader(apierrors.StatusTooManyRequests)
+	}))
+	defer testServer.Close()
+
+	c := NewOrDie(&Config{Host: testServer.URL, Version: testapi.Default.Version(), Username: "user", Password: "pass"})
+	_, err := c.Verb("POST").
+		Prefix("foo", "bar").
+		Suffix("baz").
+		Timeout(time.Second).
+		Body([]byte(strings.Repeat("abcd", 1000))).
+		DoRaw()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v %#v", err, err)
+	}
+	<-ch
+	if count != 5 {
+		t.Errorf("unexpected retries: %d", count)
+	}
+}
+
+func BenchmarkCheckRetryClosesBody(t *testing.B) {
+	count := 0
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		count++
+		if count%3 == 0 {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.Header().Set("Retry-After", "0")
+		w.WriteHeader(apierrors.StatusTooManyRequests)
+	}))
+	defer testServer.Close()
+
+	c := NewOrDie(&Config{Host: testServer.URL, Version: testapi.Default.Version(), Username: "user", Password: "pass"})
+	r := c.Verb("POST").
+		Prefix("foo", "bar").
+		Suffix("baz").
+		Timeout(time.Second).
+		Body([]byte(strings.Repeat("abcd", 1000)))
+
+	for i := 0; i < t.N; i++ {
+		if _, err := r.DoRaw(); err != nil {
+			t.Fatalf("Unexpected error: %v %#v", err, err)
+		}
+	}
+}
+func TestDoRequestNewWayReader(t *testing.T) {
+	reqObj := &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo"}}
+	reqBodyExpected, _ := testapi.Default.Codec().Encode(reqObj)
+	expectedObj := &api.Service{Spec: api.ServiceSpec{Ports: []api.ServicePort{{
+		Protocol:   "TCP",
+		Port:       12345,
+		TargetPort: util.NewIntOrStringFromInt(12345),
+	}}}}
+	expectedBody, _ := testapi.Default.Codec().Encode(expectedObj)
+	fakeHandler := util.FakeHandler{
+		StatusCode:   200,
+		ResponseBody: string(expectedBody),
+		T:            t,
+	}
+	testServer := httptest.NewServer(&fakeHandler)
+	c := NewOrDie(&Config{Host: testServer.URL, Version: testapi.Default.Version(), Username: "user", Password: "pass"})
+	obj, err := c.Verb("POST").
+		Resource("bar").
+		Name("baz").
+		Prefix("foo").
+		LabelsSelectorParam(labels.Set{"name": "foo"}.AsSelector()).
+		Timeout(time.Second).
+		Body(bytes.NewBuffer(reqBodyExpected)).
+		Do().Get()
+	if err != nil {
+		t.Errorf("Unexpected error: %v %#v", err, err)
+		return
+	}
+	if obj == nil {
+		t.Error("nil obj")
+	} else if !api.Semantic.DeepDerivative(expectedObj, obj) {
+		t.Errorf("Expected: %#v, got %#v", expectedObj, obj)
+	}
+	tmpStr := string(reqBodyExpected)
+	requestURL := testapi.Default.ResourcePathWithPrefix("foo", "bar", "", "baz")
+	requestURL += "?" + api.LabelSelectorQueryParam(testapi.Default.Version()) + "=name%3Dfoo&timeout=1s"
+	fakeHandler.ValidateRequest(t, requestURL, "POST", &tmpStr)
+	if fakeHandler.RequestReceived.Header["Authorization"] == nil {
+		t.Errorf("Request is missing authorization header: %#v", *fakeHandler.RequestReceived)
+	}
+}
+
+func TestDoRequestNewWayObj(t *testing.T) {
+	reqObj := &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo"}}
+	reqBodyExpected, _ := testapi.Default.Codec().Encode(reqObj)
+	expectedObj := &api.Service{Spec: api.ServiceSpec{Ports: []api.ServicePort{{
+		Protocol:   "TCP",
+		Port:       12345,
+		TargetPort: util.NewIntOrStringFromInt(12345),
+	}}}}
+	expectedBody, _ := testapi.Default.Codec().Encode(expectedObj)
+	fakeHandler := util.FakeHandler{
+		StatusCode:   200,
+		ResponseBody: string(expectedBody),
+		T:            t,
+	}
+	testServer := httptest.NewServer(&fakeHandler)
+	c := NewOrDie(&Config{Host: testServer.URL, Version: testapi.Default.Version(), Username: "user", Password: "pass"})
+	obj, err := c.Verb("POST").
+		Suffix("baz").
+		Name("bar").
+		Resource("foo").
+		LabelsSelectorParam(labels.Set{"name": "foo"}.AsSelector()).
+		Timeout(time.Second).
+		Body(reqObj).
+		Do().Get()
+	if err != nil {
+		t.Errorf("Unexpected error: %v %#v", err, err)
+		return
+	}
+	if obj == nil {
+		t.Error("nil obj")
+	} else if !api.Semantic.DeepDerivative(expectedObj, obj) {
+		t.Errorf("Expected: %#v, got %#v", expectedObj, obj)
+	}
+	tmpStr := string(reqBodyExpected)
+	requestURL := testapi.Default.ResourcePath("foo", "", "bar/baz")
+	requestURL += "?" + api.LabelSelectorQueryParam(testapi.Default.Version()) + "=name%3Dfoo&timeout=1s"
+	fakeHandler.ValidateRequest(t, requestURL, "POST", &tmpStr)
+	if fakeHandler.RequestReceived.Header["Authorization"] == nil {
+		t.Errorf("Request is missing authorization header: %#v", *fakeHandler.RequestReceived)
+	}
+}
+
+func TestDoRequestNewWayFile(t *testing.T) {
+	reqObj := &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo"}}
+	reqBodyExpected, err := testapi.Default.Codec().Encode(reqObj)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	file, err := ioutil.TempFile("", "foo")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	_, err = file.Write(reqBodyExpected)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	expectedObj := &api.Service{Spec: api.ServiceSpec{Ports: []api.ServicePort{{
+		Protocol:   "TCP",
+		Port:       12345,
+		TargetPort: util.NewIntOrStringFromInt(12345),
+	}}}}
+	expectedBody, _ := testapi.Default.Codec().Encode(expectedObj)
+	fakeHandler := util.FakeHandler{
+		StatusCode:   200,
+		ResponseBody: string(expectedBody),
+		T:            t,
+	}
+	testServer := httptest.NewServer(&fakeHandler)
+	c := NewOrDie(&Config{Host: testServer.URL, Version: testapi.Default.Version(), Username: "user", Password: "pass"})
+	wasCreated := true
+	obj, err := c.Verb("POST").
+		Prefix("foo/bar", "baz").
+		Timeout(time.Second).
+		Body(file.Name()).
+		Do().WasCreated(&wasCreated).Get()
+	if err != nil {
+		t.Errorf("Unexpected error: %v %#v", err, err)
+		return
+	}
+	if obj == nil {
+		t.Error("nil obj")
+	} else if !api.Semantic.DeepDerivative(expectedObj, obj) {
+		t.Errorf("Expected: %#v, got %#v", expectedObj, obj)
+	}
+	if wasCreated {
+		t.Errorf("expected object was not created")
+	}
+	tmpStr := string(reqBodyExpected)
+	requestURL := testapi.Default.ResourcePathWithPrefix("foo/bar/baz", "", "", "")
+	requestURL += "?timeout=1s"
+	fakeHandler.ValidateRequest(t, requestURL, "POST", &tmpStr)
+	if fakeHandler.RequestReceived.Header["Authorization"] == nil {
+		t.Errorf("Request is missing authorization header: %#v", *fakeHandler.RequestReceived)
+	}
+}
+
+func TestWasCreated(t *testing.T) {
+	reqObj := &api.Pod{ObjectMeta: api.ObjectMeta{Name: "foo"}}
+	reqBodyExpected, err := testapi.Default.Codec().Encode(reqObj)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	expectedObj := &api.Service{Spec: api.ServiceSpec{Ports: []api.ServicePort{{
+		Protocol:   "TCP",
+		Port:       12345,
+		TargetPort: util.NewIntOrStringFromInt(12345),
+	}}}}
+	expectedBody, _ := testapi.Default.Codec().Encode(expectedObj)
+	fakeHandler := util.FakeHandler{
+		StatusCode:   201,
+		ResponseBody: string(expectedBody),
+		T:            t,
+	}
+	testServer := httptest.NewServer(&fakeHandler)
+	c := NewOrDie(&Config{Host: testServer.URL, Version: testapi.Default.Version(), Username: "user", Password: "pass"})
+	wasCreated := false
+	obj, err := c.Verb("PUT").
+		Prefix("foo/bar", "baz").
+		Timeout(time.Second).
+		Body(reqBodyExpected).
+		Do().WasCreated(&wasCreated).Get()
+	if err != nil {
+		t.Errorf("Unexpected error: %v %#v", err, err)
+		return
+	}
+	if obj == nil {
+		t.Error("nil obj")
+	} else if !api.Semantic.DeepDerivative(expectedObj, obj) {
+		t.Errorf("Expected: %#v, got %#v", expectedObj, obj)
+	}
+	if !wasCreated {
+		t.Errorf("Expected object was created")
+	}
+
+	tmpStr := string(reqBodyExpected)
+	requestURL := testapi.Default.ResourcePathWithPrefix("foo/bar/baz", "", "", "")
+	requestURL += "?timeout=1s"
+	fakeHandler.ValidateRequest(t, requestURL, "PUT", &tmpStr)
+	if fakeHandler.RequestReceived.Header["Authorization"] == nil {
+		t.Errorf("Request is missing authorization header: %#v", *fakeHandler.RequestReceived)
+	}
+}
+
+func TestVerbs(t *testing.T) {
+	c := NewOrDie(&Config{})
+	if r := c.Post(); r.verb != "POST" {
+		t.Errorf("Post verb is wrong")
+	}
+	if r := c.Put(); r.verb != "PUT" {
+		t.Errorf("Put verb is wrong")
+	}
+	if r := c.Get(); r.verb != "GET" {
+		t.Errorf("Get verb is wrong")
+	}
+	if r := c.Delete(); r.verb != "DELETE" {
+		t.Errorf("Delete verb is wrong")
+	}
+}
+
+func TestUnversionedPath(t *testing.T) {
+	tt := []struct {
+		host         string
+		prefix       string
+		unversioned  string
+		expectedPath string
+	}{
+		{"", "", "", "/api"},
+		{"", "", "versions", "/api/versions"},
+		{"", "/", "", "/"},
+		{"", "/versions", "", "/versions"},
+		{"", "/api", "", "/api"},
+		{"", "/api/vfake", "", "/api/vfake"},
+		{"", "/api/vfake", "v1beta100", "/api/vfake/v1beta100"},
+		{"", "/api", "/versions", "/api/versions"},
+		{"", "/api", "versions", "/api/versions"},
+		{"", "/a/api", "", "/a/api"},
+		{"", "/a/api", "/versions", "/a/api/versions"},
+		{"", "/a/api", "/versions/d/e", "/a/api/versions/d/e"},
+		{"", "/a/api/vfake", "/versions/d/e", "/a/api/vfake/versions/d/e"},
+	}
+	for i, tc := range tt {
+		c := NewOrDie(&Config{Host: tc.host, Prefix: tc.prefix})
+		r := c.Post().Prefix("/alpha").UnversionedPath(tc.unversioned)
+		if r.path != tc.expectedPath {
+			t.Errorf("test case %d failed: unexpected path: %s, expected %s", i+1, r.path, tc.expectedPath)
+		}
+	}
+	for i, tc := range tt {
+		c := NewOrDie(&Config{Host: tc.host, Prefix: tc.prefix, Version: "v1"})
+		r := c.Post().Prefix("/alpha").UnversionedPath(tc.unversioned)
+		if r.path != tc.expectedPath {
+			t.Errorf("test case %d failed: unexpected path: %s, expected %s", i+1, r.path, tc.expectedPath)
+		}
+	}
+}
+
+func TestAbsPath(t *testing.T) {
+	expectedPath := "/bar/foo"
+	c := NewOrDie(&Config{})
+	r := c.Post().Prefix("/foo").AbsPath(expectedPath)
+	if r.path != expectedPath {
+		t.Errorf("unexpected path: %s, expected %s", r.path, expectedPath)
+	}
+}
+
+func TestUintParam(t *testing.T) {
+	table := []struct {
+		name      string
+		testVal   uint64
+		expectStr string
+	}{
+		{"foo", 31415, "http://localhost?foo=31415"},
+		{"bar", 42, "http://localhost?bar=42"},
+		{"baz", 0, "http://localhost?baz=0"},
+	}
+
+	for _, item := range table {
+		c := NewOrDie(&Config{})
+		r := c.Get().AbsPath("").UintParam(item.name, item.testVal)
+		if e, a := item.expectStr, r.URL().String(); e != a {
+			t.Errorf("expected %v, got %v", e, a)
+		}
+	}
+}
+
+func TestUnacceptableParamNames(t *testing.T) {
+	table := []struct {
+		name          string
+		testVal       string
+		expectSuccess bool
+	}{
+		{"timeout", "42", false},
+	}
+
+	for _, item := range table {
+		c := NewOrDie(&Config{})
+		r := c.Get().setParam(item.name, item.testVal)
+		if e, a := item.expectSuccess, r.err == nil; e != a {
+			t.Errorf("expected %v, got %v (%v)", e, a, r.err)
+		}
+	}
+}
+
+func TestBody(t *testing.T) {
+	const data = "test payload"
+
+	f, err := ioutil.TempFile("", "test_body")
+	if err != nil {
+		t.Fatalf("TempFile error: %v", err)
+	}
+	if _, err := f.WriteString(data); err != nil {
+		t.Fatalf("TempFile.WriteString error: %v", err)
+	}
+	f.Close()
+
+	c := NewOrDie(&Config{})
+	tests := []interface{}{[]byte(data), f.Name(), strings.NewReader(data)}
+	for i, tt := range tests {
+		r := c.Post().Body(tt)
+		if r.err != nil {
+			t.Errorf("%d: r.Body(%#v) error: %v", i, tt, r.err)
+			continue
+		}
+		buf := make([]byte, len(data))
+		if _, err := r.body.Read(buf); err != nil {
+			t.Errorf("%d: r.body.Read error: %v", i, err)
+			continue
+		}
+		body := string(buf)
+		if body != data {
+			t.Errorf("%d: r.body = %q; want %q", i, body, data)
+		}
+	}
+}
+
+func authFromReq(r *http.Request) (*Config, bool) {
+	auth, ok := r.Header["Authorization"]
+	if !ok {
+		return nil, false
+	}
+
+	encoded := strings.Split(auth[0], " ")
+	if len(encoded) != 2 || encoded[0] != "Basic" {
+		return nil, false
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(encoded[1])
+	if err != nil {
+		return nil, false
+	}
+	parts := strings.Split(string(decoded), ":")
+	if len(parts) != 2 {
+		return nil, false
+	}
+	return &Config{Username: parts[0], Password: parts[1]}, true
+}
+
+// checkAuth sets errors if the auth found in r doesn't match the expectation.
+// TODO: Move to util, test in more places.
+func checkAuth(t *testing.T, expect *Config, r *http.Request) {
+	foundAuth, found := authFromReq(r)
+	if !found {
+		t.Errorf("no auth found")
+	} else if e, a := expect, foundAuth; !api.Semantic.DeepDerivative(e, a) {
+		t.Fatalf("Wrong basic auth: wanted %#v, got %#v", e, a)
+	}
+}
+
+func TestWatch(t *testing.T) {
+	var table = []struct {
+		t   watch.EventType
+		obj runtime.Object
+	}{
+		{watch.Added, &api.Pod{ObjectMeta: api.ObjectMeta{Name: "first"}}},
+		{watch.Modified, &api.Pod{ObjectMeta: api.ObjectMeta{Name: "second"}}},
+		{watch.Deleted, &api.Pod{ObjectMeta: api.ObjectMeta{Name: "last"}}},
+	}
+
+	auth := &Config{Username: "user", Password: "pass"}
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		checkAuth(t, auth, r)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			panic("need flusher!")
+		}
+
+		w.Header().Set("Transfer-Encoding", "chunked")
+		w.WriteHeader(http.StatusOK)
+		flusher.Flush()
+
+		encoder := watchjson.NewEncoder(w, testapi.Default.Codec())
+		for _, item := range table {
+			if err := encoder.Encode(&watch.Event{Type: item.t, Object: item.obj}); err != nil {
+				panic(err)
+			}
+			flusher.Flush()
+		}
+	}))
+
+	s, err := New(&Config{
+		Host:     testServer.URL,
+		Version:  testapi.Default.Version(),
+		Username: "user",
+		Password: "pass",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	watching, err := s.Get().Prefix("path/to/watch/thing").Watch()
+	if err != nil {
+		t.Fatalf("Unexpected error")
+	}
+
+	for _, item := range table {
+		got, ok := <-watching.ResultChan()
+		if !ok {
+			t.Fatalf("Unexpected early close")
+		}
+		if e, a := item.t, got.Type; e != a {
+			t.Errorf("Expected %v, got %v", e, a)
+		}
+		if e, a := item.obj, got.Object; !api.Semantic.DeepDerivative(e, a) {
+			t.Errorf("Expected %v, got %v", e, a)
+		}
+	}
+
+	_, ok := <-watching.ResultChan()
+	if ok {
+		t.Fatal("Unexpected non-close")
+	}
+}
+
+func TestStream(t *testing.T) {
+	auth := &Config{Username: "user", Password: "pass"}
+	expectedBody := "expected body"
+
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		checkAuth(t, auth, r)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			panic("need flusher!")
+		}
+		w.Header().Set("Transfer-Encoding", "chunked")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(expectedBody))
+		flusher.Flush()
+	}))
+
+	s, err := New(&Config{
+		Host:     testServer.URL,
+		Version:  testapi.Default.Version(),
+		Username: "user",
+		Password: "pass",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	readCloser, err := s.Get().Prefix("path/to/stream/thing").Stream()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer readCloser.Close()
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(readCloser)
+	resultBody := buf.String()
+
+	if expectedBody != resultBody {
+		t.Errorf("Expected %s, got %s", expectedBody, resultBody)
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/resource_quotas_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/resource_quotas_test.go
@@ -1,0 +1,198 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"net/url"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+func getResourceQuotasResoureName() string {
+	return "resourcequotas"
+}
+
+func TestResourceQuotaCreate(t *testing.T) {
+	ns := api.NamespaceDefault
+	resourceQuota := &api.ResourceQuota{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "abc",
+			Namespace: "foo",
+		},
+		Spec: api.ResourceQuotaSpec{
+			Hard: api.ResourceList{
+				api.ResourceCPU:                    resource.MustParse("100"),
+				api.ResourceMemory:                 resource.MustParse("10000"),
+				api.ResourcePods:                   resource.MustParse("10"),
+				api.ResourceServices:               resource.MustParse("10"),
+				api.ResourceReplicationControllers: resource.MustParse("10"),
+				api.ResourceQuotas:                 resource.MustParse("10"),
+			},
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "POST",
+			Path:   testapi.Default.ResourcePath(getResourceQuotasResoureName(), ns, ""),
+			Query:  buildQueryValues(nil),
+			Body:   resourceQuota,
+		},
+		Response: Response{StatusCode: 200, Body: resourceQuota},
+	}
+
+	response, err := c.Setup(t).ResourceQuotas(ns).Create(resourceQuota)
+	c.Validate(t, response, err)
+}
+
+func TestResourceQuotaGet(t *testing.T) {
+	ns := api.NamespaceDefault
+	resourceQuota := &api.ResourceQuota{
+		ObjectMeta: api.ObjectMeta{
+			Name:      "abc",
+			Namespace: "foo",
+		},
+		Spec: api.ResourceQuotaSpec{
+			Hard: api.ResourceList{
+				api.ResourceCPU:                    resource.MustParse("100"),
+				api.ResourceMemory:                 resource.MustParse("10000"),
+				api.ResourcePods:                   resource.MustParse("10"),
+				api.ResourceServices:               resource.MustParse("10"),
+				api.ResourceReplicationControllers: resource.MustParse("10"),
+				api.ResourceQuotas:                 resource.MustParse("10"),
+			},
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePath(getResourceQuotasResoureName(), ns, "abc"),
+			Query:  buildQueryValues(nil),
+			Body:   nil,
+		},
+		Response: Response{StatusCode: 200, Body: resourceQuota},
+	}
+
+	response, err := c.Setup(t).ResourceQuotas(ns).Get("abc")
+	c.Validate(t, response, err)
+}
+
+func TestResourceQuotaList(t *testing.T) {
+	ns := api.NamespaceDefault
+
+	resourceQuotaList := &api.ResourceQuotaList{
+		Items: []api.ResourceQuota{
+			{
+				ObjectMeta: api.ObjectMeta{Name: "foo"},
+			},
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePath(getResourceQuotasResoureName(), ns, ""),
+			Query:  buildQueryValues(nil),
+			Body:   nil,
+		},
+		Response: Response{StatusCode: 200, Body: resourceQuotaList},
+	}
+	response, err := c.Setup(t).ResourceQuotas(ns).List(labels.Everything())
+	c.Validate(t, response, err)
+}
+
+func TestResourceQuotaUpdate(t *testing.T) {
+	ns := api.NamespaceDefault
+	resourceQuota := &api.ResourceQuota{
+		ObjectMeta: api.ObjectMeta{
+			Name:            "abc",
+			Namespace:       "foo",
+			ResourceVersion: "1",
+		},
+		Spec: api.ResourceQuotaSpec{
+			Hard: api.ResourceList{
+				api.ResourceCPU:                    resource.MustParse("100"),
+				api.ResourceMemory:                 resource.MustParse("10000"),
+				api.ResourcePods:                   resource.MustParse("10"),
+				api.ResourceServices:               resource.MustParse("10"),
+				api.ResourceReplicationControllers: resource.MustParse("10"),
+				api.ResourceQuotas:                 resource.MustParse("10"),
+			},
+		},
+	}
+	c := &testClient{
+		Request:  testRequest{Method: "PUT", Path: testapi.Default.ResourcePath(getResourceQuotasResoureName(), ns, "abc"), Query: buildQueryValues(nil)},
+		Response: Response{StatusCode: 200, Body: resourceQuota},
+	}
+	response, err := c.Setup(t).ResourceQuotas(ns).Update(resourceQuota)
+	c.Validate(t, response, err)
+}
+
+func TestResourceQuotaStatusUpdate(t *testing.T) {
+	ns := api.NamespaceDefault
+	resourceQuota := &api.ResourceQuota{
+		ObjectMeta: api.ObjectMeta{
+			Name:            "abc",
+			Namespace:       "foo",
+			ResourceVersion: "1",
+		},
+		Status: api.ResourceQuotaStatus{
+			Hard: api.ResourceList{
+				api.ResourceCPU:                    resource.MustParse("100"),
+				api.ResourceMemory:                 resource.MustParse("10000"),
+				api.ResourcePods:                   resource.MustParse("10"),
+				api.ResourceServices:               resource.MustParse("10"),
+				api.ResourceReplicationControllers: resource.MustParse("10"),
+				api.ResourceQuotas:                 resource.MustParse("10"),
+			},
+		},
+	}
+	c := &testClient{
+		Request: testRequest{
+			Method: "PUT",
+			Path:   testapi.Default.ResourcePath(getResourceQuotasResoureName(), ns, "abc") + "/status",
+			Query:  buildQueryValues(nil)},
+		Response: Response{StatusCode: 200, Body: resourceQuota},
+	}
+	response, err := c.Setup(t).ResourceQuotas(ns).UpdateStatus(resourceQuota)
+	c.Validate(t, response, err)
+}
+
+func TestResourceQuotaDelete(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request:  testRequest{Method: "DELETE", Path: testapi.Default.ResourcePath(getResourceQuotasResoureName(), ns, "foo"), Query: buildQueryValues(nil)},
+		Response: Response{StatusCode: 200},
+	}
+	err := c.Setup(t).ResourceQuotas(ns).Delete("foo")
+	c.Validate(t, nil, err)
+}
+
+func TestResourceQuotaWatch(t *testing.T) {
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePathWithPrefix("watch", getResourceQuotasResoureName(), "", ""),
+			Query:  url.Values{"resourceVersion": []string{}}},
+		Response: Response{StatusCode: 200},
+	}
+	_, err := c.Setup(t).ResourceQuotas(api.NamespaceAll).Watch(labels.Everything(), fields.Everything(), "")
+	c.Validate(t, nil, err)
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/restclient_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/restclient_test.go
@@ -1,0 +1,288 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/api/unversioned"
+	"k8s.io/kubernetes/pkg/runtime"
+	"k8s.io/kubernetes/pkg/util"
+)
+
+func TestSetsCodec(t *testing.T) {
+	testCases := map[string]struct {
+		Err    bool
+		Prefix string
+		Codec  runtime.Codec
+	}{
+		testapi.Default.Version(): {false, "/api/" + testapi.Default.Version() + "/", testapi.Default.Codec()},
+		"invalidVersion":          {true, "", nil},
+	}
+	for version, expected := range testCases {
+		client, err := New(&Config{Host: "127.0.0.1", Version: version})
+		switch {
+		case err == nil && expected.Err:
+			t.Errorf("expected error but was nil")
+			continue
+		case err != nil && !expected.Err:
+			t.Errorf("unexpected error %v", err)
+			continue
+		case err != nil:
+			continue
+		}
+		if e, a := expected.Prefix, client.RESTClient.baseURL.Path; e != a {
+			t.Errorf("expected %#v, got %#v", e, a)
+		}
+		if e, a := expected.Codec, client.RESTClient.Codec; e != a {
+			t.Errorf("expected %#v, got %#v", e, a)
+		}
+	}
+}
+
+func TestRESTClientRequires(t *testing.T) {
+	if _, err := RESTClientFor(&Config{Host: "127.0.0.1", Version: "", Codec: testapi.Default.Codec()}); err == nil {
+		t.Errorf("unexpected non-error")
+	}
+	if _, err := RESTClientFor(&Config{Host: "127.0.0.1", Version: testapi.Default.Version()}); err == nil {
+		t.Errorf("unexpected non-error")
+	}
+	if _, err := RESTClientFor(&Config{Host: "127.0.0.1", Version: testapi.Default.Version(), Codec: testapi.Default.Codec()}); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestValidatesHostParameter(t *testing.T) {
+	testCases := []struct {
+		Host   string
+		Prefix string
+
+		URL string
+		Err bool
+	}{
+		{"127.0.0.1", "", "http://127.0.0.1/" + testapi.Default.Version() + "/", false},
+		{"127.0.0.1:8080", "", "http://127.0.0.1:8080/" + testapi.Default.Version() + "/", false},
+		{"foo.bar.com", "", "http://foo.bar.com/" + testapi.Default.Version() + "/", false},
+		{"http://host/prefix", "", "http://host/prefix/" + testapi.Default.Version() + "/", false},
+		{"http://host", "", "http://host/" + testapi.Default.Version() + "/", false},
+		{"http://host", "/", "http://host/" + testapi.Default.Version() + "/", false},
+		{"http://host", "/other", "http://host/other/" + testapi.Default.Version() + "/", false},
+		{"host/server", "", "", true},
+	}
+	for i, testCase := range testCases {
+		c, err := RESTClientFor(&Config{Host: testCase.Host, Prefix: testCase.Prefix, Version: testapi.Default.Version(), Codec: testapi.Default.Codec()})
+		switch {
+		case err == nil && testCase.Err:
+			t.Errorf("expected error but was nil")
+			continue
+		case err != nil && !testCase.Err:
+			t.Errorf("unexpected error %v", err)
+			continue
+		case err != nil:
+			continue
+		}
+		if e, a := testCase.URL, c.baseURL.String(); e != a {
+			t.Errorf("%d: expected host %s, got %s", i, e, a)
+			continue
+		}
+	}
+}
+
+func TestDoRequestBearer(t *testing.T) {
+	status := &unversioned.Status{Status: unversioned.StatusFailure}
+	expectedBody, _ := testapi.Default.Codec().Encode(status)
+	fakeHandler := util.FakeHandler{
+		StatusCode:   400,
+		ResponseBody: string(expectedBody),
+		T:            t,
+	}
+	testServer := httptest.NewServer(&fakeHandler)
+	defer testServer.Close()
+	request, _ := http.NewRequest("GET", testServer.URL, nil)
+	c, err := RESTClientFor(&Config{
+		Host:        testServer.URL,
+		Version:     testapi.Default.Version(),
+		Codec:       testapi.Default.Codec(),
+		BearerToken: "test",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	err = c.Get().Do().Error()
+	if err == nil {
+		t.Fatalf("unexpected non-error: %v", err)
+	}
+	if fakeHandler.RequestReceived.Header.Get("Authorization") != "Bearer test" {
+		t.Errorf("Request is missing authorization header: %#v", *request)
+	}
+}
+
+func TestDoRequestWithoutPassword(t *testing.T) {
+	status := &unversioned.Status{Status: unversioned.StatusFailure}
+	expectedBody, _ := testapi.Default.Codec().Encode(status)
+	fakeHandler := util.FakeHandler{
+		StatusCode:   400,
+		ResponseBody: string(expectedBody),
+		T:            t,
+	}
+	testServer := httptest.NewServer(&fakeHandler)
+	defer testServer.Close()
+	c, err := RESTClientFor(&Config{
+		Host:     testServer.URL,
+		Version:  testapi.Default.Version(),
+		Codec:    testapi.Default.Codec(),
+		Username: "test",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body, err := c.Get().Prefix("test").Do().Raw()
+	if err == nil {
+		t.Fatalf("Unexpected non-error")
+	}
+	if fakeHandler.RequestReceived.Header["Authorization"] == nil {
+		t.Errorf("Request is missing authorization header: %#v", fakeHandler.RequestReceived)
+	}
+	se, ok := err.(APIStatus)
+	if !ok {
+		t.Fatalf("Unexpected kind of error: %#v", err)
+	}
+	if !reflect.DeepEqual(se.Status(), *status) {
+		t.Errorf("Unexpected status: %#v %#v", se.Status(), status)
+	}
+	if body != nil {
+		t.Errorf("Expected nil body, but saw: '%s'", string(body))
+	}
+	fakeHandler.ValidateRequest(t, "/"+testapi.Default.Version()+"/test", "GET", nil)
+}
+
+func TestDoRequestSuccess(t *testing.T) {
+	status := &unversioned.Status{Status: unversioned.StatusSuccess}
+	expectedBody, _ := testapi.Default.Codec().Encode(status)
+	fakeHandler := util.FakeHandler{
+		StatusCode:   200,
+		ResponseBody: string(expectedBody),
+		T:            t,
+	}
+	testServer := httptest.NewServer(&fakeHandler)
+	defer testServer.Close()
+	c, err := RESTClientFor(&Config{
+		Host:     testServer.URL,
+		Version:  testapi.Default.Version(),
+		Codec:    testapi.Default.Codec(),
+		Username: "user",
+		Password: "pass",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body, err := c.Get().Prefix("test").Do().Raw()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fakeHandler.RequestReceived.Header["Authorization"] == nil {
+		t.Errorf("Request is missing authorization header: %#v", fakeHandler.RequestReceived)
+	}
+	statusOut, err := testapi.Default.Codec().Decode(body)
+	if err != nil {
+		t.Errorf("Unexpected error %#v", err)
+	}
+	if !reflect.DeepEqual(status, statusOut) {
+		t.Errorf("Unexpected mis-match. Expected %#v.  Saw %#v", status, statusOut)
+	}
+	fakeHandler.ValidateRequest(t, "/"+testapi.Default.Version()+"/test", "GET", nil)
+}
+
+func TestDoRequestFailed(t *testing.T) {
+	status := &unversioned.Status{
+		Code:    http.StatusNotFound,
+		Status:  unversioned.StatusFailure,
+		Reason:  unversioned.StatusReasonNotFound,
+		Message: " \"\" not found",
+		Details: &unversioned.StatusDetails{},
+	}
+	expectedBody, _ := testapi.Default.Codec().Encode(status)
+	fakeHandler := util.FakeHandler{
+		StatusCode:   404,
+		ResponseBody: string(expectedBody),
+		T:            t,
+	}
+	testServer := httptest.NewServer(&fakeHandler)
+	defer testServer.Close()
+	c, err := RESTClientFor(&Config{
+		Host:    testServer.URL,
+		Version: testapi.Default.Version(),
+		Codec:   testapi.Default.Codec(),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body, err := c.Get().Do().Raw()
+	if err == nil || body != nil {
+		t.Errorf("unexpected non-error: %#v", body)
+	}
+	ss, ok := err.(APIStatus)
+	if !ok {
+		t.Errorf("unexpected error type %v", err)
+	}
+	actual := ss.Status()
+	if !reflect.DeepEqual(status, &actual) {
+		t.Errorf("Unexpected mis-match: %s", util.ObjectDiff(status, &actual))
+	}
+}
+
+func TestDoRequestCreated(t *testing.T) {
+	status := &unversioned.Status{Status: unversioned.StatusSuccess}
+	expectedBody, _ := testapi.Default.Codec().Encode(status)
+	fakeHandler := util.FakeHandler{
+		StatusCode:   201,
+		ResponseBody: string(expectedBody),
+		T:            t,
+	}
+	testServer := httptest.NewServer(&fakeHandler)
+	defer testServer.Close()
+	c, err := RESTClientFor(&Config{
+		Host:     testServer.URL,
+		Version:  testapi.Default.Version(),
+		Codec:    testapi.Default.Codec(),
+		Username: "user",
+		Password: "pass",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	created := false
+	body, err := c.Get().Prefix("test").Do().WasCreated(&created).Raw()
+	if err != nil {
+		t.Errorf("Unexpected error %#v", err)
+	}
+	if !created {
+		t.Errorf("Expected object to be created")
+	}
+	statusOut, err := testapi.Default.Codec().Decode(body)
+	if err != nil {
+		t.Errorf("Unexpected error %#v", err)
+	}
+	if !reflect.DeepEqual(status, statusOut) {
+		t.Errorf("Unexpected mis-match. Expected %#v.  Saw %#v", status, statusOut)
+	}
+	fakeHandler.ValidateRequest(t, "/"+testapi.Default.Version()+"/test", "GET", nil)
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/services_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/services_test.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"net/url"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/labels"
+)
+
+func TestListServices(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePath("services", ns, ""),
+			Query:  buildQueryValues(nil)},
+		Response: Response{StatusCode: 200,
+			Body: &api.ServiceList{
+				Items: []api.Service{
+					{
+						ObjectMeta: api.ObjectMeta{
+							Name: "name",
+							Labels: map[string]string{
+								"foo":  "bar",
+								"name": "baz",
+							},
+						},
+						Spec: api.ServiceSpec{
+							Selector: map[string]string{
+								"one": "two",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	receivedServiceList, err := c.Setup(t).Services(ns).List(labels.Everything())
+	t.Logf("received services: %v %#v", err, receivedServiceList)
+	c.Validate(t, receivedServiceList, err)
+}
+
+func TestListServicesLabels(t *testing.T) {
+	ns := api.NamespaceDefault
+	labelSelectorQueryParamName := api.LabelSelectorQueryParam(testapi.Default.Version())
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePath("services", ns, ""),
+			Query:  buildQueryValues(url.Values{labelSelectorQueryParamName: []string{"foo=bar,name=baz"}})},
+		Response: Response{StatusCode: 200,
+			Body: &api.ServiceList{
+				Items: []api.Service{
+					{
+						ObjectMeta: api.ObjectMeta{
+							Name: "name",
+							Labels: map[string]string{
+								"foo":  "bar",
+								"name": "baz",
+							},
+						},
+						Spec: api.ServiceSpec{
+							Selector: map[string]string{
+								"one": "two",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	c.Setup(t)
+	c.QueryValidator[labelSelectorQueryParamName] = validateLabels
+	selector := labels.Set{"foo": "bar", "name": "baz"}.AsSelector()
+	receivedServiceList, err := c.Services(ns).List(selector)
+	c.Validate(t, receivedServiceList, err)
+}
+
+func TestGetService(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePath("services", ns, "1"),
+			Query:  buildQueryValues(nil)},
+		Response: Response{StatusCode: 200, Body: &api.Service{ObjectMeta: api.ObjectMeta{Name: "service-1"}}},
+	}
+	response, err := c.Setup(t).Services(ns).Get("1")
+	c.Validate(t, response, err)
+}
+
+func TestGetServiceWithNoName(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{Error: true}
+	receivedPod, err := c.Setup(t).Services(ns).Get("")
+	if (err != nil) && (err.Error() != nameRequiredError) {
+		t.Errorf("Expected error: %v, but got %v", nameRequiredError, err)
+	}
+
+	c.Validate(t, receivedPod, err)
+}
+
+func TestCreateService(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request: testRequest{
+			Method: "POST",
+			Path:   testapi.Default.ResourcePath("services", ns, ""),
+			Body:   &api.Service{ObjectMeta: api.ObjectMeta{Name: "service-1"}},
+			Query:  buildQueryValues(nil)},
+		Response: Response{StatusCode: 200, Body: &api.Service{ObjectMeta: api.ObjectMeta{Name: "service-1"}}},
+	}
+	response, err := c.Setup(t).Services(ns).Create(&api.Service{ObjectMeta: api.ObjectMeta{Name: "service-1"}})
+	c.Validate(t, response, err)
+}
+
+func TestUpdateService(t *testing.T) {
+	ns := api.NamespaceDefault
+	svc := &api.Service{ObjectMeta: api.ObjectMeta{Name: "service-1", ResourceVersion: "1"}}
+	c := &testClient{
+		Request:  testRequest{Method: "PUT", Path: testapi.Default.ResourcePath("services", ns, "service-1"), Body: svc, Query: buildQueryValues(nil)},
+		Response: Response{StatusCode: 200, Body: svc},
+	}
+	response, err := c.Setup(t).Services(ns).Update(svc)
+	c.Validate(t, response, err)
+}
+
+func TestDeleteService(t *testing.T) {
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request:  testRequest{Method: "DELETE", Path: testapi.Default.ResourcePath("services", ns, "1"), Query: buildQueryValues(nil)},
+		Response: Response{StatusCode: 200},
+	}
+	err := c.Setup(t).Services(ns).Delete("1")
+	c.Validate(t, nil, err)
+}
+
+func TestServiceProxyGet(t *testing.T) {
+	body := "OK"
+	ns := api.NamespaceDefault
+	c := &testClient{
+		Request: testRequest{
+			Method: "GET",
+			Path:   testapi.Default.ResourcePathWithPrefix("proxy", "services", ns, "service-1") + "/foo",
+			Query:  buildQueryValues(url.Values{"param-name": []string{"param-value"}}),
+		},
+		Response: Response{StatusCode: 200, RawBody: &body},
+	}
+	response, err := c.Setup(t).Services(ns).ProxyGet("service-1", "foo", map[string]string{"param-name": "param-value"}).DoRaw()
+	c.ValidateRaw(t, response, err)
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/testclient/fake_daemon_sets.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/testclient/fake_daemon_sets.go
@@ -66,6 +66,14 @@ func (c *FakeDaemonSets) Update(daemon *experimental.DaemonSet) (*experimental.D
 	return obj.(*experimental.DaemonSet), err
 }
 
+func (c *FakeDaemonSets) UpdateStatus(daemon *experimental.DaemonSet) (*experimental.DaemonSet, error) {
+	obj, err := c.Fake.Invokes(NewUpdateSubresourceAction("daemonsets", "status", c.Namespace, daemon), &experimental.DaemonSet{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*experimental.DaemonSet), err
+}
+
 func (c *FakeDaemonSets) Delete(name string) error {
 	_, err := c.Fake.Invokes(NewDeleteAction("daemonsets", c.Namespace, name), &experimental.DaemonSet{})
 	return err

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/testclient/fake_ingress.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/testclient/fake_ingress.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testclient
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apis/experimental"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/watch"
+)
+
+// FakeIngress implements IngressInterface. Meant to be embedded into a struct to get a default
+// implementation. This makes faking out just the method you want to test easier.
+type FakeIngress struct {
+	Fake      *FakeExperimental
+	Namespace string
+}
+
+func (c *FakeIngress) Get(name string) (*experimental.Ingress, error) {
+	obj, err := c.Fake.Invokes(NewGetAction("ingress", c.Namespace, name), &experimental.Ingress{})
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*experimental.Ingress), err
+}
+
+func (c *FakeIngress) List(label labels.Selector, fields fields.Selector) (*experimental.IngressList, error) {
+	obj, err := c.Fake.Invokes(NewListAction("ingress", c.Namespace, label, nil), &experimental.IngressList{})
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*experimental.IngressList), err
+}
+
+func (c *FakeIngress) Create(ingress *experimental.Ingress) (*experimental.Ingress, error) {
+	obj, err := c.Fake.Invokes(NewCreateAction("ingress", c.Namespace, ingress), ingress)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*experimental.Ingress), err
+}
+
+func (c *FakeIngress) Update(ingress *experimental.Ingress) (*experimental.Ingress, error) {
+	obj, err := c.Fake.Invokes(NewUpdateAction("ingress", c.Namespace, ingress), ingress)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*experimental.Ingress), err
+}
+
+func (c *FakeIngress) Delete(name string, options *api.DeleteOptions) error {
+	_, err := c.Fake.Invokes(NewDeleteAction("ingress", c.Namespace, name), &experimental.Ingress{})
+	return err
+}
+
+func (c *FakeIngress) Watch(label labels.Selector, field fields.Selector, resourceVersion string) (watch.Interface, error) {
+	return c.Fake.InvokesWatch(NewWatchAction("ingress", c.Namespace, label, field, resourceVersion))
+}
+
+func (c *FakeIngress) UpdateStatus(ingress *experimental.Ingress) (result *experimental.Ingress, err error) {
+	obj, err := c.Fake.Invokes(NewUpdateSubresourceAction("ingress", "status", c.Namespace, ingress), ingress)
+	if obj == nil {
+		return nil, err
+	}
+
+	return obj.(*experimental.Ingress), err
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/testclient/fake_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/testclient/fake_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testclient
+
+import (
+	"testing"
+
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+)
+
+// This test file just ensures that Fake and structs it is embedded in
+// implement Interface.
+
+func TestFakeImplementsInterface(t *testing.T) {
+	_ = client.Interface(&Fake{})
+}
+
+type MyFake struct {
+	*Fake
+}
+
+func TestEmbeddedFakeImplementsInterface(t *testing.T) {
+	_ = client.Interface(MyFake{&Fake{}})
+	_ = client.Interface(&MyFake{&Fake{}})
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/testclient/testclient_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/testclient/testclient_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testclient
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/errors"
+	"k8s.io/kubernetes/pkg/api/testapi"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/runtime"
+)
+
+func TestNewClient(t *testing.T) {
+	o := NewObjects(api.Scheme, api.Scheme)
+	if err := AddObjectsFromPath("../../../../examples/guestbook/frontend-service.yaml", o, api.Scheme); err != nil {
+		t.Fatal(err)
+	}
+	client := &Fake{}
+	client.AddReactor("*", "*", ObjectReaction(o, testapi.Default.RESTMapper()))
+	list, err := client.Services("test").List(labels.Everything())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list.Items) != 1 {
+		t.Fatalf("unexpected list %#v", list)
+	}
+
+	// When list is invoked a second time, the same results are returned.
+	list, err = client.Services("test").List(labels.Everything())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list.Items) != 1 {
+		t.Fatalf("unexpected list %#v", list)
+	}
+	t.Logf("list: %#v", list)
+}
+
+func TestErrors(t *testing.T) {
+	o := NewObjects(api.Scheme, api.Scheme)
+	o.Add(&api.List{
+		Items: []runtime.Object{
+			// This first call to List will return this error
+			&(errors.NewNotFound("ServiceList", "").(*errors.StatusError).ErrStatus),
+			// The second call to List will return this error
+			&(errors.NewForbidden("ServiceList", "", nil).(*errors.StatusError).ErrStatus),
+		},
+	})
+	client := &Fake{}
+	client.AddReactor("*", "*", ObjectReaction(o, testapi.Default.RESTMapper()))
+	_, err := client.Services("test").List(labels.Everything())
+	if !errors.IsNotFound(err) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	t.Logf("error: %#v", err.(*errors.StatusError).Status())
+	_, err = client.Services("test").List(labels.Everything())
+	if !errors.IsForbidden(err) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/transport_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/client/unversioned/transport_test.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unversioned
+
+import (
+	"encoding/base64"
+	"net/http"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api/testapi"
+)
+
+func TestUnsecuredTLSTransport(t *testing.T) {
+	cfg := NewUnsafeTLSConfig()
+	if !cfg.InsecureSkipVerify {
+		t.Errorf("expected config to be insecure")
+	}
+}
+
+type testRoundTripper struct {
+	Request  *http.Request
+	Response *http.Response
+	Err      error
+}
+
+func (rt *testRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.Request = req
+	return rt.Response, rt.Err
+}
+
+func TestBearerAuthRoundTripper(t *testing.T) {
+	rt := &testRoundTripper{}
+	req := &http.Request{}
+	NewBearerAuthRoundTripper("test", rt).RoundTrip(req)
+	if rt.Request == nil {
+		t.Fatalf("unexpected nil request: %v", rt)
+	}
+	if rt.Request == req {
+		t.Fatalf("round tripper should have copied request object: %#v", rt.Request)
+	}
+	if rt.Request.Header.Get("Authorization") != "Bearer test" {
+		t.Errorf("unexpected authorization header: %#v", rt.Request)
+	}
+}
+
+func TestBasicAuthRoundTripper(t *testing.T) {
+	rt := &testRoundTripper{}
+	req := &http.Request{}
+	NewBasicAuthRoundTripper("user", "pass", rt).RoundTrip(req)
+	if rt.Request == nil {
+		t.Fatalf("unexpected nil request: %v", rt)
+	}
+	if rt.Request == req {
+		t.Fatalf("round tripper should have copied request object: %#v", rt.Request)
+	}
+	if rt.Request.Header.Get("Authorization") != "Basic "+base64.StdEncoding.EncodeToString([]byte("user:pass")) {
+		t.Errorf("unexpected authorization header: %#v", rt.Request)
+	}
+}
+
+func TestUserAgentRoundTripper(t *testing.T) {
+	rt := &testRoundTripper{}
+	req := &http.Request{
+		Header: make(http.Header),
+	}
+	req.Header.Set("User-Agent", "other")
+	NewUserAgentRoundTripper("test", rt).RoundTrip(req)
+	if rt.Request == nil {
+		t.Fatalf("unexpected nil request: %v", rt)
+	}
+	if rt.Request != req {
+		t.Fatalf("round tripper should not have copied request object: %#v", rt.Request)
+	}
+	if rt.Request.Header.Get("User-Agent") != "other" {
+		t.Errorf("unexpected user agent header: %#v", rt.Request)
+	}
+
+	req = &http.Request{}
+	NewUserAgentRoundTripper("test", rt).RoundTrip(req)
+	if rt.Request == nil {
+		t.Fatalf("unexpected nil request: %v", rt)
+	}
+	if rt.Request == req {
+		t.Fatalf("round tripper should have copied request object: %#v", rt.Request)
+	}
+	if rt.Request.Header.Get("User-Agent") != "test" {
+		t.Errorf("unexpected user agent header: %#v", rt.Request)
+	}
+}
+
+func TestTLSConfigKey(t *testing.T) {
+	// Make sure config fields that don't affect the tls config don't affect the cache key
+	identicalConfigurations := map[string]*Config{
+		"empty":          {},
+		"host":           {Host: "foo"},
+		"prefix":         {Prefix: "foo"},
+		"version":        {Version: "foo"},
+		"codec":          {Codec: testapi.Default.Codec()},
+		"basic":          {Username: "bob", Password: "password"},
+		"bearer":         {BearerToken: "token"},
+		"user agent":     {UserAgent: "useragent"},
+		"transport":      {Transport: http.DefaultTransport},
+		"wrap transport": {WrapTransport: func(http.RoundTripper) http.RoundTripper { return nil }},
+		"qps/burst":      {QPS: 1.0, Burst: 10},
+	}
+	for nameA, valueA := range identicalConfigurations {
+		for nameB, valueB := range identicalConfigurations {
+			keyA, err := tlsConfigKey(valueA)
+			if err != nil {
+				t.Errorf("Unexpected error for %q: %v", nameA, err)
+				continue
+			}
+			keyB, err := tlsConfigKey(valueB)
+			if err != nil {
+				t.Errorf("Unexpected error for %q: %v", nameB, err)
+				continue
+			}
+			if keyA != keyB {
+				t.Errorf("Expected identical cache keys for %q and %q, got:\n\t%s\n\t%s", nameA, nameB, keyA, keyB)
+				continue
+			}
+		}
+	}
+
+	// Make sure config fields that affect the tls config affect the cache key
+	uniqueConfigurations := map[string]*Config{
+		"no tls":                  {},
+		"insecure":                {Insecure: true},
+		"cadata 1":                {TLSClientConfig: TLSClientConfig{CAData: []byte{1}}},
+		"cadata 2":                {TLSClientConfig: TLSClientConfig{CAData: []byte{2}}},
+		"cert 1, key 1":           {TLSClientConfig: TLSClientConfig{CertData: []byte{1}, KeyData: []byte{1}}},
+		"cert 1, key 2":           {TLSClientConfig: TLSClientConfig{CertData: []byte{1}, KeyData: []byte{2}}},
+		"cert 2, key 1":           {TLSClientConfig: TLSClientConfig{CertData: []byte{2}, KeyData: []byte{1}}},
+		"cert 2, key 2":           {TLSClientConfig: TLSClientConfig{CertData: []byte{2}, KeyData: []byte{2}}},
+		"cadata 1, cert 1, key 1": {TLSClientConfig: TLSClientConfig{CAData: []byte{1}, CertData: []byte{1}, KeyData: []byte{1}}},
+	}
+	for nameA, valueA := range uniqueConfigurations {
+		for nameB, valueB := range uniqueConfigurations {
+			// Don't compare to ourselves
+			if nameA == nameB {
+				continue
+			}
+
+			keyA, err := tlsConfigKey(valueA)
+			if err != nil {
+				t.Errorf("Unexpected error for %q: %v", nameA, err)
+				continue
+			}
+			keyB, err := tlsConfigKey(valueB)
+			if err != nil {
+				t.Errorf("Unexpected error for %q: %v", nameB, err)
+				continue
+			}
+			if keyA == keyB {
+				t.Errorf("Expected unique cache keys for %q and %q, got:\n\t%s\n\t%s", nameA, nameB, keyA, keyB)
+				continue
+			}
+		}
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/atomic_value_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/atomic_value_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+)
+
+func ExpectValue(t *testing.T, atomicValue *AtomicValue, expectedValue interface{}) {
+	actualValue := atomicValue.Load()
+	if actualValue != expectedValue {
+		t.Errorf("Expected to find %v, found %v", expectedValue, actualValue)
+	}
+	ch := make(chan interface{})
+	go func() {
+		ch <- atomicValue.Load()
+	}()
+	select {
+	case actualValue = <-ch:
+		if actualValue != expectedValue {
+			t.Errorf("Expected to find %v, found %v", expectedValue, actualValue)
+			return
+		}
+	case <-time.After(ForeverTestTimeout):
+		t.Error("Value could not be read")
+		return
+	}
+}
+
+func TestAtomicValue(t *testing.T) {
+	atomicValue := &AtomicValue{}
+	ExpectValue(t, atomicValue, nil)
+	atomicValue.Store(10)
+	ExpectValue(t, atomicValue, 10)
+}
+
+func TestHighWaterMark(t *testing.T) {
+	var h HighWaterMark
+
+	for i := int64(10); i < 20; i++ {
+		if !h.Check(i) {
+			t.Errorf("unexpected false for %v", i)
+		}
+		if h.Check(i - 1) {
+			t.Errorf("unexpected true for %v", i-1)
+		}
+	}
+
+	m := int64(0)
+	wg := sync.WaitGroup{}
+	for i := 0; i < 300; i++ {
+		wg.Add(1)
+		v := rand.Int63()
+		go func(v int64) {
+			defer wg.Done()
+			h.Check(v)
+		}(v)
+		if v > m {
+			m = v
+		}
+	}
+	wg.Wait()
+	if m != int64(h) {
+		t.Errorf("unexpected value, wanted %v, got %v", m, int64(h))
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/backoff_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/backoff_test.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+	"time"
+)
+
+func NewFakeBackOff(initial, max time.Duration, tc *FakeClock) *Backoff {
+	return &Backoff{
+		perItemBackoff:  map[string]*backoffEntry{},
+		Clock:           tc,
+		defaultDuration: initial,
+		maxDuration:     max,
+	}
+}
+
+func TestSlowBackoff(t *testing.T) {
+	id := "_idSlow"
+	tc := &FakeClock{Time: time.Now()}
+	step := time.Second
+	maxDuration := 50 * step
+
+	b := NewFakeBackOff(step, maxDuration, tc)
+	cases := []time.Duration{0, 1, 2, 4, 8, 16, 32, 50, 50, 50}
+	for ix, c := range cases {
+		tc.Step(step)
+		w := b.Get(id)
+		if w != c*step {
+			t.Errorf("input: '%d': expected %s, got %s", ix, c*step, w)
+		}
+		b.Next(id, tc.Now())
+	}
+}
+
+func TestBackoffReset(t *testing.T) {
+	id := "_idReset"
+	tc := &FakeClock{Time: time.Now()}
+	step := time.Second
+	maxDuration := step * 5
+	b := NewFakeBackOff(step, maxDuration, tc)
+	startTime := tc.Now()
+
+	// get to backoff = maxDuration
+	for i := 0; i <= int(maxDuration/step); i++ {
+		tc.Step(step)
+		b.Next(id, tc.Now())
+	}
+
+	// backoff should be capped at maxDuration
+	if !b.IsInBackOffSince(id, tc.Now()) {
+		t.Errorf("expected to be in Backoff got %s", b.Get(id))
+	}
+
+	lastUpdate := tc.Now()
+	tc.Step(2*maxDuration + step) // time += 11s, 11 > 2*maxDuration
+	if b.IsInBackOffSince(id, lastUpdate) {
+		t.Errorf("now=%s lastUpdate=%s (%s) expected Backoff reset got %s b.lastUpdate=%s", tc.Now(), startTime, tc.Now().Sub(lastUpdate), b.Get(id))
+	}
+}
+
+func TestBackoffHightWaterMark(t *testing.T) {
+	id := "_idHiWaterMark"
+	tc := &FakeClock{Time: time.Now()}
+	step := time.Second
+	maxDuration := 5 * step
+	b := NewFakeBackOff(step, maxDuration, tc)
+
+	// get to backoff = maxDuration
+	for i := 0; i <= int(maxDuration/step); i++ {
+		tc.Step(step)
+		b.Next(id, tc.Now())
+	}
+
+	// backoff high watermark expires after 2*maxDuration
+	tc.Step(maxDuration + step)
+	b.Next(id, tc.Now())
+
+	if b.Get(id) != maxDuration {
+		t.Errorf("expected Backoff to stay at high watermark %s got %s", maxDuration, b.Get(id))
+	}
+}
+
+func TestBackoffGC(t *testing.T) {
+	id := "_idGC"
+	tc := &FakeClock{Time: time.Now()}
+	step := time.Second
+	maxDuration := 5 * step
+
+	b := NewFakeBackOff(step, maxDuration, tc)
+
+	for i := 0; i <= int(maxDuration/step); i++ {
+		tc.Step(step)
+		b.Next(id, tc.Now())
+	}
+	lastUpdate := tc.Now()
+	tc.Step(maxDuration + step)
+	b.GC()
+	_, found := b.perItemBackoff[id]
+	if !found {
+		t.Errorf("expected GC to skip entry, elapsed time=%s maxDuration=%s", tc.Now().Sub(lastUpdate), maxDuration)
+	}
+
+	tc.Step(maxDuration + step)
+	b.GC()
+	r, found := b.perItemBackoff[id]
+	if found {
+		t.Errorf("expected GC of entry after %s got entry %v", tc.Now().Sub(lastUpdate), r)
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/bandwidth/linux.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/bandwidth/linux.go
@@ -1,3 +1,5 @@
+// +build linux
+
 /*
 Copyright 2015 The Kubernetes Authors All rights reserved.
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/bandwidth/linux_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/bandwidth/linux_test.go
@@ -1,0 +1,624 @@
+// +build linux
+
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bandwidth
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api/resource"
+	"k8s.io/kubernetes/pkg/util/exec"
+)
+
+var tcClassOutput = `class htb 1:1 root prio 0 rate 10000bit ceil 10000bit burst 1600b cburst 1600b 
+class htb 1:2 root prio 0 rate 10000bit ceil 10000bit burst 1600b cburst 1600b 
+class htb 1:3 root prio 0 rate 10000bit ceil 10000bit burst 1600b cburst 1600b 
+class htb 1:4 root prio 0 rate 10000bit ceil 10000bit burst 1600b cburst 1600b 
+`
+
+var tcClassOutput2 = `class htb 1:1 root prio 0 rate 10000bit ceil 10000bit burst 1600b cburst 1600b 
+class htb 1:2 root prio 0 rate 10000bit ceil 10000bit burst 1600b cburst 1600b 
+class htb 1:3 root prio 0 rate 10000bit ceil 10000bit burst 1600b cburst 1600b 
+class htb 1:4 root prio 0 rate 10000bit ceil 10000bit burst 1600b cburst 1600b 
+class htb 1:5 root prio 0 rate 10000bit ceil 10000bit burst 1600b cburst 1600b 
+`
+
+func TestNextClassID(t *testing.T) {
+	tests := []struct {
+		output    string
+		expectErr bool
+		expected  int
+		err       error
+	}{
+		{
+			output:   tcClassOutput,
+			expected: 5,
+		},
+		{
+			output:   "\n",
+			expected: 1,
+		},
+		{
+			expected:  -1,
+			expectErr: true,
+			err:       errors.New("test error"),
+		},
+	}
+	for _, test := range tests {
+		fcmd := exec.FakeCmd{
+			CombinedOutputScript: []exec.FakeCombinedOutputAction{
+				func() ([]byte, error) { return []byte(test.output), test.err },
+			},
+		}
+		fexec := exec.FakeExec{
+			CommandScript: []exec.FakeCommandAction{
+				func(cmd string, args ...string) exec.Cmd {
+					return exec.InitFakeCmd(&fcmd, cmd, args...)
+				},
+			},
+		}
+		shaper := &tcShaper{e: &fexec}
+		class, err := shaper.nextClassID()
+		if test.expectErr {
+			if err == nil {
+				t.Errorf("unexpected non-error")
+			}
+		} else {
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if class != test.expected {
+				t.Errorf("expected: %d, found %d", test.expected, class)
+			}
+		}
+	}
+}
+
+func TestHexCIDR(t *testing.T) {
+	tests := []struct {
+		input     string
+		output    string
+		expectErr bool
+	}{
+		{
+			input:  "1.2.0.0/16",
+			output: "01020000/ffff0000",
+		},
+		{
+			input:  "172.17.0.2/32",
+			output: "ac110002/ffffffff",
+		},
+		{
+			input:     "foo",
+			expectErr: true,
+		},
+	}
+	for _, test := range tests {
+		output, err := hexCIDR(test.input)
+		if test.expectErr {
+			if err == nil {
+				t.Error("unexpected non-error")
+			}
+		} else {
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if output != test.output {
+				t.Errorf("expected: %s, saw: %s", test.output, output)
+			}
+			input, err := asciiCIDR(output)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if input != test.input {
+				t.Errorf("expected: %s, saw: %s", test.input, input)
+			}
+		}
+	}
+}
+
+var tcFilterOutput = `filter parent 1: protocol ip pref 1 u32 
+filter parent 1: protocol ip pref 1 u32 fh 800: ht divisor 1 
+filter parent 1: protocol ip pref 1 u32 fh 800::800 order 2048 key ht 800 bkt 0 flowid 1:1 
+  match ac110002/ffffffff at 16
+filter parent 1: protocol ip pref 1 u32 fh 800::801 order 2049 key ht 800 bkt 0 flowid 1:2 
+  match 01020000/ffff0000 at 16
+`
+
+func TestFindCIDRClass(t *testing.T) {
+	tests := []struct {
+		cidr           string
+		output         string
+		expectErr      bool
+		expectNotFound bool
+		expectedClass  string
+		expectedHandle string
+		err            error
+	}{
+		{
+			cidr:           "172.17.0.2/32",
+			output:         tcFilterOutput,
+			expectedClass:  "1:1",
+			expectedHandle: "800::800",
+		},
+		{
+			cidr:           "1.2.3.4/16",
+			output:         tcFilterOutput,
+			expectedClass:  "1:2",
+			expectedHandle: "800::801",
+		},
+		{
+			cidr:           "2.2.3.4/16",
+			output:         tcFilterOutput,
+			expectNotFound: true,
+		},
+		{
+			err:       errors.New("test error"),
+			expectErr: true,
+		},
+	}
+	for _, test := range tests {
+		fcmd := exec.FakeCmd{
+			CombinedOutputScript: []exec.FakeCombinedOutputAction{
+				func() ([]byte, error) { return []byte(test.output), test.err },
+			},
+		}
+		fexec := exec.FakeExec{
+			CommandScript: []exec.FakeCommandAction{
+				func(cmd string, args ...string) exec.Cmd {
+					return exec.InitFakeCmd(&fcmd, cmd, args...)
+				},
+			},
+		}
+		shaper := &tcShaper{e: &fexec}
+		class, handle, found, err := shaper.findCIDRClass(test.cidr)
+		if test.expectErr {
+			if err == nil {
+				t.Errorf("unexpected non-error")
+			}
+		} else {
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if test.expectNotFound {
+				if found {
+					t.Errorf("unexpectedly found an interface: %s %s", class, handle)
+				}
+			} else {
+				if class != test.expectedClass {
+					t.Errorf("expected: %s, found %s", test.expectedClass, class)
+				}
+				if handle != test.expectedHandle {
+					t.Errorf("expected: %s, found %s", test.expectedHandle, handle)
+				}
+			}
+		}
+	}
+}
+
+func TestGetCIDRs(t *testing.T) {
+	fcmd := exec.FakeCmd{
+		CombinedOutputScript: []exec.FakeCombinedOutputAction{
+			func() ([]byte, error) { return []byte(tcFilterOutput), nil },
+		},
+	}
+	fexec := exec.FakeExec{
+		CommandScript: []exec.FakeCommandAction{
+			func(cmd string, args ...string) exec.Cmd {
+				return exec.InitFakeCmd(&fcmd, cmd, args...)
+			},
+		},
+	}
+	shaper := &tcShaper{e: &fexec}
+	cidrs, err := shaper.GetCIDRs()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	expectedCidrs := []string{"172.17.0.2/32", "1.2.0.0/16"}
+	if !reflect.DeepEqual(cidrs, expectedCidrs) {
+		t.Errorf("expected: %v, saw: %v", expectedCidrs, cidrs)
+	}
+}
+
+func TestLimit(t *testing.T) {
+	tests := []struct {
+		cidr          string
+		ingress       *resource.Quantity
+		egress        *resource.Quantity
+		expectErr     bool
+		expectedCalls int
+		err           error
+	}{
+		{
+			cidr:          "1.2.3.4/32",
+			ingress:       resource.NewQuantity(10, resource.DecimalSI),
+			egress:        resource.NewQuantity(20, resource.DecimalSI),
+			expectedCalls: 6,
+		},
+		{
+			cidr:          "1.2.3.4/32",
+			ingress:       resource.NewQuantity(10, resource.DecimalSI),
+			egress:        nil,
+			expectedCalls: 3,
+		},
+		{
+			cidr:          "1.2.3.4/32",
+			ingress:       nil,
+			egress:        resource.NewQuantity(20, resource.DecimalSI),
+			expectedCalls: 3,
+		},
+		{
+			cidr:          "1.2.3.4/32",
+			ingress:       nil,
+			egress:        nil,
+			expectedCalls: 0,
+		},
+		{
+			err:       errors.New("test error"),
+			ingress:   resource.NewQuantity(10, resource.DecimalSI),
+			egress:    resource.NewQuantity(20, resource.DecimalSI),
+			expectErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		fcmd := exec.FakeCmd{
+			CombinedOutputScript: []exec.FakeCombinedOutputAction{
+				func() ([]byte, error) { return []byte(tcClassOutput), test.err },
+				func() ([]byte, error) { return []byte{}, test.err },
+				func() ([]byte, error) { return []byte{}, test.err },
+				func() ([]byte, error) { return []byte(tcClassOutput2), test.err },
+				func() ([]byte, error) { return []byte{}, test.err },
+				func() ([]byte, error) { return []byte{}, test.err },
+			},
+		}
+
+		fexec := exec.FakeExec{
+			CommandScript: []exec.FakeCommandAction{
+				func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+				func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+				func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+				func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+				func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+				func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+			},
+		}
+		iface := "cbr0"
+		shaper := &tcShaper{e: &fexec, iface: iface}
+		if err := shaper.Limit(test.cidr, test.ingress, test.egress); err != nil && !test.expectErr {
+			t.Errorf("unexpected error: %v", err)
+			return
+		} else if err == nil && test.expectErr {
+			t.Error("unexpected non-error")
+			return
+		}
+		// No more testing in the error case
+		if test.expectErr {
+			if fcmd.CombinedOutputCalls != 1 {
+				t.Errorf("unexpected number of calls: %d, expected: 1", fcmd.CombinedOutputCalls)
+			}
+			return
+		}
+
+		if fcmd.CombinedOutputCalls != test.expectedCalls {
+			t.Errorf("unexpected number of calls: %d, expected: %d", fcmd.CombinedOutputCalls, test.expectedCalls)
+		}
+
+		for ix := range fcmd.CombinedOutputLog {
+			output := fcmd.CombinedOutputLog[ix]
+			if output[0] != "tc" {
+				t.Errorf("unexpected command: %s, expected tc", output[0])
+			}
+			if output[4] != iface {
+				t.Errorf("unexpected interface: %s, expected %s (%v)", output[4], iface, output)
+			}
+			if ix == 1 {
+				var expectedRate string
+				if test.ingress != nil {
+					expectedRate = makeKBitString(test.ingress)
+				} else {
+					expectedRate = makeKBitString(test.egress)
+				}
+				if output[11] != expectedRate {
+					t.Errorf("unexpected ingress: %s, expected: %s", output[11], expectedRate)
+				}
+				if output[8] != "1:5" {
+					t.Errorf("unexpected class: %s, expected: %s", output[8], "1:5")
+				}
+			}
+			if ix == 2 {
+				if output[15] != test.cidr {
+					t.Errorf("unexpected cidr: %s, expected: %s", output[15], test.cidr)
+				}
+				if output[17] != "1:5" {
+					t.Errorf("unexpected class: %s, expected: %s", output[17], "1:5")
+				}
+			}
+			if ix == 4 {
+				if output[11] != makeKBitString(test.egress) {
+					t.Errorf("unexpected egress: %s, expected: %s", output[11], makeKBitString(test.egress))
+				}
+				if output[8] != "1:6" {
+					t.Errorf("unexpected class: %s, expected: %s", output[8], "1:6")
+				}
+			}
+			if ix == 5 {
+				if output[15] != test.cidr {
+					t.Errorf("unexpected cidr: %s, expected: %s", output[15], test.cidr)
+				}
+				if output[17] != "1:6" {
+					t.Errorf("unexpected class: %s, expected: %s", output[17], "1:5")
+				}
+			}
+		}
+	}
+}
+
+func TestReset(t *testing.T) {
+	tests := []struct {
+		cidr           string
+		err            error
+		expectErr      bool
+		expectedHandle string
+		expectedClass  string
+	}{
+		{
+			cidr:           "1.2.3.4/16",
+			expectedHandle: "800::801",
+			expectedClass:  "1:2",
+		},
+		{
+			cidr:           "172.17.0.2/32",
+			expectedHandle: "800::800",
+			expectedClass:  "1:1",
+		},
+		{
+			err:       errors.New("test error"),
+			expectErr: true,
+		},
+	}
+	for _, test := range tests {
+		fcmd := exec.FakeCmd{
+			CombinedOutputScript: []exec.FakeCombinedOutputAction{
+				func() ([]byte, error) { return []byte(tcFilterOutput), test.err },
+				func() ([]byte, error) { return []byte{}, test.err },
+				func() ([]byte, error) { return []byte{}, test.err },
+			},
+		}
+
+		fexec := exec.FakeExec{
+			CommandScript: []exec.FakeCommandAction{
+				func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+				func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+				func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+			},
+		}
+		iface := "cbr0"
+		shaper := &tcShaper{e: &fexec, iface: iface}
+
+		if err := shaper.Reset(test.cidr); err != nil && !test.expectErr {
+			t.Errorf("unexpected error: %v", err)
+			return
+		} else if test.expectErr && err == nil {
+			t.Error("unexpected non-error")
+			return
+		}
+
+		// No more testing in the error case
+		if test.expectErr {
+			if fcmd.CombinedOutputCalls != 1 {
+				t.Errorf("unexpected number of calls: %d, expected: 1", fcmd.CombinedOutputCalls)
+			}
+			return
+		}
+
+		if fcmd.CombinedOutputCalls != 3 {
+			t.Errorf("unexpected number of calls: %d, expected: 3", fcmd.CombinedOutputCalls)
+		}
+
+		for ix := range fcmd.CombinedOutputLog {
+			output := fcmd.CombinedOutputLog[ix]
+			if output[0] != "tc" {
+				t.Errorf("unexpected command: %s, expected tc", output[0])
+			}
+			if output[4] != iface {
+				t.Errorf("unexpected interface: %s, expected %s (%v)", output[4], iface, output)
+			}
+			if ix == 1 && output[12] != test.expectedHandle {
+				t.Errorf("unexpected handle: %s, expected: %s", output[12], test.expectedHandle)
+			}
+			if ix == 2 && output[8] != test.expectedClass {
+				t.Errorf("unexpected class: %s, expected: %s", output[8], test.expectedClass)
+			}
+		}
+	}
+}
+
+var tcQdisc = "qdisc htb 1: root refcnt 2 r2q 10 default 30 direct_packets_stat 0\n"
+
+func TestReconcileInterfaceExists(t *testing.T) {
+	fcmd := exec.FakeCmd{
+		CombinedOutputScript: []exec.FakeCombinedOutputAction{
+			func() ([]byte, error) { return []byte(tcQdisc), nil },
+		},
+	}
+
+	fexec := exec.FakeExec{
+		CommandScript: []exec.FakeCommandAction{
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+		},
+	}
+	iface := "cbr0"
+	shaper := &tcShaper{e: &fexec, iface: iface}
+	err := shaper.ReconcileInterface()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if fcmd.CombinedOutputCalls != 1 {
+		t.Errorf("unexpected number of calls: %d", fcmd.CombinedOutputCalls)
+	}
+
+	output := fcmd.CombinedOutputLog[0]
+	if len(output) != 5 {
+		t.Errorf("unexpected command: %v", output)
+	}
+	if output[0] != "tc" {
+		t.Errorf("unexpected command: %s", output[0])
+	}
+	if output[4] != iface {
+		t.Errorf("unexpected interface: %s, expected %s", output[4], iface)
+	}
+	if output[2] != "show" {
+		t.Errorf("unexpected action: %s", output[2])
+	}
+}
+
+func TestReconcileInterfaceDoesntExist(t *testing.T) {
+	fcmd := exec.FakeCmd{
+		CombinedOutputScript: []exec.FakeCombinedOutputAction{
+			func() ([]byte, error) { return []byte("\n"), nil },
+			func() ([]byte, error) { return []byte("\n"), nil },
+		},
+	}
+
+	fexec := exec.FakeExec{
+		CommandScript: []exec.FakeCommandAction{
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+		},
+	}
+	iface := "cbr0"
+	shaper := &tcShaper{e: &fexec, iface: iface}
+	err := shaper.ReconcileInterface()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	if fcmd.CombinedOutputCalls != 2 {
+		t.Errorf("unexpected number of calls: %d", fcmd.CombinedOutputCalls)
+	}
+
+	for ix, output := range fcmd.CombinedOutputLog {
+		if output[0] != "tc" {
+			t.Errorf("unexpected command: %s", output[0])
+		}
+		if output[4] != iface {
+			t.Errorf("unexpected interface: %s, expected %s", output[4], iface)
+		}
+		if ix == 0 {
+			if len(output) != 5 {
+				t.Errorf("unexpected command: %v", output)
+			}
+			if output[2] != "show" {
+				t.Errorf("unexpected action: %s", output[2])
+			}
+		}
+		if ix == 1 {
+			if len(output) != 11 {
+				t.Errorf("unexpected command: %v", output)
+			}
+			if output[2] != "add" {
+				t.Errorf("unexpected action: %s", output[2])
+			}
+			if output[7] != "1:" {
+				t.Errorf("unexpected root class: %s", output[7])
+			}
+			if output[8] != "htb" {
+				t.Errorf("unexpected qdisc algo: %s", output[8])
+			}
+		}
+	}
+}
+
+var tcQdiscWrong = []string{
+	"qdisc htb 2: root refcnt 2 r2q 10 default 30 direct_packets_stat 0\n",
+	"qdisc foo 1: root refcnt 2 r2q 10 default 30 direct_packets_stat 0\n",
+}
+
+func TestReconcileInterfaceIsWrong(t *testing.T) {
+	for _, test := range tcQdiscWrong {
+		fcmd := exec.FakeCmd{
+			CombinedOutputScript: []exec.FakeCombinedOutputAction{
+				func() ([]byte, error) { return []byte(test), nil },
+				func() ([]byte, error) { return []byte("\n"), nil },
+				func() ([]byte, error) { return []byte("\n"), nil },
+			},
+		}
+
+		fexec := exec.FakeExec{
+			CommandScript: []exec.FakeCommandAction{
+				func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+				func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+				func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+			},
+		}
+		iface := "cbr0"
+		shaper := &tcShaper{e: &fexec, iface: iface}
+		err := shaper.ReconcileInterface()
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		if fcmd.CombinedOutputCalls != 3 {
+			t.Errorf("unexpected number of calls: %d", fcmd.CombinedOutputCalls)
+		}
+
+		for ix, output := range fcmd.CombinedOutputLog {
+			if output[0] != "tc" {
+				t.Errorf("unexpected command: %s", output[0])
+			}
+			if output[4] != iface {
+				t.Errorf("unexpected interface: %s, expected %s", output[4], iface)
+			}
+			if ix == 0 {
+				if len(output) != 5 {
+					t.Errorf("unexpected command: %v", output)
+				}
+				if output[2] != "show" {
+					t.Errorf("unexpected action: %s", output[2])
+				}
+			}
+			if ix == 1 {
+				if len(output) != 8 {
+					t.Errorf("unexpected command: %v", output)
+				}
+				if output[2] != "delete" {
+					t.Errorf("unexpected action: %s", output[2])
+				}
+				if output[7] != strings.Split(test, " ")[2] {
+					t.Errorf("unexpected class: %s, expected: %s", output[7], strings.Split(test, " ")[2])
+				}
+			}
+			if ix == 2 {
+				if len(output) != 11 {
+					t.Errorf("unexpected command: %v", output)
+				}
+				if output[7] != "1:" {
+					t.Errorf("unexpected root class: %s", output[7])
+				}
+				if output[8] != "htb" {
+					t.Errorf("unexpected qdisc algo: %s", output[8])
+				}
+			}
+		}
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/bandwidth/unsupported.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/bandwidth/unsupported.go
@@ -1,0 +1,52 @@
+// +build !linux
+
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bandwidth
+
+import (
+	"errors"
+
+	"k8s.io/kubernetes/pkg/api/resource"
+)
+
+type unsupportedShaper struct {
+}
+
+func NewTCShaper(iface string) BandwidthShaper {
+	return &unsupportedShaper{}
+}
+
+func (f *unsupportedShaper) Limit(cidr string, egress, ingress *resource.Quantity) error {
+	return errors.New("unimplemented")
+}
+
+func (f *unsupportedShaper) Reset(cidr string) error {
+	return nil
+}
+
+func (f *unsupportedShaper) ReconcileInterface() error {
+	return errors.New("unimplemented")
+}
+
+func (f *unsupportedShaper) ReconcileCIDR(cidr string, egress, ingress *resource.Quantity) error {
+	return errors.New("unimplemented")
+}
+
+func (f *unsupportedShaper) GetCIDRs() ([]string, error) {
+	return []string{}, nil
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/cache_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/cache_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+)
+
+const (
+	maxTestCacheSize int = shardsCount * 2
+)
+
+func ExpectEntry(t *testing.T, cache Cache, index uint64, expectedValue interface{}) {
+	elem, found := cache.Get(index)
+	if !found {
+		t.Error("Expected to find entry with key 1")
+	} else if elem != expectedValue {
+		t.Errorf("Expected to find %v, got %v", expectedValue, elem)
+	}
+}
+
+func TestBasic(t *testing.T) {
+	cache := NewCache(maxTestCacheSize)
+	cache.Add(1, "xxx")
+	ExpectEntry(t, cache, 1, "xxx")
+}
+
+func TestOverflow(t *testing.T) {
+	cache := NewCache(maxTestCacheSize)
+	for i := 0; i < maxTestCacheSize+1; i++ {
+		cache.Add(uint64(i), "xxx")
+	}
+	foundIndexes := make([]uint64, 0)
+	for i := 0; i < maxTestCacheSize+1; i++ {
+		_, found := cache.Get(uint64(i))
+		if found {
+			foundIndexes = append(foundIndexes, uint64(i))
+		}
+	}
+	if len(foundIndexes) != maxTestCacheSize {
+		t.Errorf("Expect to find %d elements, got %d %v", maxTestCacheSize, len(foundIndexes), foundIndexes)
+	}
+}
+
+func TestOverwrite(t *testing.T) {
+	cache := NewCache(maxTestCacheSize)
+	cache.Add(1, "xxx")
+	ExpectEntry(t, cache, 1, "xxx")
+	cache.Add(1, "yyy")
+	ExpectEntry(t, cache, 1, "yyy")
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/clock_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/clock_test.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFakeClock(t *testing.T) {
+	startTime := time.Now()
+	tc := &FakeClock{Time: startTime}
+	tc.Step(time.Second)
+	now := tc.Now()
+	if now.Sub(startTime) != time.Second {
+		t.Errorf("input: %s now=%s gap=%s expected=%s", startTime, now, now.Sub(startTime), time.Second)
+	}
+
+	tt := tc.Now()
+	tc.Time = tt.Add(time.Hour)
+	if tc.Now().Sub(tt) != time.Hour {
+		t.Errorf("input: %s now=%s gap=%s expected=%s", tt, tc.Now(), tc.Now().Sub(tt), time.Hour)
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/config/config_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/config/config_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestConfigurationChannels(t *testing.T) {
+	mux := NewMux(nil)
+	channelOne := mux.Channel("one")
+	if channelOne != mux.Channel("one") {
+		t.Error("Didn't get the same muxuration channel back with the same name")
+	}
+	channelTwo := mux.Channel("two")
+	if channelOne == channelTwo {
+		t.Error("Got back the same muxuration channel for different names")
+	}
+}
+
+type MergeMock struct {
+	source string
+	update interface{}
+	t      *testing.T
+}
+
+func (m MergeMock) Merge(source string, update interface{}) error {
+	if m.source != source {
+		m.t.Errorf("Expected %s, Got %s", m.source, source)
+	}
+	if !reflect.DeepEqual(m.update, update) {
+		m.t.Errorf("Expected %s, Got %s", m.update, update)
+	}
+	return nil
+}
+
+func TestMergeInvoked(t *testing.T) {
+	merger := MergeMock{"one", "test", t}
+	mux := NewMux(&merger)
+	mux.Channel("one") <- "test"
+}
+
+func TestMergeFuncInvoked(t *testing.T) {
+	ch := make(chan bool)
+	mux := NewMux(MergeFunc(func(source string, update interface{}) error {
+		if source != "one" {
+			t.Errorf("Expected %s, Got %s", "one", source)
+		}
+		if update.(string) != "test" {
+			t.Errorf("Expected %s, Got %s", "test", update)
+		}
+		ch <- true
+		return nil
+	}))
+	mux.Channel("one") <- "test"
+	<-ch
+}
+
+func TestSimultaneousMerge(t *testing.T) {
+	ch := make(chan bool, 2)
+	mux := NewMux(MergeFunc(func(source string, update interface{}) error {
+		switch source {
+		case "one":
+			if update.(string) != "test" {
+				t.Errorf("Expected %s, Got %s", "test", update)
+			}
+		case "two":
+			if update.(string) != "test2" {
+				t.Errorf("Expected %s, Got %s", "test2", update)
+			}
+		default:
+			t.Errorf("Unexpected source, Got %s", update)
+		}
+		ch <- true
+		return nil
+	}))
+	source := mux.Channel("one")
+	source2 := mux.Channel("two")
+	source <- "test"
+	source2 <- "test2"
+	<-ch
+	<-ch
+}
+
+func TestBroadcaster(t *testing.T) {
+	b := NewBroadcaster()
+	b.Notify(struct{}{})
+
+	ch := make(chan bool, 2)
+	b.Add(ListenerFunc(func(object interface{}) {
+		if object != "test" {
+			t.Errorf("Expected %s, Got %s", "test", object)
+		}
+		ch <- true
+	}))
+	b.Add(ListenerFunc(func(object interface{}) {
+		if object != "test" {
+			t.Errorf("Expected %s, Got %s", "test", object)
+		}
+		ch <- true
+	}))
+	b.Notify("test")
+	<-ch
+	<-ch
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/dbus/dbus_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/dbus/dbus_test.go
@@ -1,0 +1,249 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dbus
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	godbus "github.com/godbus/dbus"
+)
+
+const (
+	DBusNameFlagAllowReplacement uint32 = 1 << (iota + 1)
+	DBusNameFlagReplaceExisting
+	DBusNameFlagDoNotQueue
+)
+
+const (
+	DBusRequestNameReplyPrimaryOwner uint32 = iota + 1
+	DBusRequestNameReplyInQueue
+	DBusRequestNameReplyExists
+	DBusRequestNameReplyAlreadyOwner
+)
+
+const (
+	DBusReleaseNameReplyReleased uint32 = iota + 1
+	DBusReleaseNameReplyNonExistent
+	DBusReleaseNameReplyNotOwner
+)
+
+func doDBusTest(t *testing.T, dbus Interface, real bool) {
+	bus, err := dbus.SystemBus()
+	if err != nil {
+		if !real {
+			t.Errorf("dbus.SystemBus() failed with fake Interface")
+		}
+		t.Skipf("D-Bus is not running: %v", err)
+	}
+	busObj := bus.BusObject()
+
+	id := ""
+	err = busObj.Call("org.freedesktop.DBus.GetId", 0).Store(&id)
+	if err != nil {
+		t.Errorf("expected success, got %v", err)
+	}
+	if len(id) == 0 {
+		t.Errorf("expected non-empty Id, got \"\"")
+	}
+
+	// Switch to the session bus for the rest, since the system bus is more
+	// locked down (and thus harder to trick into emitting signals).
+
+	bus, err = dbus.SessionBus()
+	if err != nil {
+		if !real {
+			t.Errorf("dbus.SystemBus() failed with fake Interface")
+		}
+		t.Skipf("D-Bus session bus is not available: %v", err)
+	}
+	busObj = bus.BusObject()
+
+	name := fmt.Sprintf("io.kubernetes.dbus_test_%d", os.Getpid())
+	owner := ""
+	err = busObj.Call("org.freedesktop.DBus.GetNameOwner", 0, name).Store(&owner)
+	if err == nil {
+		t.Errorf("expected '%s' to be un-owned, but found owner %s", name, owner)
+	}
+	dbuserr, ok := err.(godbus.Error)
+	if !ok {
+		t.Errorf("expected godbus.Error, but got %#v", err)
+	}
+	if dbuserr.Name != "org.freedesktop.DBus.Error.NameHasNoOwner" {
+		t.Errorf("expected NameHasNoOwner error but got %v", err)
+	}
+
+	sigchan := make(chan *godbus.Signal, 10)
+	bus.Signal(sigchan)
+
+	rule := fmt.Sprintf("type='signal',interface='org.freedesktop.DBus',member='NameOwnerChanged',path='/org/freedesktop/DBus',sender='org.freedesktop.DBus',arg0='%s'", name)
+	err = busObj.Call("org.freedesktop.DBus.AddMatch", 0, rule).Store()
+	if err != nil {
+		t.Errorf("expected success, got %v", err)
+	}
+
+	var ret uint32
+	err = busObj.Call("org.freedesktop.DBus.RequestName", 0, name, DBusNameFlagDoNotQueue).Store(&ret)
+	if err != nil {
+		t.Errorf("expected success, got %v", err)
+	}
+	if ret != DBusRequestNameReplyPrimaryOwner {
+		t.Errorf("expected %v, got %v", DBusRequestNameReplyPrimaryOwner, ret)
+	}
+
+	err = busObj.Call("org.freedesktop.DBus.GetNameOwner", 0, name).Store(&owner)
+	if err != nil {
+		t.Errorf("expected success, got %v", err)
+	}
+
+	var changedSignal, acquiredSignal, lostSignal *godbus.Signal
+
+	sig1 := <-sigchan
+	sig2 := <-sigchan
+	// We get two signals, but the order isn't guaranteed
+	if sig1.Name == "org.freedesktop.DBus.NameOwnerChanged" {
+		changedSignal = sig1
+		acquiredSignal = sig2
+	} else {
+		acquiredSignal = sig1
+		changedSignal = sig2
+	}
+
+	if acquiredSignal.Sender != "org.freedesktop.DBus" || acquiredSignal.Name != "org.freedesktop.DBus.NameAcquired" {
+		t.Errorf("expected NameAcquired signal, got %v", acquiredSignal)
+	}
+	acquiredName := acquiredSignal.Body[0].(string)
+	if acquiredName != name {
+		t.Errorf("unexpected NameAcquired arguments: %v", acquiredSignal)
+	}
+
+	if changedSignal.Sender != "org.freedesktop.DBus" || changedSignal.Name != "org.freedesktop.DBus.NameOwnerChanged" {
+		t.Errorf("expected NameOwnerChanged signal, got %v", changedSignal)
+	}
+
+	changedName := changedSignal.Body[0].(string)
+	oldOwner := changedSignal.Body[1].(string)
+	newOwner := changedSignal.Body[2].(string)
+	if changedName != name || oldOwner != "" || newOwner != owner {
+		t.Errorf("unexpected NameOwnerChanged arguments: %v", changedSignal)
+	}
+
+	err = busObj.Call("org.freedesktop.DBus.ReleaseName", 0, name).Store(&ret)
+	if err != nil {
+		t.Errorf("expected success, got %v", err)
+	}
+	if ret != DBusReleaseNameReplyReleased {
+		t.Errorf("expected %v, got %v", DBusReleaseNameReplyReleased, ret)
+	}
+
+	sig1 = <-sigchan
+	sig2 = <-sigchan
+	if sig1.Name == "org.freedesktop.DBus.NameOwnerChanged" {
+		changedSignal = sig1
+		lostSignal = sig2
+	} else {
+		lostSignal = sig1
+		changedSignal = sig2
+	}
+
+	if lostSignal.Sender != "org.freedesktop.DBus" || lostSignal.Name != "org.freedesktop.DBus.NameLost" {
+		t.Errorf("expected NameLost signal, got %v", lostSignal)
+	}
+	lostName := lostSignal.Body[0].(string)
+	if lostName != name {
+		t.Errorf("unexpected NameLost arguments: %v", lostSignal)
+	}
+
+	if changedSignal.Sender != "org.freedesktop.DBus" || changedSignal.Name != "org.freedesktop.DBus.NameOwnerChanged" {
+		t.Errorf("expected NameOwnerChanged signal, got %v", changedSignal)
+	}
+
+	changedName = changedSignal.Body[0].(string)
+	oldOwner = changedSignal.Body[1].(string)
+	newOwner = changedSignal.Body[2].(string)
+	if changedName != name || oldOwner != owner || newOwner != "" {
+		t.Errorf("unexpected NameOwnerChanged arguments: %v", changedSignal)
+	}
+
+	if len(sigchan) != 0 {
+		t.Errorf("unexpected extra signals (%d)", len(sigchan))
+	}
+
+	// Unregister sigchan
+	bus.Signal(sigchan)
+}
+
+func TestRealDBus(t *testing.T) {
+	dbus := New()
+	doDBusTest(t, dbus, true)
+}
+
+func TestFakeDBus(t *testing.T) {
+	uniqueName := ":1.1"
+	ownedName := ""
+
+	fakeSystem := NewFakeConnection()
+	fakeSystem.SetBusObject(
+		func(method string, args ...interface{}) ([]interface{}, error) {
+			if method == "org.freedesktop.DBus.GetId" {
+				return []interface{}{"foo"}, nil
+			}
+			return nil, fmt.Errorf("unexpected method call '%s'", method)
+		},
+	)
+
+	fakeSession := NewFakeConnection()
+	fakeSession.SetBusObject(
+		func(method string, args ...interface{}) ([]interface{}, error) {
+			if method == "org.freedesktop.DBus.GetNameOwner" {
+				checkName := args[0].(string)
+				if checkName != ownedName {
+					return nil, godbus.Error{"org.freedesktop.DBus.Error.NameHasNoOwner", nil}
+				} else {
+					return []interface{}{uniqueName}, nil
+				}
+			} else if method == "org.freedesktop.DBus.RequestName" {
+				reqName := args[0].(string)
+				_ = args[1].(uint32)
+				if ownedName != "" {
+					return []interface{}{DBusRequestNameReplyAlreadyOwner}, nil
+				}
+				ownedName = reqName
+				fakeSession.EmitSignal("org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus", "NameAcquired", reqName)
+				fakeSession.EmitSignal("org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus", "NameOwnerChanged", reqName, "", uniqueName)
+				return []interface{}{DBusRequestNameReplyPrimaryOwner}, nil
+			} else if method == "org.freedesktop.DBus.ReleaseName" {
+				reqName := args[0].(string)
+				if reqName != ownedName {
+					return []interface{}{DBusReleaseNameReplyNotOwner}, nil
+				}
+				ownedName = ""
+				fakeSession.EmitSignal("org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus", "NameOwnerChanged", reqName, uniqueName, "")
+				fakeSession.EmitSignal("org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus", "NameLost", reqName)
+				return []interface{}{DBusReleaseNameReplyReleased}, nil
+			} else if method == "org.freedesktop.DBus.AddMatch" {
+				return nil, nil
+			} else {
+				return nil, fmt.Errorf("unexpected method call '%s'", method)
+			}
+		},
+	)
+
+	dbus := NewFake(fakeSystem, fakeSession)
+	doDBusTest(t, dbus, false)
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/deployment/deployment.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/deployment/deployment.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployment
+
+import (
+	"fmt"
+	"hash/adler32"
+
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apis/experimental"
+	client "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/fields"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/util"
+)
+
+// Returns the old RCs targetted by the given Deployment.
+func GetOldRCs(deployment experimental.Deployment, c client.Interface) ([]*api.ReplicationController, error) {
+	namespace := deployment.ObjectMeta.Namespace
+	// 1. Find all pods whose labels match deployment.Spec.Selector
+	podList, err := c.Pods(namespace).List(labels.SelectorFromSet(deployment.Spec.Selector), fields.Everything())
+	if err != nil {
+		return nil, fmt.Errorf("error listing pods: %v", err)
+	}
+	// 2. Find the corresponding RCs for pods in podList.
+	// TODO: Right now we list all RCs and then filter. We should add an API for this.
+	oldRCs := map[string]api.ReplicationController{}
+	rcList, err := c.ReplicationControllers(namespace).List(labels.Everything())
+	if err != nil {
+		return nil, fmt.Errorf("error listing replication controllers: %v", err)
+	}
+	for _, pod := range podList.Items {
+		podLabelsSelector := labels.Set(pod.ObjectMeta.Labels)
+		for _, rc := range rcList.Items {
+			rcLabelsSelector := labels.SelectorFromSet(rc.Spec.Selector)
+			if rcLabelsSelector.Matches(podLabelsSelector) {
+				// Filter out RC that has the same pod template spec as the deployment - that is the new RC.
+				if api.Semantic.DeepEqual(rc.Spec.Template, GetNewRCTemplate(deployment)) {
+					continue
+				}
+				oldRCs[rc.ObjectMeta.Name] = rc
+			}
+		}
+	}
+	requiredRCs := []*api.ReplicationController{}
+	for _, value := range oldRCs {
+		requiredRCs = append(requiredRCs, &value)
+	}
+	return requiredRCs, nil
+}
+
+// Returns an RC that matches the intent of the given deployment.
+// Returns nil if the new RC doesnt exist yet.
+func GetNewRC(deployment experimental.Deployment, c client.Interface) (*api.ReplicationController, error) {
+	namespace := deployment.ObjectMeta.Namespace
+	rcList, err := c.ReplicationControllers(namespace).List(labels.Everything())
+	if err != nil {
+		return nil, fmt.Errorf("error listing replication controllers: %v", err)
+	}
+	newRCTemplate := GetNewRCTemplate(deployment)
+
+	for _, rc := range rcList.Items {
+		if api.Semantic.DeepEqual(rc.Spec.Template, newRCTemplate) {
+			// This is the new RC.
+			return &rc, nil
+		}
+	}
+	// new RC does not exist.
+	return nil, nil
+}
+
+// Returns the desired PodTemplateSpec for the new RC corresponding to the given RC.
+func GetNewRCTemplate(deployment experimental.Deployment) *api.PodTemplateSpec {
+	// newRC will have the same template as in deployment spec, plus a unique label in some cases.
+	newRCTemplate := &api.PodTemplateSpec{
+		ObjectMeta: deployment.Spec.Template.ObjectMeta,
+		Spec:       deployment.Spec.Template.Spec,
+	}
+	podTemplateSpecHash := GetPodTemplateSpecHash(newRCTemplate)
+	if deployment.Spec.UniqueLabelKey != "" {
+		newLabels := map[string]string{}
+		for key, value := range deployment.Spec.Template.ObjectMeta.Labels {
+			newLabels[key] = value
+		}
+		newLabels[deployment.Spec.UniqueLabelKey] = fmt.Sprintf("%d", podTemplateSpecHash)
+		newRCTemplate.ObjectMeta.Labels = newLabels
+	}
+	return newRCTemplate
+}
+
+func GetPodTemplateSpecHash(template *api.PodTemplateSpec) uint32 {
+	podTemplateSpecHasher := adler32.New()
+	util.DeepHashObject(podTemplateSpecHasher, template)
+	return podTemplateSpecHasher.Sum32()
+}
+
+// Returns the sum of Replicas of the given replication controllers.
+func GetReplicaCountForRCs(replicationControllers []*api.ReplicationController) int {
+	totalReplicaCount := 0
+	for _, rc := range replicationControllers {
+		totalReplicaCount += rc.Spec.Replicas
+	}
+	return totalReplicaCount
+}
+
+// Returns the number of available pods corresponding to the given RCs.
+func GetAvailablePodsForRCs(c client.Interface, rcs []*api.ReplicationController) (int, error) {
+	// TODO: Use MinReadySeconds once https://github.com/kubernetes/kubernetes/pull/12894 is merged.
+	allPods, err := getPodsForRCs(c, rcs)
+	if err != nil {
+		return 0, err
+	}
+	readyPodCount := 0
+	for _, pod := range allPods {
+		if api.IsPodReady(&pod) {
+			readyPodCount++
+		}
+	}
+	return readyPodCount, nil
+}
+
+func getPodsForRCs(c client.Interface, replicationControllers []*api.ReplicationController) ([]api.Pod, error) {
+	allPods := []api.Pod{}
+	for _, rc := range replicationControllers {
+		podList, err := c.Pods(rc.ObjectMeta.Namespace).List(labels.SelectorFromSet(rc.Spec.Selector), fields.Everything())
+		if err != nil {
+			return allPods, fmt.Errorf("error listing pods: %v", err)
+		}
+		allPods = append(allPods, podList.Items...)
+	}
+	return allPods, nil
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/errors/errors_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/errors/errors_test.go
@@ -1,0 +1,286 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestEmptyAggregate(t *testing.T) {
+	var slice []error
+	var agg Aggregate
+	var err error
+
+	agg = NewAggregate(slice)
+	if agg != nil {
+		t.Errorf("expected nil, got %#v", agg)
+	}
+	err = NewAggregate(slice)
+	if err != nil {
+		t.Errorf("expected nil, got %#v", err)
+	}
+
+	// This is not normally possible, but pedantry demands I test it.
+	agg = aggregate(slice) // empty aggregate
+	if s := agg.Error(); s != "" {
+		t.Errorf("expected empty string, got %q", s)
+	}
+	if s := agg.Errors(); len(s) != 0 {
+		t.Errorf("expected empty slice, got %#v", s)
+	}
+	err = agg.(error)
+	if s := err.Error(); s != "" {
+		t.Errorf("expected empty string, got %q", s)
+	}
+}
+
+func TestSingularAggregate(t *testing.T) {
+	var slice []error = []error{fmt.Errorf("err")}
+	var agg Aggregate
+	var err error
+
+	agg = NewAggregate(slice)
+	if agg == nil {
+		t.Errorf("expected non-nil")
+	}
+	if s := agg.Error(); s != "err" {
+		t.Errorf("expected 'err', got %q", s)
+	}
+	if s := agg.Errors(); len(s) != 1 {
+		t.Errorf("expected one-element slice, got %#v", s)
+	}
+	if s := agg.Errors()[0].Error(); s != "err" {
+		t.Errorf("expected 'err', got %q", s)
+	}
+
+	err = agg.(error)
+	if err == nil {
+		t.Errorf("expected non-nil")
+	}
+	if s := err.Error(); s != "err" {
+		t.Errorf("expected 'err', got %q", s)
+	}
+}
+
+func TestPluralAggregate(t *testing.T) {
+	var slice []error = []error{fmt.Errorf("abc"), fmt.Errorf("123")}
+	var agg Aggregate
+	var err error
+
+	agg = NewAggregate(slice)
+	if agg == nil {
+		t.Errorf("expected non-nil")
+	}
+	if s := agg.Error(); s != "[abc, 123]" {
+		t.Errorf("expected '[abc, 123]', got %q", s)
+	}
+	if s := agg.Errors(); len(s) != 2 {
+		t.Errorf("expected two-elements slice, got %#v", s)
+	}
+	if s := agg.Errors()[0].Error(); s != "abc" {
+		t.Errorf("expected '[abc, 123]', got %q", s)
+	}
+
+	err = agg.(error)
+	if err == nil {
+		t.Errorf("expected non-nil")
+	}
+	if s := err.Error(); s != "[abc, 123]" {
+		t.Errorf("expected '[abc, 123]', got %q", s)
+	}
+}
+
+func TestFilterOut(t *testing.T) {
+	testCases := []struct {
+		err      error
+		filter   []Matcher
+		expected error
+	}{
+		{
+			nil,
+			[]Matcher{},
+			nil,
+		},
+		{
+			aggregate{},
+			[]Matcher{},
+			nil,
+		},
+		{
+			aggregate{fmt.Errorf("abc")},
+			[]Matcher{},
+			aggregate{fmt.Errorf("abc")},
+		},
+		{
+			aggregate{fmt.Errorf("abc")},
+			[]Matcher{func(err error) bool { return false }},
+			aggregate{fmt.Errorf("abc")},
+		},
+		{
+			aggregate{fmt.Errorf("abc")},
+			[]Matcher{func(err error) bool { return true }},
+			nil,
+		},
+		{
+			aggregate{fmt.Errorf("abc")},
+			[]Matcher{func(err error) bool { return false }, func(err error) bool { return false }},
+			aggregate{fmt.Errorf("abc")},
+		},
+		{
+			aggregate{fmt.Errorf("abc")},
+			[]Matcher{func(err error) bool { return false }, func(err error) bool { return true }},
+			nil,
+		},
+		{
+			aggregate{fmt.Errorf("abc"), fmt.Errorf("def"), fmt.Errorf("ghi")},
+			[]Matcher{func(err error) bool { return err.Error() == "def" }},
+			aggregate{fmt.Errorf("abc"), fmt.Errorf("ghi")},
+		},
+		{
+			aggregate{aggregate{fmt.Errorf("abc")}},
+			[]Matcher{},
+			aggregate{aggregate{fmt.Errorf("abc")}},
+		},
+		{
+			aggregate{aggregate{fmt.Errorf("abc"), aggregate{fmt.Errorf("def")}}},
+			[]Matcher{},
+			aggregate{aggregate{fmt.Errorf("abc"), aggregate{fmt.Errorf("def")}}},
+		},
+		{
+			aggregate{aggregate{fmt.Errorf("abc"), aggregate{fmt.Errorf("def")}}},
+			[]Matcher{func(err error) bool { return err.Error() == "def" }},
+			aggregate{aggregate{fmt.Errorf("abc")}},
+		},
+	}
+	for i, testCase := range testCases {
+		err := FilterOut(testCase.err, testCase.filter...)
+		if !reflect.DeepEqual(testCase.expected, err) {
+			t.Errorf("%d: expected %v, got %v", i, testCase.expected, err)
+		}
+	}
+}
+
+func TestFlatten(t *testing.T) {
+	testCases := []struct {
+		agg      Aggregate
+		expected Aggregate
+	}{
+		{
+			nil,
+			nil,
+		},
+		{
+			aggregate{},
+			nil,
+		},
+		{
+			aggregate{fmt.Errorf("abc")},
+			aggregate{fmt.Errorf("abc")},
+		},
+		{
+			aggregate{fmt.Errorf("abc"), fmt.Errorf("def"), fmt.Errorf("ghi")},
+			aggregate{fmt.Errorf("abc"), fmt.Errorf("def"), fmt.Errorf("ghi")},
+		},
+		{
+			aggregate{aggregate{fmt.Errorf("abc")}},
+			aggregate{fmt.Errorf("abc")},
+		},
+		{
+			aggregate{aggregate{aggregate{fmt.Errorf("abc")}}},
+			aggregate{fmt.Errorf("abc")},
+		},
+		{
+			aggregate{aggregate{fmt.Errorf("abc"), aggregate{fmt.Errorf("def")}}},
+			aggregate{fmt.Errorf("abc"), fmt.Errorf("def")},
+		},
+		{
+			aggregate{aggregate{aggregate{fmt.Errorf("abc")}, fmt.Errorf("def"), aggregate{fmt.Errorf("ghi")}}},
+			aggregate{fmt.Errorf("abc"), fmt.Errorf("def"), fmt.Errorf("ghi")},
+		},
+	}
+	for i, testCase := range testCases {
+		agg := Flatten(testCase.agg)
+		if !reflect.DeepEqual(testCase.expected, agg) {
+			t.Errorf("%d: expected %v, got %v", i, testCase.expected, agg)
+		}
+	}
+}
+
+func TestAggregateGoroutines(t *testing.T) {
+	testCases := []struct {
+		errs     []error
+		expected map[string]bool // can't compare directly to Aggregate due to non-deterministic ordering
+	}{
+		{
+			[]error{},
+			nil,
+		},
+		{
+			[]error{nil},
+			nil,
+		},
+		{
+			[]error{nil, nil},
+			nil,
+		},
+		{
+			[]error{fmt.Errorf("1")},
+			map[string]bool{"1": true},
+		},
+		{
+			[]error{fmt.Errorf("1"), nil},
+			map[string]bool{"1": true},
+		},
+		{
+			[]error{fmt.Errorf("1"), fmt.Errorf("267")},
+			map[string]bool{"1": true, "267": true},
+		},
+		{
+			[]error{fmt.Errorf("1"), nil, fmt.Errorf("1234")},
+			map[string]bool{"1": true, "1234": true},
+		},
+		{
+			[]error{nil, fmt.Errorf("1"), nil, fmt.Errorf("1234"), fmt.Errorf("22")},
+			map[string]bool{"1": true, "1234": true, "22": true},
+		},
+	}
+	for i, testCase := range testCases {
+		funcs := make([]func() error, len(testCase.errs))
+		for i := range testCase.errs {
+			err := testCase.errs[i]
+			funcs[i] = func() error { return err }
+		}
+		agg := AggregateGoroutines(funcs...)
+		if agg == nil {
+			if len(testCase.expected) > 0 {
+				t.Errorf("%d: expected %v, got nil", i, testCase.expected)
+			}
+			continue
+		}
+		if len(agg.Errors()) != len(testCase.expected) {
+			t.Errorf("%d: expected %d errors in aggregate, got %v", i, len(testCase.expected), agg)
+			continue
+		}
+		for _, err := range agg.Errors() {
+			if !testCase.expected[err.Error()] {
+				t.Errorf("%d: expected %v, got aggregate containing %v", i, testCase.expected, err)
+			}
+		}
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/exec/exec_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/exec/exec_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package exec
+
+import (
+	osexec "os/exec"
+	"testing"
+)
+
+func TestExecutorNoArgs(t *testing.T) {
+	ex := New()
+
+	cmd := ex.Command("true")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Errorf("expected success, got %v", err)
+	}
+	if len(out) != 0 {
+		t.Errorf("expected no output, got %q", string(out))
+	}
+
+	cmd = ex.Command("false")
+	out, err = cmd.CombinedOutput()
+	if err == nil {
+		t.Errorf("expected failure, got nil error")
+	}
+	if len(out) != 0 {
+		t.Errorf("expected no output, got %q", string(out))
+	}
+	ee, ok := err.(ExitError)
+	if !ok {
+		t.Errorf("expected an ExitError, got %+v", err)
+	}
+	if ee.Exited() {
+		if code := ee.ExitStatus(); code != 1 {
+			t.Errorf("expected exit status 1, got %d", code)
+		}
+	}
+
+	cmd = ex.Command("/does/not/exist")
+	out, err = cmd.CombinedOutput()
+	if err == nil {
+		t.Errorf("expected failure, got nil error")
+	}
+	if ee, ok := err.(ExitError); ok {
+		t.Errorf("expected non-ExitError, got %+v", ee)
+	}
+}
+
+func TestExecutorWithArgs(t *testing.T) {
+	ex := New()
+
+	cmd := ex.Command("/bin/echo", "stdout")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Errorf("expected success, got %+v", err)
+	}
+	if string(out) != "stdout\n" {
+		t.Errorf("unexpected output: %q", string(out))
+	}
+
+	cmd = ex.Command("/bin/sh", "-c", "echo stderr > /dev/stderr")
+	out, err = cmd.CombinedOutput()
+	if err != nil {
+		t.Errorf("expected success, got %+v", err)
+	}
+	if string(out) != "stderr\n" {
+		t.Errorf("unexpected output: %q", string(out))
+	}
+}
+
+func TestLookPath(t *testing.T) {
+	ex := New()
+
+	shExpected, _ := osexec.LookPath("sh")
+	sh, _ := ex.LookPath("sh")
+	if sh != shExpected {
+		t.Errorf("unexpected result for LookPath: got %s, expected %s", sh, shExpected)
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/fake_handler_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/fake_handler_test.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestFakeHandlerPath(t *testing.T) {
+	handler := FakeHandler{}
+	server := httptest.NewServer(&handler)
+	defer server.Close()
+	method := "GET"
+	path := "/foo/bar"
+	body := "somebody"
+
+	req, err := http.NewRequest(method, server.URL+path, bytes.NewBufferString(body))
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	client := http.Client{}
+	_, err = client.Do(req)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	handler.ValidateRequest(t, path, method, &body)
+}
+
+func TestFakeHandlerPathNoBody(t *testing.T) {
+	handler := FakeHandler{}
+	server := httptest.NewServer(&handler)
+	defer server.Close()
+	method := "GET"
+	path := "/foo/bar"
+
+	req, err := http.NewRequest(method, server.URL+path, nil)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	client := http.Client{}
+	_, err = client.Do(req)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	handler.ValidateRequest(t, path, method, nil)
+}
+
+type fakeError struct {
+	errors []string
+}
+
+func (f *fakeError) Errorf(format string, args ...interface{}) {
+	f.errors = append(f.errors, format)
+}
+
+func (f *fakeError) Logf(format string, args ...interface{}) {}
+
+func TestFakeHandlerWrongPath(t *testing.T) {
+	handler := FakeHandler{}
+	server := httptest.NewServer(&handler)
+	defer server.Close()
+	method := "GET"
+	path := "/foo/bar"
+	fakeT := fakeError{}
+
+	req, err := http.NewRequest(method, server.URL+"/foo/baz", nil)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	client := http.Client{}
+	_, err = client.Do(req)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	handler.ValidateRequest(&fakeT, path, method, nil)
+	if len(fakeT.errors) != 1 {
+		t.Errorf("Unexpected error set: %#v", fakeT.errors)
+	}
+}
+
+func TestFakeHandlerWrongMethod(t *testing.T) {
+	handler := FakeHandler{}
+	server := httptest.NewServer(&handler)
+	defer server.Close()
+	method := "GET"
+	path := "/foo/bar"
+	fakeT := fakeError{}
+
+	req, err := http.NewRequest("PUT", server.URL+path, nil)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	client := http.Client{}
+	_, err = client.Do(req)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	handler.ValidateRequest(&fakeT, path, method, nil)
+	if len(fakeT.errors) != 1 {
+		t.Errorf("Unexpected error set: %#v", fakeT.errors)
+	}
+}
+
+func TestFakeHandlerWrongBody(t *testing.T) {
+	handler := FakeHandler{}
+	server := httptest.NewServer(&handler)
+	defer server.Close()
+	method := "GET"
+	path := "/foo/bar"
+	body := "somebody"
+	fakeT := fakeError{}
+
+	req, err := http.NewRequest(method, server.URL+path, bytes.NewBufferString(body))
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	client := http.Client{}
+	_, err = client.Do(req)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	otherbody := "otherbody"
+	handler.ValidateRequest(&fakeT, path, method, &otherbody)
+	if len(fakeT.errors) != 1 {
+		t.Errorf("Unexpected error set: %#v", fakeT.errors)
+	}
+}
+
+func TestFakeHandlerNilBody(t *testing.T) {
+	handler := FakeHandler{}
+	server := httptest.NewServer(&handler)
+	defer server.Close()
+	method := "GET"
+	path := "/foo/bar"
+	body := "somebody"
+	fakeT := fakeError{}
+
+	req, err := http.NewRequest(method, server.URL+path, nil)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	client := http.Client{}
+	_, err = client.Do(req)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	handler.ValidateRequest(&fakeT, path, method, &body)
+	if len(fakeT.errors) != 1 {
+		t.Errorf("Unexpected error set: %#v", fakeT.errors)
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/fielderrors/fielderrors.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/fielderrors/fielderrors.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/kubernetes/pkg/util/errors"
 
 	"github.com/davecgh/go-spew/spew"
-	"github.com/golang/glog"
 )
 
 // ValidationErrorType is a machine readable value providing more detail about why
@@ -74,7 +73,7 @@ func (t ValidationErrorType) String() string {
 	case ValidationErrorTypeTooLong:
 		return "too long"
 	default:
-		glog.Errorf("unrecognized validation type: %#v", t)
+		panic(fmt.Sprintf("unrecognized validation type: %#v", t))
 		return ""
 	}
 }
@@ -161,7 +160,7 @@ func (list ValidationErrorList) Prefix(prefix string) ValidationErrorList {
 			}
 			list[i] = err
 		} else {
-			glog.Warningf("Programmer error: ValidationErrorList holds non-ValidationError: %#v", list[i])
+			panic(fmt.Sprintf("Programmer error: ValidationErrorList holds non-ValidationError: %#v", list[i]))
 		}
 	}
 	return list

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/fielderrors/fielderrors_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/fielderrors/fielderrors_test.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fielderrors
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMakeFuncs(t *testing.T) {
+	testCases := []struct {
+		fn       func() *ValidationError
+		expected ValidationErrorType
+	}{
+		{
+			func() *ValidationError { return NewFieldInvalid("f", "v", "d") },
+			ValidationErrorTypeInvalid,
+		},
+		{
+			func() *ValidationError { return NewFieldValueNotSupported("f", "v", nil) },
+			ValidationErrorTypeNotSupported,
+		},
+		{
+			func() *ValidationError { return NewFieldDuplicate("f", "v") },
+			ValidationErrorTypeDuplicate,
+		},
+		{
+			func() *ValidationError { return NewFieldNotFound("f", "v") },
+			ValidationErrorTypeNotFound,
+		},
+		{
+			func() *ValidationError { return NewFieldRequired("f") },
+			ValidationErrorTypeRequired,
+		},
+	}
+
+	for _, testCase := range testCases {
+		err := testCase.fn()
+		if err.Type != testCase.expected {
+			t.Errorf("expected Type %q, got %q", testCase.expected, err.Type)
+		}
+	}
+}
+
+func TestValidationErrorUsefulMessage(t *testing.T) {
+	s := NewFieldInvalid("foo", "bar", "deet").Error()
+	t.Logf("message: %v", s)
+	for _, part := range []string{"foo", "bar", "deet", ValidationErrorTypeInvalid.String()} {
+		if !strings.Contains(s, part) {
+			t.Errorf("error message did not contain expected part '%v'", part)
+		}
+	}
+
+	type complicated struct {
+		Baz   int
+		Qux   string
+		Inner interface{}
+		KV    map[string]int
+	}
+	s = NewFieldInvalid(
+		"foo",
+		&complicated{
+			Baz:   1,
+			Qux:   "aoeu",
+			Inner: &complicated{Qux: "asdf"},
+			KV:    map[string]int{"Billy": 2},
+		},
+		"detail",
+	).Error()
+	t.Logf("message: %v", s)
+	for _, part := range []string{
+		"foo", ValidationErrorTypeInvalid.String(),
+		"Baz", "Qux", "Inner", "KV", "detail",
+		"1", "aoeu", "asdf", "Billy", "2",
+	} {
+		if !strings.Contains(s, part) {
+			t.Errorf("error message did not contain expected part '%v'", part)
+		}
+	}
+}
+
+func TestErrListFilter(t *testing.T) {
+	list := ValidationErrorList{
+		NewFieldInvalid("test.field", "", ""),
+		NewFieldInvalid("field.test", "", ""),
+		NewFieldDuplicate("test", "value"),
+	}
+	if len(list.Filter(NewValidationErrorTypeMatcher(ValidationErrorTypeDuplicate))) != 2 {
+		t.Errorf("should not filter")
+	}
+	if len(list.Filter(NewValidationErrorTypeMatcher(ValidationErrorTypeInvalid))) != 1 {
+		t.Errorf("should filter")
+	}
+	if len(list.Filter(NewValidationErrorFieldPrefixMatcher("test"))) != 1 {
+		t.Errorf("should filter")
+	}
+	if len(list.Filter(NewValidationErrorFieldPrefixMatcher("test."))) != 2 {
+		t.Errorf("should filter")
+	}
+	if len(list.Filter(NewValidationErrorFieldPrefixMatcher(""))) != 0 {
+		t.Errorf("should filter")
+	}
+	if len(list.Filter(NewValidationErrorFieldPrefixMatcher("field."), NewValidationErrorTypeMatcher(ValidationErrorTypeDuplicate))) != 1 {
+		t.Errorf("should filter")
+	}
+}
+
+func TestErrListPrefix(t *testing.T) {
+	testCases := []struct {
+		Err      *ValidationError
+		Expected string
+	}{
+		{
+			NewFieldNotFound("[0].bar", "value"),
+			"foo[0].bar",
+		},
+		{
+			NewFieldInvalid("field", "value", ""),
+			"foo.field",
+		},
+		{
+			NewFieldDuplicate("", "value"),
+			"foo",
+		},
+	}
+	for _, testCase := range testCases {
+		errList := ValidationErrorList{testCase.Err}
+		prefix := errList.Prefix("foo")
+		if prefix == nil || len(prefix) != len(errList) {
+			t.Errorf("Prefix should return self")
+		}
+		if e, a := testCase.Expected, errList[0].(*ValidationError).Field; e != a {
+			t.Errorf("expected %s, got %s", e, a)
+		}
+	}
+}
+
+func TestErrListPrefixIndex(t *testing.T) {
+	testCases := []struct {
+		Err      *ValidationError
+		Expected string
+	}{
+		{
+			NewFieldNotFound("[0].bar", "value"),
+			"[1][0].bar",
+		},
+		{
+			NewFieldInvalid("field", "value", ""),
+			"[1].field",
+		},
+		{
+			NewFieldDuplicate("", "value"),
+			"[1]",
+		},
+	}
+	for _, testCase := range testCases {
+		errList := ValidationErrorList{testCase.Err}
+		prefix := errList.PrefixIndex(1)
+		if prefix == nil || len(prefix) != len(errList) {
+			t.Errorf("PrefixIndex should return self")
+		}
+		if e, a := testCase.Expected, errList[0].(*ValidationError).Field; e != a {
+			t.Errorf("expected %s, got %s", e, a)
+		}
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/flushwriter/writer_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/flushwriter/writer_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flushwriter
+
+import (
+	"fmt"
+	"testing"
+)
+
+type writerWithFlush struct {
+	writeCount, flushCount int
+	err                    error
+}
+
+func (w *writerWithFlush) Flush() {
+	w.flushCount++
+}
+
+func (w *writerWithFlush) Write(p []byte) (n int, err error) {
+	w.writeCount++
+	return len(p), w.err
+}
+
+type writerWithNoFlush struct {
+	writeCount int
+}
+
+func (w *writerWithNoFlush) Write(p []byte) (n int, err error) {
+	w.writeCount++
+	return len(p), nil
+}
+
+func TestWriteWithFlush(t *testing.T) {
+	w := &writerWithFlush{}
+	fw := Wrap(w)
+	for i := 0; i < 10; i++ {
+		_, err := fw.Write([]byte("Test write"))
+		if err != nil {
+			t.Errorf("Unexpected error while writing with flush writer: %v", err)
+		}
+	}
+	if w.flushCount != 10 {
+		t.Errorf("Flush not called the expected number of times. Actual: %d", w.flushCount)
+	}
+	if w.writeCount != 10 {
+		t.Errorf("Write not called the expected number of times. Actual: %d", w.writeCount)
+	}
+}
+
+func TestWriteWithoutFlush(t *testing.T) {
+	w := &writerWithNoFlush{}
+	fw := Wrap(w)
+	for i := 0; i < 10; i++ {
+		_, err := fw.Write([]byte("Test write"))
+		if err != nil {
+			t.Errorf("Unexpected error while writing with flush writer: %v", err)
+		}
+	}
+	if w.writeCount != 10 {
+		t.Errorf("Write not called the expected number of times. Actual: %d", w.writeCount)
+	}
+}
+
+func TestWriteError(t *testing.T) {
+	e := fmt.Errorf("Error")
+	w := &writerWithFlush{err: e}
+	fw := Wrap(w)
+	_, err := fw.Write([]byte("Test write"))
+	if err != e {
+		t.Errorf("Did not get expected error. Got: %#v", err)
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/hash_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/hash_test.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"hash/adler32"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+)
+
+type A struct {
+	x int
+	y string
+}
+
+type B struct {
+	x []int
+	y map[string]bool
+}
+
+type C struct {
+	x int
+	y string
+}
+
+func (c C) String() string {
+	return fmt.Sprintf("%d:%s", c.x, c.y)
+}
+
+func TestDeepHashObject(t *testing.T) {
+	successCases := []func() interface{}{
+		func() interface{} { return 8675309 },
+		func() interface{} { return "Jenny, I got your number" },
+		func() interface{} { return []string{"eight", "six", "seven"} },
+		func() interface{} { return [...]int{5, 3, 0, 9} },
+		func() interface{} { return map[int]string{8: "8", 6: "6", 7: "7"} },
+		func() interface{} { return map[string]int{"5": 5, "3": 3, "0": 0, "9": 9} },
+		func() interface{} { return A{867, "5309"} },
+		func() interface{} { return &A{867, "5309"} },
+		func() interface{} {
+			return B{[]int{8, 6, 7}, map[string]bool{"5": true, "3": true, "0": true, "9": true}}
+		},
+		func() interface{} { return map[A]bool{A{8675309, "Jenny"}: true, A{9765683, "!Jenny"}: false} },
+		func() interface{} { return map[C]bool{C{8675309, "Jenny"}: true, C{9765683, "!Jenny"}: false} },
+		func() interface{} { return map[*A]bool{&A{8675309, "Jenny"}: true, &A{9765683, "!Jenny"}: false} },
+		func() interface{} { return map[*C]bool{&C{8675309, "Jenny"}: true, &C{9765683, "!Jenny"}: false} },
+	}
+
+	for _, tc := range successCases {
+		hasher1 := adler32.New()
+		DeepHashObject(hasher1, tc())
+		hash1 := hasher1.Sum32()
+		DeepHashObject(hasher1, tc())
+		hash2 := hasher1.Sum32()
+		if hash1 != hash2 {
+			t.Fatalf("hash of the same object (%q) produced different results: %d vs %d", toString(tc()), hash1, hash2)
+		}
+		for i := 0; i < 100; i++ {
+			hasher2 := adler32.New()
+
+			DeepHashObject(hasher1, tc())
+			hash1a := hasher1.Sum32()
+			DeepHashObject(hasher2, tc())
+			hash2a := hasher2.Sum32()
+
+			if hash1a != hash1 {
+				t.Errorf("repeated hash of the same object (%q) produced different results: %d vs %d", toString(tc()), hash1, hash1a)
+			}
+			if hash2a != hash2 {
+				t.Errorf("repeated hash of the same object (%q) produced different results: %d vs %d", toString(tc()), hash2, hash2a)
+			}
+			if hash1a != hash2a {
+				t.Errorf("hash of the same object produced (%q) different results: %d vs %d", toString(tc()), hash1a, hash2a)
+			}
+		}
+	}
+}
+
+func toString(obj interface{}) string {
+	return spew.Sprintf("%#v", obj)
+}
+
+type wheel struct {
+	radius uint32
+}
+
+type unicycle struct {
+	primaryWheel   *wheel
+	licencePlateID string
+	tags           map[string]string
+}
+
+func TestDeepObjectPointer(t *testing.T) {
+	// Arrange
+	wheel1 := wheel{radius: 17}
+	wheel2 := wheel{radius: 22}
+	wheel3 := wheel{radius: 17}
+
+	myUni1 := unicycle{licencePlateID: "blah", primaryWheel: &wheel1, tags: map[string]string{"color": "blue", "name": "john"}}
+	myUni2 := unicycle{licencePlateID: "blah", primaryWheel: &wheel2, tags: map[string]string{"color": "blue", "name": "john"}}
+	myUni3 := unicycle{licencePlateID: "blah", primaryWheel: &wheel3, tags: map[string]string{"color": "blue", "name": "john"}}
+
+	// Run it more than once to verify determinism of hasher.
+	for i := 0; i < 100; i++ {
+		hasher1 := adler32.New()
+		hasher2 := adler32.New()
+		hasher3 := adler32.New()
+		// Act
+		DeepHashObject(hasher1, myUni1)
+		hash1 := hasher1.Sum32()
+		DeepHashObject(hasher1, myUni1)
+		hash1a := hasher1.Sum32()
+		DeepHashObject(hasher2, myUni2)
+		hash2 := hasher2.Sum32()
+		DeepHashObject(hasher3, myUni3)
+		hash3 := hasher3.Sum32()
+
+		// Assert
+		if hash1 != hash1a {
+			t.Errorf("repeated hash of the same object produced different results: %d vs %d", hash1, hash1a)
+		}
+
+		if hash1 == hash2 {
+			t.Errorf("hash1 (%d) and hash2(%d) must be different because they have different values for wheel size", hash1, hash2)
+		}
+
+		if hash1 != hash3 {
+			t.Errorf("hash1 (%d) and hash3(%d) must be the same because although they point to different objects, they have the same values for wheel size", hash1, hash3)
+		}
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/http.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/http.go
@@ -18,6 +18,7 @@ package util
 
 import (
 	"io"
+	"net/http"
 	"net/url"
 	"strings"
 )
@@ -43,4 +44,21 @@ func IsProbableEOF(err error) bool {
 		return true
 	}
 	return false
+}
+
+var defaultTransport = http.DefaultTransport.(*http.Transport)
+
+// SetTransportDefaults applies the defaults from http.DefaultTransport
+// for the Proxy, Dial, and TLSHandshakeTimeout fields if unset
+func SetTransportDefaults(t *http.Transport) *http.Transport {
+	if t.Proxy == nil {
+		t.Proxy = defaultTransport.Proxy
+	}
+	if t.Dial == nil {
+		t.Dial = defaultTransport.Dial
+	}
+	if t.TLSHandshakeTimeout == 0 {
+		t.TLSHandshakeTimeout = defaultTransport.TLSHandshakeTimeout
+	}
+	return t
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/httpstream/httpstream.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/httpstream/httpstream.go
@@ -78,6 +78,8 @@ type Stream interface {
 	Reset() error
 	// Headers returns the headers used to create the stream.
 	Headers() http.Header
+	// Identifier returns the stream's ID.
+	Identifier() uint32
 }
 
 // IsUpgradeRequest returns true if the given request is a connection upgrade request

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/httpstream/spdy/roundtripper.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/httpstream/spdy/roundtripper.go
@@ -87,6 +87,11 @@ func (s *SpdyRoundTripper) dial(req *http.Request) (net.Conn, error) {
 		return nil, err
 	}
 
+	// Return if we were configured to skip validation
+	if s.tlsConfig != nil && s.tlsConfig.InsecureSkipVerify {
+		return conn, nil
+	}
+
 	host, _, err := net.SplitHostPort(dialAddr)
 	if err != nil {
 		return nil, err

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/httpstream/spdy/roundtripper_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/httpstream/spdy/roundtripper_test.go
@@ -1,0 +1,236 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spdy
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/util/httpstream"
+)
+
+func TestRoundTripAndNewConnection(t *testing.T) {
+
+	localhostPool := x509.NewCertPool()
+	if !localhostPool.AppendCertsFromPEM(localhostCert) {
+		t.Errorf("error setting up localhostCert pool")
+	}
+
+	testCases := map[string]struct {
+		serverFunc             func(http.Handler) *httptest.Server
+		clientTLS              *tls.Config
+		serverConnectionHeader string
+		serverUpgradeHeader    string
+		shouldError            bool
+	}{
+		"no headers": {
+			serverFunc:             httptest.NewServer,
+			serverConnectionHeader: "",
+			serverUpgradeHeader:    "",
+			shouldError:            true,
+		},
+		"no upgrade header": {
+			serverFunc:             httptest.NewServer,
+			serverConnectionHeader: "Upgrade",
+			serverUpgradeHeader:    "",
+			shouldError:            true,
+		},
+		"no connection header": {
+			serverFunc:             httptest.NewServer,
+			serverConnectionHeader: "",
+			serverUpgradeHeader:    "SPDY/3.1",
+			shouldError:            true,
+		},
+		"http": {
+			serverFunc:             httptest.NewServer,
+			serverConnectionHeader: "Upgrade",
+			serverUpgradeHeader:    "SPDY/3.1",
+			shouldError:            false,
+		},
+		"https (invalid hostname + InsecureSkipVerify)": {
+			serverFunc: func(h http.Handler) *httptest.Server {
+				cert, err := tls.X509KeyPair(exampleCert, exampleKey)
+				if err != nil {
+					t.Errorf("https (invalid hostname): proxy_test: %v", err)
+				}
+				ts := httptest.NewUnstartedServer(h)
+				ts.TLS = &tls.Config{
+					Certificates: []tls.Certificate{cert},
+				}
+				ts.StartTLS()
+				return ts
+			},
+			clientTLS:              &tls.Config{InsecureSkipVerify: true},
+			serverConnectionHeader: "Upgrade",
+			serverUpgradeHeader:    "SPDY/3.1",
+			shouldError:            false,
+		},
+		"https (valid hostname + RootCAs)": {
+			serverFunc: func(h http.Handler) *httptest.Server {
+				cert, err := tls.X509KeyPair(localhostCert, localhostKey)
+				if err != nil {
+					t.Errorf("https (valid hostname): proxy_test: %v", err)
+				}
+				ts := httptest.NewUnstartedServer(h)
+				ts.TLS = &tls.Config{
+					Certificates: []tls.Certificate{cert},
+				}
+				ts.StartTLS()
+				return ts
+			},
+			clientTLS:              &tls.Config{RootCAs: localhostPool},
+			serverConnectionHeader: "Upgrade",
+			serverUpgradeHeader:    "SPDY/3.1",
+			shouldError:            false,
+		},
+	}
+
+	for k, testCase := range testCases {
+		server := testCase.serverFunc(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			if testCase.shouldError {
+				if e, a := httpstream.HeaderUpgrade, req.Header.Get(httpstream.HeaderConnection); e != a {
+					t.Fatalf("%s: Expected connection=upgrade header, got '%s", k, a)
+				}
+
+				w.Header().Set(httpstream.HeaderConnection, testCase.serverConnectionHeader)
+				w.Header().Set(httpstream.HeaderUpgrade, testCase.serverUpgradeHeader)
+				w.WriteHeader(http.StatusSwitchingProtocols)
+
+				return
+			}
+
+			streamCh := make(chan httpstream.Stream)
+
+			responseUpgrader := NewResponseUpgrader()
+			spdyConn := responseUpgrader.UpgradeResponse(w, req, func(s httpstream.Stream) error {
+				streamCh <- s
+				return nil
+			})
+			if spdyConn == nil {
+				t.Fatalf("%s: unexpected nil spdyConn", k)
+			}
+			defer spdyConn.Close()
+
+			stream := <-streamCh
+			io.Copy(stream, stream)
+		}))
+		defer server.Close()
+
+		req, err := http.NewRequest("GET", server.URL, nil)
+		if err != nil {
+			t.Fatalf("%s: Error creating request: %s", k, err)
+		}
+
+		spdyTransport := NewRoundTripper(testCase.clientTLS)
+		client := &http.Client{Transport: spdyTransport}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("%s: unexpected error from client.Do: %s", k, err)
+		}
+
+		conn, err := spdyTransport.NewConnection(resp)
+		haveErr := err != nil
+		if e, a := testCase.shouldError, haveErr; e != a {
+			t.Fatalf("%s: shouldError=%t, got %t: %v", k, e, a, err)
+		}
+		if testCase.shouldError {
+			continue
+		}
+		defer conn.Close()
+
+		if resp.StatusCode != http.StatusSwitchingProtocols {
+			t.Fatalf("%s: expected http 101 switching protocols, got %d", k, resp.StatusCode)
+		}
+
+		stream, err := conn.CreateStream(http.Header{})
+		if err != nil {
+			t.Fatalf("%s: error creating client stream: %s", k, err)
+		}
+
+		n, err := stream.Write([]byte("hello"))
+		if err != nil {
+			t.Fatalf("%s: error writing to stream: %s", k, err)
+		}
+		if n != 5 {
+			t.Fatalf("%s: Expected to write 5 bytes, but actually wrote %d", k, n)
+		}
+
+		b := make([]byte, 5)
+		n, err = stream.Read(b)
+		if err != nil {
+			t.Fatalf("%s: error reading from stream: %s", k, err)
+		}
+		if n != 5 {
+			t.Fatalf("%s: Expected to read 5 bytes, but actually read %d", k, n)
+		}
+		if e, a := "hello", string(b[0:n]); e != a {
+			t.Fatalf("%s: expected '%s', got '%s'", k, e, a)
+		}
+	}
+}
+
+// exampleCert was generated from crypto/tls/generate_cert.go with the following command:
+//    go run generate_cert.go  --rsa-bits 512 --host example.com --ca --start-date "Jan 1 00:00:00 1970" --duration=1000000h
+var exampleCert = []byte(`-----BEGIN CERTIFICATE-----
+MIIBcjCCAR6gAwIBAgIQBOUTYowZaENkZi0faI9DgTALBgkqhkiG9w0BAQswEjEQ
+MA4GA1UEChMHQWNtZSBDbzAgFw03MDAxMDEwMDAwMDBaGA8yMDg0MDEyOTE2MDAw
+MFowEjEQMA4GA1UEChMHQWNtZSBDbzBcMA0GCSqGSIb3DQEBAQUAA0sAMEgCQQCZ
+xfR3sgeHBraGFfF/24tTn4PRVAHOf2UOOxSQRs+aYjNqimFqf/SRIblQgeXdBJDR
+gVK5F1Js2zwlehw0bHxRAgMBAAGjUDBOMA4GA1UdDwEB/wQEAwIApDATBgNVHSUE
+DDAKBggrBgEFBQcDATAPBgNVHRMBAf8EBTADAQH/MBYGA1UdEQQPMA2CC2V4YW1w
+bGUuY29tMAsGCSqGSIb3DQEBCwNBAI/mfBB8dm33IpUl+acSyWfL6gX5Wc0FFyVj
+dKeesE1XBuPX1My/rzU6Oy/YwX7LOL4FaeNUS6bbL4axSLPKYSs=
+-----END CERTIFICATE-----`)
+
+var exampleKey = []byte(`-----BEGIN RSA PRIVATE KEY-----
+MIIBOgIBAAJBAJnF9HeyB4cGtoYV8X/bi1Ofg9FUAc5/ZQ47FJBGz5piM2qKYWp/
+9JEhuVCB5d0EkNGBUrkXUmzbPCV6HDRsfFECAwEAAQJBAJLH9yPuButniACTn5L5
+IJQw1mWQt6zBw9eCo41YWkA0866EgjC53aPZaRjXMp0uNJGdIsys2V5rCOOLWN2C
+ODECIQDICHsi8QQQ9wpuJy8X5l8MAfxHL+DIqI84wQTeVM91FQIhAMTME8A18/7h
+1Ad6drdnxAkuC0tX6Sx0LDozrmen+HFNAiAlcEDrt0RVkIcpOrg7tuhPLQf0oudl
+Zvb3Xlj069awSQIgcT15E/43w2+RASifzVNhQ2MCTr1sSA8lL+xzK+REmnUCIBhQ
+j4139pf8Re1J50zBxS/JlQfgDQi9sO9pYeiHIxNs
+-----END RSA PRIVATE KEY-----`)
+
+// localhostCert was generated from crypto/tls/generate_cert.go with the following command:
+//     go run generate_cert.go  --rsa-bits 512 --host 127.0.0.1,::1,example.com --ca --start-date "Jan 1 00:00:00 1970" --duration=1000000h
+var localhostCert = []byte(`-----BEGIN CERTIFICATE-----
+MIIBdzCCASOgAwIBAgIBADALBgkqhkiG9w0BAQUwEjEQMA4GA1UEChMHQWNtZSBD
+bzAeFw03MDAxMDEwMDAwMDBaFw00OTEyMzEyMzU5NTlaMBIxEDAOBgNVBAoTB0Fj
+bWUgQ28wWjALBgkqhkiG9w0BAQEDSwAwSAJBAN55NcYKZeInyTuhcCwFMhDHCmwa
+IUSdtXdcbItRB/yfXGBhiex00IaLXQnSU+QZPRZWYqeTEbFSgihqi1PUDy8CAwEA
+AaNoMGYwDgYDVR0PAQH/BAQDAgCkMBMGA1UdJQQMMAoGCCsGAQUFBwMBMA8GA1Ud
+EwEB/wQFMAMBAf8wLgYDVR0RBCcwJYILZXhhbXBsZS5jb22HBH8AAAGHEAAAAAAA
+AAAAAAAAAAAAAAEwCwYJKoZIhvcNAQEFA0EAAoQn/ytgqpiLcZu9XKbCJsJcvkgk
+Se6AbGXgSlq+ZCEVo0qIwSgeBqmsJxUu7NCSOwVJLYNEBO2DtIxoYVk+MA==
+-----END CERTIFICATE-----`)
+
+// localhostKey is the private key for localhostCert.
+var localhostKey = []byte(`-----BEGIN RSA PRIVATE KEY-----
+MIIBPAIBAAJBAN55NcYKZeInyTuhcCwFMhDHCmwaIUSdtXdcbItRB/yfXGBhiex0
+0IaLXQnSU+QZPRZWYqeTEbFSgihqi1PUDy8CAwEAAQJBAQdUx66rfh8sYsgfdcvV
+NoafYpnEcB5s4m/vSVe6SU7dCK6eYec9f9wpT353ljhDUHq3EbmE4foNzJngh35d
+AekCIQDhRQG5Li0Wj8TM4obOnnXUXf1jRv0UkzE9AHWLG5q3AwIhAPzSjpYUDjVW
+MCUXgckTpKCuGwbJk7424Nb8bLzf3kllAiA5mUBgjfr/WtFSJdWcPQ4Zt9KTMNKD
+EUO0ukpTwEIl6wIhAMbGqZK3zAAFdq8DD2jPx+UJXnh0rnOkZBzDtJ6/iN69AiEA
+1Aq8MJgTaYsDQWyU/hDq5YkDJc9e9DSCvUIzqxQWMQE=
+-----END RSA PRIVATE KEY-----`)

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/httpstream/spdy/upgrade_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/httpstream/spdy/upgrade_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spdy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestUpgradeResponse(t *testing.T) {
+	testCases := []struct {
+		connectionHeader string
+		upgradeHeader    string
+		shouldError      bool
+	}{
+		{
+			connectionHeader: "",
+			upgradeHeader:    "",
+			shouldError:      true,
+		},
+		{
+			connectionHeader: "Upgrade",
+			upgradeHeader:    "",
+			shouldError:      true,
+		},
+		{
+			connectionHeader: "",
+			upgradeHeader:    "SPDY/3.1",
+			shouldError:      true,
+		},
+		{
+			connectionHeader: "Upgrade",
+			upgradeHeader:    "SPDY/3.1",
+			shouldError:      false,
+		},
+	}
+
+	for i, testCase := range testCases {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			upgrader := NewResponseUpgrader()
+			conn := upgrader.UpgradeResponse(w, req, nil)
+			haveErr := conn == nil
+			if e, a := testCase.shouldError, haveErr; e != a {
+				t.Fatalf("%d: expected shouldErr=%t, got %t", i, testCase.shouldError, haveErr)
+			}
+			if haveErr {
+				return
+			}
+			if conn == nil {
+				t.Fatalf("%d: unexpected nil conn", i)
+			}
+			defer conn.Close()
+		}))
+		defer server.Close()
+
+		req, err := http.NewRequest("GET", server.URL, nil)
+		if err != nil {
+			t.Fatalf("%d: error creating request: %s", i, err)
+		}
+
+		req.Header.Set("Connection", testCase.connectionHeader)
+		req.Header.Set("Upgrade", testCase.upgradeHeader)
+
+		client := &http.Client{}
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatalf("%d: unexpected non-nil err from client.Do: %s", i, err)
+		}
+
+		if testCase.shouldError {
+			continue
+		}
+
+		if resp.StatusCode != http.StatusSwitchingProtocols {
+			t.Fatalf("%d: expected status 101 switching protocols, got %d", i, resp.StatusCode)
+		}
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/io/io_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/io/io_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package io_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/pborman/uuid"
+	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/latest"
+	"k8s.io/kubernetes/pkg/util/io"
+	"k8s.io/kubernetes/pkg/volume"
+)
+
+func TestSavePodToFile(t *testing.T) {
+	pod := volume.NewPersistentVolumeRecyclerPodTemplate()
+
+	// sets all default values on a pod for equality comparison after decoding from file
+	encoded, err := latest.GroupOrDie("").Codec.Encode(pod)
+	latest.GroupOrDie("").Codec.DecodeInto(encoded, pod)
+
+	path := fmt.Sprintf("/tmp/kube-io-test-%s", uuid.New())
+	defer os.Remove(path)
+
+	if err := io.SavePodToFile(pod, path, 777); err != nil {
+		t.Fatalf("failed to save pod to file: %v", err)
+	}
+
+	podFromFile, err := io.LoadPodFromFile(path)
+	if err != nil {
+		t.Fatalf("failed to load pod from file: %v", err)
+	}
+	if !api.Semantic.DeepEqual(pod, podFromFile) {
+		t.Errorf("\nexpected %#v\ngot	%#v\n", pod, podFromFile)
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/iptables/iptables.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/iptables/iptables.go
@@ -106,7 +106,7 @@ type RestoreCountersFlag bool
 const RestoreCounters RestoreCountersFlag = true
 const NoRestoreCounters RestoreCountersFlag = false
 
-// Option flag for Restore
+// Option flag for Flush
 type FlushFlag bool
 
 const FlushTables FlushFlag = true
@@ -170,7 +170,7 @@ const (
 func (runner *runner) connectToFirewallD() {
 	bus, err := runner.dbus.SystemBus()
 	if err != nil {
-		glog.V(1).Info("Could not connect to D-Bus system bus: %s", err)
+		glog.V(1).Infof("Could not connect to D-Bus system bus: %s", err)
 		return
 	}
 
@@ -226,7 +226,7 @@ func (runner *runner) DeleteChain(table Table, chain Chain) error {
 	runner.mu.Lock()
 	defer runner.mu.Unlock()
 
-	// TODO: we could call iptable -S first, ignore the output and check for non-zero return (more like DeleteRule)
+	// TODO: we could call iptables -S first, ignore the output and check for non-zero return (more like DeleteRule)
 	out, err := runner.run(opDeleteChain, fullArgs)
 	if err != nil {
 		return fmt.Errorf("error deleting chain %q: %v: %s", chain, err, out)

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/iptables/iptables_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/iptables/iptables_test.go
@@ -1,0 +1,768 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package iptables
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/kubernetes/pkg/util/dbus"
+	"k8s.io/kubernetes/pkg/util/exec"
+	"k8s.io/kubernetes/pkg/util/sets"
+)
+
+func getIptablesCommand(protocol Protocol) string {
+	if protocol == ProtocolIpv4 {
+		return cmdIptables
+	}
+	if protocol == ProtocolIpv6 {
+		return cmdIp6tables
+	}
+	panic("Unknown protocol")
+}
+
+func testEnsureChain(t *testing.T, protocol Protocol) {
+	fcmd := exec.FakeCmd{
+		CombinedOutputScript: []exec.FakeCombinedOutputAction{
+			// iptables version check
+			func() ([]byte, error) { return []byte("iptables v1.9.22"), nil },
+			// Success.
+			func() ([]byte, error) { return []byte{}, nil },
+			// Exists.
+			func() ([]byte, error) { return nil, &exec.FakeExitError{Status: 1} },
+			// Failure.
+			func() ([]byte, error) { return nil, &exec.FakeExitError{Status: 2} },
+		},
+	}
+	fexec := exec.FakeExec{
+		CommandScript: []exec.FakeCommandAction{
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+		},
+	}
+	runner := New(&fexec, dbus.NewFake(nil, nil), protocol)
+	defer runner.Destroy()
+	// Success.
+	exists, err := runner.EnsureChain(TableNAT, Chain("FOOBAR"))
+	if err != nil {
+		t.Errorf("expected success, got %v", err)
+	}
+	if exists {
+		t.Errorf("expected exists = false")
+	}
+	if fcmd.CombinedOutputCalls != 2 {
+		t.Errorf("expected 2 CombinedOutput() calls, got %d", fcmd.CombinedOutputCalls)
+	}
+	cmd := getIptablesCommand(protocol)
+	if !sets.NewString(fcmd.CombinedOutputLog[1]...).HasAll(cmd, "-t", "nat", "-N", "FOOBAR") {
+		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[1])
+	}
+	// Exists.
+	exists, err = runner.EnsureChain(TableNAT, Chain("FOOBAR"))
+	if err != nil {
+		t.Errorf("expected success, got %v", err)
+	}
+	if !exists {
+		t.Errorf("expected exists = true")
+	}
+	// Failure.
+	_, err = runner.EnsureChain(TableNAT, Chain("FOOBAR"))
+	if err == nil {
+		t.Errorf("expected failure")
+	}
+}
+
+func TestEnsureChainIpv4(t *testing.T) {
+	testEnsureChain(t, ProtocolIpv4)
+}
+
+func TestEnsureChainIpv6(t *testing.T) {
+	testEnsureChain(t, ProtocolIpv6)
+}
+
+func TestFlushChain(t *testing.T) {
+	fcmd := exec.FakeCmd{
+		CombinedOutputScript: []exec.FakeCombinedOutputAction{
+			// iptables version check
+			func() ([]byte, error) { return []byte("iptables v1.9.22"), nil },
+			// Success.
+			func() ([]byte, error) { return []byte{}, nil },
+			// Failure.
+			func() ([]byte, error) { return nil, &exec.FakeExitError{Status: 1} },
+		},
+	}
+	fexec := exec.FakeExec{
+		CommandScript: []exec.FakeCommandAction{
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+		},
+	}
+	runner := New(&fexec, dbus.NewFake(nil, nil), ProtocolIpv4)
+	defer runner.Destroy()
+	// Success.
+	err := runner.FlushChain(TableNAT, Chain("FOOBAR"))
+	if err != nil {
+		t.Errorf("expected success, got %v", err)
+	}
+	if fcmd.CombinedOutputCalls != 2 {
+		t.Errorf("expected 2 CombinedOutput() calls, got %d", fcmd.CombinedOutputCalls)
+	}
+	if !sets.NewString(fcmd.CombinedOutputLog[1]...).HasAll("iptables", "-t", "nat", "-F", "FOOBAR") {
+		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[1])
+	}
+	// Failure.
+	err = runner.FlushChain(TableNAT, Chain("FOOBAR"))
+	if err == nil {
+		t.Errorf("expected failure")
+	}
+}
+
+func TestDeleteChain(t *testing.T) {
+	fcmd := exec.FakeCmd{
+		CombinedOutputScript: []exec.FakeCombinedOutputAction{
+			// iptables version check
+			func() ([]byte, error) { return []byte("iptables v1.9.22"), nil },
+			// Success.
+			func() ([]byte, error) { return []byte{}, nil },
+			// Failure.
+			func() ([]byte, error) { return nil, &exec.FakeExitError{Status: 1} },
+		},
+	}
+	fexec := exec.FakeExec{
+		CommandScript: []exec.FakeCommandAction{
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+		},
+	}
+	runner := New(&fexec, dbus.NewFake(nil, nil), ProtocolIpv4)
+	defer runner.Destroy()
+	// Success.
+	err := runner.DeleteChain(TableNAT, Chain("FOOBAR"))
+	if err != nil {
+		t.Errorf("expected success, got %v", err)
+	}
+	if fcmd.CombinedOutputCalls != 2 {
+		t.Errorf("expected 2 CombinedOutput() calls, got %d", fcmd.CombinedOutputCalls)
+	}
+	if !sets.NewString(fcmd.CombinedOutputLog[1]...).HasAll("iptables", "-t", "nat", "-X", "FOOBAR") {
+		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[1])
+	}
+	// Failure.
+	err = runner.DeleteChain(TableNAT, Chain("FOOBAR"))
+	if err == nil {
+		t.Errorf("expected failure")
+	}
+}
+
+func TestEnsureRuleAlreadyExists(t *testing.T) {
+	fcmd := exec.FakeCmd{
+		CombinedOutputScript: []exec.FakeCombinedOutputAction{
+			// iptables version check
+			func() ([]byte, error) { return []byte("iptables v1.9.22"), nil },
+			// Success.
+			func() ([]byte, error) { return []byte{}, nil },
+		},
+	}
+	fexec := exec.FakeExec{
+		CommandScript: []exec.FakeCommandAction{
+			// iptables version check
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+			// The second Command() call is checking the rule.  Success of that exec means "done".
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+		},
+	}
+	runner := New(&fexec, dbus.NewFake(nil, nil), ProtocolIpv4)
+	defer runner.Destroy()
+	exists, err := runner.EnsureRule(Append, TableNAT, ChainOutput, "abc", "123")
+	if err != nil {
+		t.Errorf("expected success, got %v", err)
+	}
+	if !exists {
+		t.Errorf("expected exists = true")
+	}
+	if fcmd.CombinedOutputCalls != 2 {
+		t.Errorf("expected 2 CombinedOutput() calls, got %d", fcmd.CombinedOutputCalls)
+	}
+	if !sets.NewString(fcmd.CombinedOutputLog[1]...).HasAll("iptables", "-t", "nat", "-C", "OUTPUT", "abc", "123") {
+		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[1])
+	}
+}
+
+func TestEnsureRuleNew(t *testing.T) {
+	fcmd := exec.FakeCmd{
+		CombinedOutputScript: []exec.FakeCombinedOutputAction{
+			// iptables version check
+			func() ([]byte, error) { return []byte("iptables v1.9.22"), nil },
+			// Status 1 on the first call.
+			func() ([]byte, error) { return nil, &exec.FakeExitError{Status: 1} },
+			// Success on the second call.
+			func() ([]byte, error) { return []byte{}, nil },
+		},
+	}
+	fexec := exec.FakeExec{
+		CommandScript: []exec.FakeCommandAction{
+			// iptables version check
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+			// The second Command() call is checking the rule.  Failure of that means create it.
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+		},
+	}
+	runner := New(&fexec, dbus.NewFake(nil, nil), ProtocolIpv4)
+	defer runner.Destroy()
+	exists, err := runner.EnsureRule(Append, TableNAT, ChainOutput, "abc", "123")
+	if err != nil {
+		t.Errorf("expected success, got %v", err)
+	}
+	if exists {
+		t.Errorf("expected exists = false")
+	}
+	if fcmd.CombinedOutputCalls != 3 {
+		t.Errorf("expected 3 CombinedOutput() calls, got %d", fcmd.CombinedOutputCalls)
+	}
+	if !sets.NewString(fcmd.CombinedOutputLog[2]...).HasAll("iptables", "-t", "nat", "-A", "OUTPUT", "abc", "123") {
+		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[2])
+	}
+}
+
+func TestEnsureRuleErrorChecking(t *testing.T) {
+	fcmd := exec.FakeCmd{
+		CombinedOutputScript: []exec.FakeCombinedOutputAction{
+			// iptables version check
+			func() ([]byte, error) { return []byte("iptables v1.9.22"), nil },
+			// Status 2 on the first call.
+			func() ([]byte, error) { return nil, &exec.FakeExitError{Status: 2} },
+		},
+	}
+	fexec := exec.FakeExec{
+		CommandScript: []exec.FakeCommandAction{
+			// iptables version check
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+			// The second Command() call is checking the rule.  Failure of that means create it.
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+		},
+	}
+	runner := New(&fexec, dbus.NewFake(nil, nil), ProtocolIpv4)
+	defer runner.Destroy()
+	_, err := runner.EnsureRule(Append, TableNAT, ChainOutput, "abc", "123")
+	if err == nil {
+		t.Errorf("expected failure")
+	}
+	if fcmd.CombinedOutputCalls != 2 {
+		t.Errorf("expected 2 CombinedOutput() calls, got %d", fcmd.CombinedOutputCalls)
+	}
+}
+
+func TestEnsureRuleErrorCreating(t *testing.T) {
+	fcmd := exec.FakeCmd{
+		CombinedOutputScript: []exec.FakeCombinedOutputAction{
+			// iptables version check
+			func() ([]byte, error) { return []byte("iptables v1.9.22"), nil },
+			// Status 1 on the first call.
+			func() ([]byte, error) { return nil, &exec.FakeExitError{Status: 1} },
+			// Status 1 on the second call.
+			func() ([]byte, error) { return nil, &exec.FakeExitError{Status: 1} },
+		},
+	}
+	fexec := exec.FakeExec{
+		CommandScript: []exec.FakeCommandAction{
+			// iptables version check
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+			// The second Command() call is checking the rule.  Failure of that means create it.
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+		},
+	}
+	runner := New(&fexec, dbus.NewFake(nil, nil), ProtocolIpv4)
+	defer runner.Destroy()
+	_, err := runner.EnsureRule(Append, TableNAT, ChainOutput, "abc", "123")
+	if err == nil {
+		t.Errorf("expected failure")
+	}
+	if fcmd.CombinedOutputCalls != 3 {
+		t.Errorf("expected 3 CombinedOutput() calls, got %d", fcmd.CombinedOutputCalls)
+	}
+}
+
+func TestDeleteRuleAlreadyExists(t *testing.T) {
+	fcmd := exec.FakeCmd{
+		CombinedOutputScript: []exec.FakeCombinedOutputAction{
+			// iptables version check
+			func() ([]byte, error) { return []byte("iptables v1.9.22"), nil },
+			// Status 1 on the first call.
+			func() ([]byte, error) { return nil, &exec.FakeExitError{Status: 1} },
+		},
+	}
+	fexec := exec.FakeExec{
+		CommandScript: []exec.FakeCommandAction{
+			// iptables version check
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+			// The second Command() call is checking the rule.  Failure of that exec means "does not exist".
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+		},
+	}
+	runner := New(&fexec, dbus.NewFake(nil, nil), ProtocolIpv4)
+	defer runner.Destroy()
+	err := runner.DeleteRule(TableNAT, ChainOutput, "abc", "123")
+	if err != nil {
+		t.Errorf("expected success, got %v", err)
+	}
+	if fcmd.CombinedOutputCalls != 2 {
+		t.Errorf("expected 2 CombinedOutput() calls, got %d", fcmd.CombinedOutputCalls)
+	}
+	if !sets.NewString(fcmd.CombinedOutputLog[1]...).HasAll("iptables", "-t", "nat", "-C", "OUTPUT", "abc", "123") {
+		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[1])
+	}
+}
+
+func TestDeleteRuleNew(t *testing.T) {
+	fcmd := exec.FakeCmd{
+		CombinedOutputScript: []exec.FakeCombinedOutputAction{
+			// iptables version check
+			func() ([]byte, error) { return []byte("iptables v1.9.22"), nil },
+			// Success on the first call.
+			func() ([]byte, error) { return []byte{}, nil },
+			// Success on the second call.
+			func() ([]byte, error) { return []byte{}, nil },
+		},
+	}
+	fexec := exec.FakeExec{
+		CommandScript: []exec.FakeCommandAction{
+			// iptables version check
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+			// The second Command() call is checking the rule.  Success of that means delete it.
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+		},
+	}
+	runner := New(&fexec, dbus.NewFake(nil, nil), ProtocolIpv4)
+	defer runner.Destroy()
+	err := runner.DeleteRule(TableNAT, ChainOutput, "abc", "123")
+	if err != nil {
+		t.Errorf("expected success, got %v", err)
+	}
+	if fcmd.CombinedOutputCalls != 3 {
+		t.Errorf("expected 3 CombinedOutput() calls, got %d", fcmd.CombinedOutputCalls)
+	}
+	if !sets.NewString(fcmd.CombinedOutputLog[2]...).HasAll("iptables", "-t", "nat", "-D", "OUTPUT", "abc", "123") {
+		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[2])
+	}
+}
+
+func TestDeleteRuleErrorChecking(t *testing.T) {
+	fcmd := exec.FakeCmd{
+		CombinedOutputScript: []exec.FakeCombinedOutputAction{
+			// iptables version check
+			func() ([]byte, error) { return []byte("iptables v1.9.22"), nil },
+			// Status 2 on the first call.
+			func() ([]byte, error) { return nil, &exec.FakeExitError{Status: 2} },
+		},
+	}
+	fexec := exec.FakeExec{
+		CommandScript: []exec.FakeCommandAction{
+			// iptables version check
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+			// The second Command() call is checking the rule.  Failure of that means create it.
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+		},
+	}
+	runner := New(&fexec, dbus.NewFake(nil, nil), ProtocolIpv4)
+	defer runner.Destroy()
+	err := runner.DeleteRule(TableNAT, ChainOutput, "abc", "123")
+	if err == nil {
+		t.Errorf("expected failure")
+	}
+	if fcmd.CombinedOutputCalls != 2 {
+		t.Errorf("expected 2 CombinedOutput() calls, got %d", fcmd.CombinedOutputCalls)
+	}
+}
+
+func TestDeleteRuleErrorCreating(t *testing.T) {
+	fcmd := exec.FakeCmd{
+		CombinedOutputScript: []exec.FakeCombinedOutputAction{
+			// iptables version check
+			func() ([]byte, error) { return []byte("iptables v1.9.22"), nil },
+			// Success on the first call.
+			func() ([]byte, error) { return []byte{}, nil },
+			// Status 1 on the second call.
+			func() ([]byte, error) { return nil, &exec.FakeExitError{Status: 1} },
+		},
+	}
+	fexec := exec.FakeExec{
+		CommandScript: []exec.FakeCommandAction{
+			// iptables version check
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+			// The second Command() call is checking the rule.  Success of that means delete it.
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+		},
+	}
+	runner := New(&fexec, dbus.NewFake(nil, nil), ProtocolIpv4)
+	defer runner.Destroy()
+	err := runner.DeleteRule(TableNAT, ChainOutput, "abc", "123")
+	if err == nil {
+		t.Errorf("expected failure")
+	}
+	if fcmd.CombinedOutputCalls != 3 {
+		t.Errorf("expected 3 CombinedOutput() calls, got %d", fcmd.CombinedOutputCalls)
+	}
+}
+
+func TestGetIptablesHasCheckCommand(t *testing.T) {
+	testCases := []struct {
+		Version  string
+		Err      bool
+		Expected bool
+	}{
+		{"iptables v1.4.7", false, false},
+		{"iptables v1.4.11", false, true},
+		{"iptables v1.4.19.1", false, true},
+		{"iptables v2.0.0", false, true},
+		{"total junk", true, false},
+	}
+
+	for _, testCase := range testCases {
+		fcmd := exec.FakeCmd{
+			CombinedOutputScript: []exec.FakeCombinedOutputAction{
+				func() ([]byte, error) { return []byte(testCase.Version), nil },
+			},
+		}
+		fexec := exec.FakeExec{
+			CommandScript: []exec.FakeCommandAction{
+				func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+			},
+		}
+		version, err := GetIptablesVersionString(&fexec)
+		if (err != nil) != testCase.Err {
+			t.Errorf("Expected error: %v, Got error: %v", testCase.Err, err)
+		}
+		if err == nil {
+			check := getIptablesHasCheckCommand(version)
+			if testCase.Expected != check {
+				t.Errorf("Expected result: %v, Got result: %v", testCase.Expected, check)
+			}
+		}
+	}
+}
+
+func TestCheckRuleWithoutCheckPresent(t *testing.T) {
+	iptables_save_output := `# Generated by iptables-save v1.4.7 on Wed Oct 29 14:56:01 2014
+*nat
+:PREROUTING ACCEPT [2136997:197881818]
+:POSTROUTING ACCEPT [4284525:258542680]
+:OUTPUT ACCEPT [5901660:357267963]
+-A PREROUTING -m addrtype --dst-type LOCAL -j DOCKER
+COMMIT
+# Completed on Wed Oct 29 14:56:01 2014`
+
+	fcmd := exec.FakeCmd{
+		CombinedOutputScript: []exec.FakeCombinedOutputAction{
+			// Success.
+			func() ([]byte, error) { return []byte(iptables_save_output), nil },
+		},
+	}
+	fexec := exec.FakeExec{
+		CommandScript: []exec.FakeCommandAction{
+			// The first Command() call is checking the rule.  Success of that exec means "done".
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+		},
+	}
+	runner := &runner{exec: &fexec}
+	exists, err := runner.checkRuleWithoutCheck(TableNAT, ChainPrerouting, "-m", "addrtype", "-j", "DOCKER", "--dst-type", "LOCAL")
+	if err != nil {
+		t.Errorf("expected success, got %v", err)
+	}
+	if !exists {
+		t.Errorf("expected exists = true")
+	}
+	if fcmd.CombinedOutputCalls != 1 {
+		t.Errorf("expected 1 CombinedOutput() call, got %d", fcmd.CombinedOutputCalls)
+	}
+	if !sets.NewString(fcmd.CombinedOutputLog[0]...).HasAll("iptables-save", "-t", "nat") {
+		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[0])
+	}
+}
+
+func TestCheckRuleWithoutCheckAbsent(t *testing.T) {
+	iptables_save_output := `# Generated by iptables-save v1.4.7 on Wed Oct 29 14:56:01 2014
+*nat
+:PREROUTING ACCEPT [2136997:197881818]
+:POSTROUTING ACCEPT [4284525:258542680]
+:OUTPUT ACCEPT [5901660:357267963]
+-A PREROUTING -m addrtype --dst-type LOCAL -j DOCKER
+COMMIT
+# Completed on Wed Oct 29 14:56:01 2014`
+
+	fcmd := exec.FakeCmd{
+		CombinedOutputScript: []exec.FakeCombinedOutputAction{
+			// Success.
+			func() ([]byte, error) { return []byte(iptables_save_output), nil },
+		},
+	}
+	fexec := exec.FakeExec{
+		CommandScript: []exec.FakeCommandAction{
+			// The first Command() call is checking the rule.  Success of that exec means "done".
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+		},
+	}
+	runner := &runner{exec: &fexec}
+	exists, err := runner.checkRuleWithoutCheck(TableNAT, ChainPrerouting, "-m", "addrtype", "-j", "DOCKER")
+	if err != nil {
+		t.Errorf("expected success, got %v", err)
+	}
+	if exists {
+		t.Errorf("expected exists = false")
+	}
+	if fcmd.CombinedOutputCalls != 1 {
+		t.Errorf("expected 1 CombinedOutput() call, got %d", fcmd.CombinedOutputCalls)
+	}
+	if !sets.NewString(fcmd.CombinedOutputLog[0]...).HasAll("iptables-save", "-t", "nat") {
+		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[0])
+	}
+}
+
+func TestIptablesWaitFlag(t *testing.T) {
+	testCases := []struct {
+		Version string
+		Result  string
+	}{
+		{"0.55.55", ""},
+		{"1.0.55", ""},
+		{"1.4.19", ""},
+		{"1.4.20", "-w"},
+		{"1.4.21", "-w"},
+		{"1.4.22", "-w2"},
+		{"1.5.0", "-w2"},
+		{"2.0.0", "-w2"},
+	}
+
+	for _, testCase := range testCases {
+		result := getIptablesWaitFlag(testCase.Version)
+		if strings.Join(result, "") != testCase.Result {
+			t.Errorf("For %s expected %v got %v", testCase.Version, testCase.Result, result)
+		}
+	}
+}
+
+func TestWaitFlagUnavailable(t *testing.T) {
+	fcmd := exec.FakeCmd{
+		CombinedOutputScript: []exec.FakeCombinedOutputAction{
+			// iptables version check
+			func() ([]byte, error) { return []byte("iptables v1.4.19"), nil },
+			// Success.
+			func() ([]byte, error) { return []byte{}, nil },
+		},
+	}
+	fexec := exec.FakeExec{
+		CommandScript: []exec.FakeCommandAction{
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+		},
+	}
+	runner := New(&fexec, dbus.NewFake(nil, nil), ProtocolIpv4)
+	defer runner.Destroy()
+	err := runner.DeleteChain(TableNAT, Chain("FOOBAR"))
+	if err != nil {
+		t.Errorf("expected success, got %v", err)
+	}
+	if fcmd.CombinedOutputCalls != 2 {
+		t.Errorf("expected 2 CombinedOutput() calls, got %d", fcmd.CombinedOutputCalls)
+	}
+	if sets.NewString(fcmd.CombinedOutputLog[1]...).HasAny("-w", "-w2") {
+		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[1])
+	}
+}
+
+func TestWaitFlagOld(t *testing.T) {
+	fcmd := exec.FakeCmd{
+		CombinedOutputScript: []exec.FakeCombinedOutputAction{
+			// iptables version check
+			func() ([]byte, error) { return []byte("iptables v1.4.20"), nil },
+			// Success.
+			func() ([]byte, error) { return []byte{}, nil },
+		},
+	}
+	fexec := exec.FakeExec{
+		CommandScript: []exec.FakeCommandAction{
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+		},
+	}
+	runner := New(&fexec, dbus.NewFake(nil, nil), ProtocolIpv4)
+	defer runner.Destroy()
+	err := runner.DeleteChain(TableNAT, Chain("FOOBAR"))
+	if err != nil {
+		t.Errorf("expected success, got %v", err)
+	}
+	if fcmd.CombinedOutputCalls != 2 {
+		t.Errorf("expected 2 CombinedOutput() calls, got %d", fcmd.CombinedOutputCalls)
+	}
+	if !sets.NewString(fcmd.CombinedOutputLog[1]...).HasAll("iptables", "-w") {
+		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[1])
+	}
+	if sets.NewString(fcmd.CombinedOutputLog[1]...).HasAny("-w2") {
+		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[1])
+	}
+}
+
+func TestWaitFlagNew(t *testing.T) {
+	fcmd := exec.FakeCmd{
+		CombinedOutputScript: []exec.FakeCombinedOutputAction{
+			// iptables version check
+			func() ([]byte, error) { return []byte("iptables v1.4.22"), nil },
+			// Success.
+			func() ([]byte, error) { return []byte{}, nil },
+		},
+	}
+	fexec := exec.FakeExec{
+		CommandScript: []exec.FakeCommandAction{
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+		},
+	}
+	runner := New(&fexec, dbus.NewFake(nil, nil), ProtocolIpv4)
+	defer runner.Destroy()
+	err := runner.DeleteChain(TableNAT, Chain("FOOBAR"))
+	if err != nil {
+		t.Errorf("expected success, got %v", err)
+	}
+	if fcmd.CombinedOutputCalls != 2 {
+		t.Errorf("expected 2 CombinedOutput() calls, got %d", fcmd.CombinedOutputCalls)
+	}
+	if !sets.NewString(fcmd.CombinedOutputLog[1]...).HasAll("iptables", "-w2") {
+		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[1])
+	}
+	if sets.NewString(fcmd.CombinedOutputLog[1]...).HasAny("-w") {
+		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[1])
+	}
+}
+
+func TestReload(t *testing.T) {
+	dbusConn := dbus.NewFakeConnection()
+	dbusConn.SetBusObject(func(method string, args ...interface{}) ([]interface{}, error) { return nil, nil })
+	dbusConn.AddObject(firewalldName, firewalldPath, func(method string, args ...interface{}) ([]interface{}, error) { return nil, nil })
+	fdbus := dbus.NewFake(dbusConn, nil)
+
+	reloaded := make(chan bool, 2)
+
+	fcmd := exec.FakeCmd{
+		CombinedOutputScript: []exec.FakeCombinedOutputAction{
+			// iptables version check
+			func() ([]byte, error) { return []byte("iptables v1.4.22"), nil },
+
+			// first reload
+			// EnsureChain
+			func() ([]byte, error) { return []byte{}, nil },
+			// EnsureRule abc check
+			func() ([]byte, error) { return []byte{}, &exec.FakeExitError{1} },
+			// EnsureRule abc
+			func() ([]byte, error) { return []byte{}, nil },
+
+			// second reload
+			// EnsureChain
+			func() ([]byte, error) { return []byte{}, nil },
+			// EnsureRule abc check
+			func() ([]byte, error) { return []byte{}, &exec.FakeExitError{1} },
+			// EnsureRule abc
+			func() ([]byte, error) { return []byte{}, nil },
+		},
+	}
+	fexec := exec.FakeExec{
+		CommandScript: []exec.FakeCommandAction{
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+			func(cmd string, args ...string) exec.Cmd { return exec.InitFakeCmd(&fcmd, cmd, args...) },
+		},
+	}
+
+	runner := New(&fexec, fdbus, ProtocolIpv4)
+	defer runner.Destroy()
+
+	runner.AddReloadFunc(func() {
+		exists, err := runner.EnsureChain(TableNAT, Chain("FOOBAR"))
+		if err != nil {
+			t.Errorf("expected success, got %v", err)
+		}
+		if exists {
+			t.Errorf("expected exists = false")
+		}
+		reloaded <- true
+	})
+
+	runner.AddReloadFunc(func() {
+		exists, err := runner.EnsureRule(Append, TableNAT, ChainOutput, "abc", "123")
+		if err != nil {
+			t.Errorf("expected success, got %v", err)
+		}
+		if exists {
+			t.Errorf("expected exists = false")
+		}
+		reloaded <- true
+	})
+
+	dbusConn.EmitSignal("org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus", "NameOwnerChanged", firewalldName, "", ":1.1")
+	<-reloaded
+	<-reloaded
+
+	if fcmd.CombinedOutputCalls != 4 {
+		t.Errorf("expected 4 CombinedOutput() calls total, got %d", fcmd.CombinedOutputCalls)
+	}
+	if !sets.NewString(fcmd.CombinedOutputLog[1]...).HasAll("iptables", "-t", "nat", "-N", "FOOBAR") {
+		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[1])
+	}
+	if !sets.NewString(fcmd.CombinedOutputLog[2]...).HasAll("iptables", "-t", "nat", "-C", "OUTPUT", "abc", "123") {
+		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[2])
+	}
+	if !sets.NewString(fcmd.CombinedOutputLog[3]...).HasAll("iptables", "-t", "nat", "-A", "OUTPUT", "abc", "123") {
+		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[3])
+	}
+
+	go func() { time.Sleep(time.Second / 100); reloaded <- true }()
+	dbusConn.EmitSignal(firewalldName, firewalldPath, firewalldInterface, "DefaultZoneChanged", "public")
+	dbusConn.EmitSignal("org.freedesktop.DBus", "/org/freedesktop/DBus", "org.freedesktop.DBus", "NameOwnerChanged", "io.k8s.Something", "", ":1.1")
+	<-reloaded
+
+	if fcmd.CombinedOutputCalls != 4 {
+		t.Errorf("Incorrect signal caused a reload")
+	}
+
+	dbusConn.EmitSignal(firewalldName, firewalldPath, firewalldInterface, "Reloaded")
+	<-reloaded
+	<-reloaded
+
+	if fcmd.CombinedOutputCalls != 7 {
+		t.Errorf("expected 7 CombinedOutput() calls total, got %d", fcmd.CombinedOutputCalls)
+	}
+	if !sets.NewString(fcmd.CombinedOutputLog[4]...).HasAll("iptables", "-t", "nat", "-N", "FOOBAR") {
+		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[4])
+	}
+	if !sets.NewString(fcmd.CombinedOutputLog[5]...).HasAll("iptables", "-t", "nat", "-C", "OUTPUT", "abc", "123") {
+		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[5])
+	}
+	if !sets.NewString(fcmd.CombinedOutputLog[6]...).HasAll("iptables", "-t", "nat", "-A", "OUTPUT", "abc", "123") {
+		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[6])
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/jsonpath/jsonpath_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/jsonpath/jsonpath_test.go
@@ -1,0 +1,254 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jsonpath
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+)
+
+type jsonpathTest struct {
+	name     string
+	template string
+	input    interface{}
+	expect   string
+}
+
+func testJSONPath(tests []jsonpathTest, t *testing.T) {
+	for _, test := range tests {
+		j := New(test.name)
+		err := j.Parse(test.template)
+		if err != nil {
+			t.Errorf("in %s, parse %s error %v", test.name, test.template, err)
+		}
+		buf := new(bytes.Buffer)
+		err = j.Execute(buf, test.input)
+		if err != nil {
+			t.Errorf("in %s, execute error %v", test.name, err)
+		}
+		out := buf.String()
+		if out != test.expect {
+			t.Errorf(`in %s, expect to get "%s", got "%s"`, test.name, test.expect, out)
+		}
+	}
+}
+
+// testJSONPathSortOutput test testcases related to map, the results may print in random order
+func testJSONPathSortOutput(tests []jsonpathTest, t *testing.T) {
+	for _, test := range tests {
+		j := New(test.name)
+		err := j.Parse(test.template)
+		if err != nil {
+			t.Errorf("in %s, parse %s error %v", test.name, test.template, err)
+		}
+		buf := new(bytes.Buffer)
+		err = j.Execute(buf, test.input)
+		if err != nil {
+			t.Errorf("in %s, execute error %v", test.name, err)
+		}
+		out := buf.String()
+		//since map is itereated in random order, we need to sort the results.
+		sortedOut := strings.Fields(out)
+		sort.Strings(sortedOut)
+		sortedExpect := strings.Fields(test.expect)
+		sort.Strings(sortedExpect)
+		if !reflect.DeepEqual(sortedOut, sortedExpect) {
+			t.Errorf(`in %s, expect to get "%s", got "%s"`, test.name, test.expect, out)
+		}
+	}
+}
+
+func testFailJSONPath(tests []jsonpathTest, t *testing.T) {
+	for _, test := range tests {
+		j := New(test.name)
+		err := j.Parse(test.template)
+		if err != nil {
+			t.Errorf("in %s, parse %s error %v", test.name, test.template, err)
+		}
+		buf := new(bytes.Buffer)
+		err = j.Execute(buf, test.input)
+		var out string
+		if err == nil {
+			out = "nil"
+		} else {
+			out = err.Error()
+		}
+		if out != test.expect {
+			t.Errorf("in %s, expect to get error %s, got %s", test.name, test.expect, out)
+		}
+	}
+}
+
+type book struct {
+	Category string
+	Author   string
+	Title    string
+	Price    float32
+}
+
+func (b book) String() string {
+	return fmt.Sprintf("{Category: %s, Author: %s, Title: %s, Price: %v}", b.Category, b.Author, b.Title, b.Price)
+}
+
+type bicycle struct {
+	Color string
+	Price float32
+}
+
+type store struct {
+	Book    []book
+	Bicycle bicycle
+	Name    string
+	Labels  map[string]int
+}
+
+func TestStructInput(t *testing.T) {
+
+	storeData := store{
+		Name: "jsonpath",
+		Book: []book{
+			{"reference", "Nigel Rees", "Sayings of the Centurey", 8.95},
+			{"fiction", "Evelyn Waugh", "Sword of Honour", 12.99},
+			{"fiction", "Herman Melville", "Moby Dick", 8.99},
+		},
+		Bicycle: bicycle{"red", 19.95},
+		Labels: map[string]int{
+			"engieer":  10,
+			"web/html": 15,
+			"k8s-app":  20,
+		},
+	}
+
+	storeTests := []jsonpathTest{
+		{"plain", "hello jsonpath", nil, "hello jsonpath"},
+		{"recursive", "{..}", []int{1, 2, 3}, "[1 2 3]"},
+		{"filter", "{[?(@<5)]}", []int{2, 6, 3, 7}, "2 3"},
+		{"quote", `{"{"}`, nil, "{"},
+		{"union", "{[1,3,4]}", []int{0, 1, 2, 3, 4}, "1 3 4"},
+		{"array", "{[0:2]}", []string{"Monday", "Tudesday"}, "Monday Tudesday"},
+		{"variable", "hello {.Name}", storeData, "hello jsonpath"},
+		{"dict/", "{$.Labels.web/html}", storeData, "15"},
+		{"dict-", "{.Labels.k8s-app}", storeData, "20"},
+		{"nest", "{.Bicycle.Color}", storeData, "red"},
+		{"allarray", "{.Book[*].Author}", storeData, "Nigel Rees Evelyn Waugh Herman Melville"},
+		{"allfileds", "{.Bicycle.*}", storeData, "red 19.95"},
+		{"recurfileds", "{..Price}", storeData, "8.95 12.99 8.99 19.95"},
+		{"lastarray", "{.Book[-1:]}", storeData,
+			"{Category: fiction, Author: Herman Melville, Title: Moby Dick, Price: 8.99}"},
+		{"recurarray", "{..Book[2]}", storeData,
+			"{Category: fiction, Author: Herman Melville, Title: Moby Dick, Price: 8.99}"},
+	}
+	testJSONPath(storeTests, t)
+
+	failStoreTests := []jsonpathTest{
+		{"invalid identfier", "{hello}", storeData, "unrecongnized identifier hello"},
+		{"nonexistent field", "{.hello}", storeData, "hello is not found"},
+		{"invalid array", "{.Labels[0]}", storeData, "map[string]int is not array or slice"},
+		{"invalid filter operator", "{.Book[?(@.Price<>10)]}", storeData, "unrecognized filter operator <>"},
+		{"redundent end", "{range .Labels.*}{@}{end}{end}", storeData, "not in range, nothing to end"},
+	}
+	testFailJSONPath(failStoreTests, t)
+}
+
+func TestJSONInput(t *testing.T) {
+	var pointsJSON = []byte(`[
+		{"id": "i1", "x":4, "y":-5},
+		{"id": "i2", "x":-2, "y":-5, "z":1},
+		{"id": "i3", "x":  8, "y":  3 },
+		{"id": "i4", "x": -6, "y": -1 },
+		{"id": "i5", "x":  0, "y":  2, "z": 1 },
+		{"id": "i6", "x":  1, "y":  4 }
+	]`)
+	var pointsData interface{}
+	err := json.Unmarshal(pointsJSON, &pointsData)
+	if err != nil {
+		t.Error(err)
+	}
+	pointsTests := []jsonpathTest{
+		{"exists filter", "{[?(@.z)].id}", pointsData, "i2 i5"},
+		{"bracket key", "{[0]['id']}", pointsData, "i1"},
+	}
+	testJSONPath(pointsTests, t)
+}
+
+// TestKubenates tests some use cases from kubenates
+func TestKubenates(t *testing.T) {
+	var input = []byte(`{
+	  "kind": "List",
+	  "items":[
+		{
+		  "kind":"None",
+		  "metadata":{"name":"127.0.0.1"},
+		  "status":{
+			"capacity":{"cpu":"4"},
+			"addresses":[{"type": "LegacyHostIP", "address":"127.0.0.1"}]
+		  }
+		},
+		{
+		  "kind":"None",
+		  "metadata":{"name":"127.0.0.2"},
+		  "status":{
+			"capacity":{"cpu":"8"},
+			"addresses":[
+			  {"type": "LegacyHostIP", "address":"127.0.0.2"},
+			  {"type": "another", "address":"127.0.0.3"}
+			]
+		  }
+		}
+	  ],
+	  "users":[
+	    {
+	      "name": "myself",
+	      "user": {}
+	    },
+	    {
+	      "name": "e2e",
+	      "user": {"username": "admin", "password": "secret"}
+	  	}
+	  ]
+	}`)
+	var nodesData interface{}
+	err := json.Unmarshal(input, &nodesData)
+	if err != nil {
+		t.Error(err)
+	}
+
+	nodesTests := []jsonpathTest{
+		{"range item", "{range .items[*]}{.metadata.name}, {end}{.kind}", nodesData, `127.0.0.1, 127.0.0.2, List`},
+		{"range addresss", "{.items[*].status.addresses[*].address}", nodesData,
+			`127.0.0.1 127.0.0.2 127.0.0.3`},
+		{"double range", "{range .items[*]}{range .status.addresses[*]}{.address}, {end}{end}", nodesData,
+			`127.0.0.1, 127.0.0.2, 127.0.0.3, `},
+		{"item name", "{.items[*].metadata.name}", nodesData, `127.0.0.1 127.0.0.2`},
+		{"union nodes capacity", "{.items[*]['metadata.name', 'status.capacity']}", nodesData,
+			`127.0.0.1 127.0.0.2 map[cpu:4] map[cpu:8]`},
+		{"range nodes capacity", "{range .items[*]}[{.metadata.name}, {.status.capacity}] {end}", nodesData,
+			`[127.0.0.1, map[cpu:4]] [127.0.0.2, map[cpu:8]] `},
+		{"user password", `{.users[?(@.name=="e2e")].user.password}`, &nodesData, "secret"},
+	}
+	testJSONPath(nodesTests, t)
+
+	randomPrintOrderTests := []jsonpathTest{
+		{"recursive name", "{..name}", nodesData, `127.0.0.1 127.0.0.2 myself e2e`},
+	}
+	testJSONPathSortOutput(randomPrintOrderTests, t)
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/jsonpath/parser_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/jsonpath/parser_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package jsonpath
+
+import (
+	"testing"
+)
+
+type parserTest struct {
+	name  string
+	text  string
+	nodes []Node
+}
+
+var parserTests = []parserTest{
+	{"plain", `hello jsonpath`, []Node{newText("hello jsonpath")}},
+	{"variable", `hello {.jsonpath}`,
+		[]Node{newText("hello "), newList(), newField("jsonpath")}},
+	{"arrayfiled", `hello {['jsonpath']}`,
+		[]Node{newText("hello "), newList(), newField("jsonpath")}},
+	{"quote", `{"{"}`, []Node{newList(), newText("{")}},
+	{"array", `{[1:3]}`, []Node{newList(),
+		newArray([3]ParamsEntry{{1, true}, {3, true}, {0, false}})}},
+	{"allarray", `{.book[*].author}`,
+		[]Node{newList(), newField("book"),
+			newArray([3]ParamsEntry{{0, false}, {0, false}, {0, false}}), newField("author")}},
+	{"wildcard", `{.bicycle.*}`,
+		[]Node{newList(), newField("bicycle"), newWildcard()}},
+	{"filter", `{[?(@.price<3)]}`,
+		[]Node{newList(), newFilter(newList(), newList(), "<"),
+			newList(), newField("price"), newList(), newInt(3)}},
+	{"recursive", `{..}`, []Node{newList(), newRecursive()}},
+	{"recurField", `{..price}`,
+		[]Node{newList(), newRecursive(), newField("price")}},
+	{"arraydict", `{['book.price']}`, []Node{newList(),
+		newField("book"), newField("price"),
+	}},
+	{"union", `{['bicycle.price', 3, 'book.price']}`, []Node{newList(), newUnion([]*ListNode{}),
+		newList(), newField("bicycle"), newField("price"),
+		newList(), newArray([3]ParamsEntry{{3, true}, {4, true}, {0, false}}),
+		newList(), newField("book"), newField("price"),
+	}},
+	{"range", `{range .items}{.name},{end}`, []Node{
+		newList(), newIdentifier("range"), newField("items"),
+		newList(), newField("name"), newText(","),
+		newList(), newIdentifier("end"),
+	}},
+}
+
+func collectNode(nodes []Node, cur Node) []Node {
+	nodes = append(nodes, cur)
+	switch cur.Type() {
+	case NodeList:
+		for _, node := range cur.(*ListNode).Nodes {
+			nodes = collectNode(nodes, node)
+		}
+	case NodeFilter:
+		nodes = collectNode(nodes, cur.(*FilterNode).Left)
+		nodes = collectNode(nodes, cur.(*FilterNode).Right)
+	case NodeUnion:
+		for _, node := range cur.(*UnionNode).Nodes {
+			nodes = collectNode(nodes, node)
+		}
+	}
+	return nodes
+}
+
+func TestParser(t *testing.T) {
+	for _, test := range parserTests {
+		parser, err := Parse(test.name, test.text)
+		if err != nil {
+			t.Errorf("parse %s error %v", test.name, err)
+		}
+		result := collectNode([]Node{}, parser.Root)[1:]
+		if len(result) != len(test.nodes) {
+			t.Errorf("in %s, expect to get %d nodes, got %d nodes", test.name, len(test.nodes), len(result))
+			t.Error(result)
+		}
+		for i, expect := range test.nodes {
+			if result[i].String() != expect.String() {
+				t.Errorf("in %s, %dth node, expect %v, got %v", test.name, i, expect, result[i])
+			}
+		}
+	}
+}
+
+type failParserTest struct {
+	name string
+	text string
+	err  string
+}
+
+func TestFailParser(t *testing.T) {
+	failParserTests := []failParserTest{
+		{"unclosed action", "{.hello", "unclosed action"},
+		{"unrecognized character", "{*}", "unrecognized character in action: U+002A '*'"},
+		{"invalid number", "{+12.3.0}", "cannot parse number +12.3.0"},
+		{"unterminated array", "{[1}", "unterminated array"},
+		{"invalid index", "{[::-1]}", "invalid array index ::-1"},
+		{"unterminated filter", "{[?(.price]}", "unterminated filter"},
+	}
+	for _, test := range failParserTests {
+		_, err := Parse(test.name, test.text)
+		var out string
+		if err == nil {
+			out = "nil"
+		} else {
+			out = err.Error()
+		}
+		if out != test.err {
+			t.Errorf("in %s, expect to get error %v, got %v", test.name, test.err, out)
+		}
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/limitwriter/doc.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/limitwriter/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package limitwriter provides a writer that only allows a certain number of bytes to be
+// written.
+package limitwriter

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/limitwriter/limitwriter.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/limitwriter/limitwriter.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package limitwriter
+
+import (
+	"errors"
+	"io"
+)
+
+// New creates a writer that is limited to writing at most n bytes to w. This writer is not
+// thread safe.
+func New(w io.Writer, n int64) io.Writer {
+	return &limitWriter{
+		w: w,
+		n: n,
+	}
+}
+
+// ErrMaximumWrite is returned when all bytes have been written.
+var ErrMaximumWrite = errors.New("maximum write")
+
+type limitWriter struct {
+	w io.Writer
+	n int64
+}
+
+func (w *limitWriter) Write(p []byte) (n int, err error) {
+	if int64(len(p)) > w.n {
+		p = p[:w.n]
+	}
+	if len(p) > 0 {
+		n, err = w.w.Write(p)
+		w.n -= int64(n)
+	}
+	if w.n == 0 {
+		err = ErrMaximumWrite
+	}
+	return
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/line_delimiter_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/line_delimiter_test.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"os"
+)
+
+func ExampleTrailingNewline() {
+	ld := NewLineDelimiter(os.Stdout, "|")
+	defer ld.Flush()
+	fmt.Fprint(ld, "  Hello  \n  World  \n")
+	// Output:
+	// |  Hello  |
+	// |  World  |
+	// ||
+}
+func ExampleNoTrailingNewline() {
+	ld := NewLineDelimiter(os.Stdout, "|")
+	defer ld.Flush()
+	fmt.Fprint(ld, "  Hello  \n  World  ")
+	// Output:
+	// |  Hello  |
+	// |  World  |
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/mount/mount.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/mount/mount.go
@@ -75,7 +75,7 @@ func (mounter *SafeFormatAndMount) formatAndMount(source string, target string, 
 	// Try to mount the disk
 	err := mounter.Interface.Mount(source, target, fstype, options)
 	if err != nil {
-		// It is possible that this disk is not formatted. Double check using 'file'
+		// It is possible that this disk is not formatted. Double check using diskLooksUnformatted
 		notFormatted, err := mounter.diskLooksUnformatted(source)
 		if err == nil && notFormatted {
 			// Disk is unformatted so format it.
@@ -96,7 +96,7 @@ func (mounter *SafeFormatAndMount) formatAndMount(source string, target string, 
 	return err
 }
 
-// diskLooksUnformatted uses 'file' to see if the given disk is unformated
+// diskLooksUnformatted uses 'lsblk' to see if the given disk is unformated
 func (mounter *SafeFormatAndMount) diskLooksUnformatted(disk string) (bool, error) {
 	args := []string{"-nd", "-o", "FSTYPE", disk}
 	cmd := mounter.Runner.Command("lsblk", args...)

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/mount/mount_linux_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/mount/mount_linux_test.go
@@ -1,0 +1,182 @@
+// +build linux
+
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mount
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestReadProcMountsFrom(t *testing.T) {
+	successCase :=
+		`/dev/0 /path/to/0 type0 flags 0 0
+		/dev/1    /path/to/1   type1	flags 1 1
+		/dev/2 /path/to/2 type2 flags,1,2=3 2 2
+		`
+	hash, err := readProcMountsFrom(strings.NewReader(successCase), nil)
+	if err != nil {
+		t.Errorf("expected success")
+	}
+	if hash != 0xa3522051 {
+		t.Errorf("expected 0xa3522051, got %#x", hash)
+	}
+	mounts := []MountPoint{}
+	hash, err = readProcMountsFrom(strings.NewReader(successCase), &mounts)
+	if err != nil {
+		t.Errorf("expected success")
+	}
+	if hash != 0xa3522051 {
+		t.Errorf("expected 0xa3522051, got %#x", hash)
+	}
+	if len(mounts) != 3 {
+		t.Fatalf("expected 3 mounts, got %d", len(mounts))
+	}
+	mp := MountPoint{"/dev/0", "/path/to/0", "type0", []string{"flags"}, 0, 0}
+	if !mountPointsEqual(&mounts[0], &mp) {
+		t.Errorf("got unexpected MountPoint[0]: %#v", mounts[0])
+	}
+	mp = MountPoint{"/dev/1", "/path/to/1", "type1", []string{"flags"}, 1, 1}
+	if !mountPointsEqual(&mounts[1], &mp) {
+		t.Errorf("got unexpected MountPoint[1]: %#v", mounts[1])
+	}
+	mp = MountPoint{"/dev/2", "/path/to/2", "type2", []string{"flags", "1", "2=3"}, 2, 2}
+	if !mountPointsEqual(&mounts[2], &mp) {
+		t.Errorf("got unexpected MountPoint[2]: %#v", mounts[2])
+	}
+
+	errorCases := []string{
+		"/dev/0 /path/to/mount\n",
+		"/dev/1 /path/to/mount type flags a 0\n",
+		"/dev/2 /path/to/mount type flags 0 b\n",
+	}
+	for _, ec := range errorCases {
+		_, err := readProcMountsFrom(strings.NewReader(ec), &mounts)
+		if err == nil {
+			t.Errorf("expected error")
+		}
+	}
+}
+
+func mountPointsEqual(a, b *MountPoint) bool {
+	if a.Device != b.Device || a.Path != b.Path || a.Type != b.Type || !slicesEqual(a.Opts, b.Opts) || a.Pass != b.Pass || a.Freq != b.Freq {
+		return false
+	}
+	return true
+}
+
+func slicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestGetMountRefs(t *testing.T) {
+	fm := &FakeMounter{
+		MountPoints: []MountPoint{
+			{Device: "/dev/sdb", Path: "/var/lib/kubelet/plugins/kubernetes.io/gce-pd/mounts/gce-pd"},
+			{Device: "/dev/sdb", Path: "/var/lib/kubelet/pods/some-pod/volumes/kubernetes.io~gce-pd/gce-pd-in-pod"},
+			{Device: "/dev/sdc", Path: "/var/lib/kubelet/plugins/kubernetes.io/gce-pd/mounts/gce-pd2"},
+			{Device: "/dev/sdc", Path: "/var/lib/kubelet/pods/some-pod/volumes/kubernetes.io~gce-pd/gce-pd2-in-pod"},
+			{Device: "/dev/sdc", Path: "/var/lib/kubelet/pods/some-pod/volumes/kubernetes.io~gce-pd/gce-pd2-in-pod2"},
+		},
+	}
+
+	tests := []struct {
+		mountPath    string
+		expectedRefs []string
+	}{
+		{
+			"/var/lib/kubelet/pods/some-pod/volumes/kubernetes.io~gce-pd/gce-pd-in-pod",
+			[]string{
+				"/var/lib/kubelet/plugins/kubernetes.io/gce-pd/mounts/gce-pd",
+			},
+		},
+		{
+			"/var/lib/kubelet/pods/some-pod/volumes/kubernetes.io~gce-pd/gce-pd2-in-pod",
+			[]string{
+				"/var/lib/kubelet/pods/some-pod/volumes/kubernetes.io~gce-pd/gce-pd2-in-pod2",
+				"/var/lib/kubelet/plugins/kubernetes.io/gce-pd/mounts/gce-pd2",
+			},
+		},
+	}
+
+	for i, test := range tests {
+		if refs, err := GetMountRefs(fm, test.mountPath); err != nil || !setEquivalent(test.expectedRefs, refs) {
+			t.Errorf("%d. getMountRefs(%q) = %v, %v; expected %v, nil", i, test.mountPath, refs, err, test.expectedRefs)
+		}
+	}
+}
+
+func setEquivalent(set1, set2 []string) bool {
+	map1 := make(map[string]bool)
+	map2 := make(map[string]bool)
+	for _, s := range set1 {
+		map1[s] = true
+	}
+	for _, s := range set2 {
+		map2[s] = true
+	}
+
+	for s := range map1 {
+		if !map2[s] {
+			return false
+		}
+	}
+	for s := range map2 {
+		if !map1[s] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestGetDeviceNameFromMount(t *testing.T) {
+	fm := &FakeMounter{
+		MountPoints: []MountPoint{
+			{Device: "/dev/disk/by-path/prefix-lun-1",
+				Path: "/mnt/111"},
+			{Device: "/dev/disk/by-path/prefix-lun-1",
+				Path: "/mnt/222"},
+		},
+	}
+
+	tests := []struct {
+		mountPath      string
+		expectedDevice string
+		expectedRefs   int
+	}{
+		{
+			"/mnt/222",
+			"/dev/disk/by-path/prefix-lun-1",
+			2,
+		},
+	}
+
+	for i, test := range tests {
+		if device, refs, err := GetDeviceNameFromMount(fm, test.mountPath); err != nil || test.expectedRefs != refs || test.expectedDevice != device {
+			t.Errorf("%d. GetDeviceNameFromMount(%s) = (%s, %d), %v; expected (%s,%d), nil", i, test.mountPath, device, refs, err, test.expectedDevice, test.expectedRefs)
+		}
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/mount/safe_format_and_mount_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/mount/safe_format_and_mount_test.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mount
+
+import (
+	"fmt"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/util/exec"
+)
+
+type ErrorMounter struct {
+	*FakeMounter
+	errIndex int
+	err      []error
+}
+
+func (mounter *ErrorMounter) Mount(source string, target string, fstype string, options []string) error {
+	i := mounter.errIndex
+	mounter.errIndex++
+	if mounter.err != nil && mounter.err[i] != nil {
+		return mounter.err[i]
+	}
+	return mounter.FakeMounter.Mount(source, target, fstype, options)
+}
+
+type ExecArgs struct {
+	command string
+	args    []string
+	output  string
+	err     error
+}
+
+func TestSafeFormatAndMount(t *testing.T) {
+	tests := []struct {
+		fstype        string
+		mountOptions  []string
+		execScripts   []ExecArgs
+		mountErrs     []error
+		expectedError error
+	}{
+		{ // Test a read only mount
+			fstype:       "ext4",
+			mountOptions: []string{"ro"},
+		},
+		{ // Test a normal mount
+			fstype: "ext4",
+		},
+
+		{ // Test that 'file' is called and fails
+			fstype:    "ext4",
+			mountErrs: []error{fmt.Errorf("unknown filesystem type '(null)'")},
+			execScripts: []ExecArgs{
+				{"lsblk", []string{"-nd", "-o", "FSTYPE", "/dev/foo"}, "ext4", nil},
+			},
+			expectedError: fmt.Errorf("unknown filesystem type '(null)'"),
+		},
+		{ // Test that 'file' is called and confirms unformatted disk, format fails
+			fstype:    "ext4",
+			mountErrs: []error{fmt.Errorf("unknown filesystem type '(null)'")},
+			execScripts: []ExecArgs{
+				{"lsblk", []string{"-nd", "-o", "FSTYPE", "/dev/foo"}, "", nil},
+				{"mkfs.ext4", []string{"-E", "lazy_itable_init=0,lazy_journal_init=0", "-F", "/dev/foo"}, "", fmt.Errorf("formatting failed")},
+			},
+			expectedError: fmt.Errorf("formatting failed"),
+		},
+		{ // Test that 'file' is called and confirms unformatted disk, format passes, second mount fails
+			fstype:    "ext4",
+			mountErrs: []error{fmt.Errorf("unknown filesystem type '(null)'"), fmt.Errorf("Still cannot mount")},
+			execScripts: []ExecArgs{
+				{"lsblk", []string{"-nd", "-o", "FSTYPE", "/dev/foo"}, "", nil},
+				{"mkfs.ext4", []string{"-E", "lazy_itable_init=0,lazy_journal_init=0", "-F", "/dev/foo"}, "", nil},
+			},
+			expectedError: fmt.Errorf("Still cannot mount"),
+		},
+		{ // Test that 'file' is called and confirms unformatted disk, format passes, second mount passes
+			fstype:    "ext4",
+			mountErrs: []error{fmt.Errorf("unknown filesystem type '(null)'"), nil},
+			execScripts: []ExecArgs{
+				{"lsblk", []string{"-nd", "-o", "FSTYPE", "/dev/foo"}, "", nil},
+				{"mkfs.ext4", []string{"-E", "lazy_itable_init=0,lazy_journal_init=0", "-F", "/dev/foo"}, "", nil},
+			},
+			expectedError: nil,
+		},
+		{ // Test that 'file' is called and confirms unformatted disk, format passes, second mount passes with ext3
+			fstype:    "ext3",
+			mountErrs: []error{fmt.Errorf("unknown filesystem type '(null)'"), nil},
+			execScripts: []ExecArgs{
+				{"lsblk", []string{"-nd", "-o", "FSTYPE", "/dev/foo"}, "", nil},
+				{"mkfs.ext3", []string{"-E", "lazy_itable_init=0,lazy_journal_init=0", "-F", "/dev/foo"}, "", nil},
+			},
+			expectedError: nil,
+		},
+	}
+
+	for _, test := range tests {
+		commandScripts := []exec.FakeCommandAction{}
+		for _, expected := range test.execScripts {
+			ecmd := expected.command
+			eargs := expected.args
+			output := expected.output
+			err := expected.err
+			commandScript := func(cmd string, args ...string) exec.Cmd {
+				if cmd != ecmd {
+					t.Errorf("Unexpected command %s. Expecting %s", cmd, ecmd)
+				}
+
+				for j := range args {
+					if args[j] != eargs[j] {
+						t.Errorf("Unexpected args %v. Expecting %v", args, eargs)
+					}
+				}
+				fake := exec.FakeCmd{
+					CombinedOutputScript: []exec.FakeCombinedOutputAction{
+						func() ([]byte, error) { return []byte(output), err },
+					},
+				}
+				return exec.InitFakeCmd(&fake, cmd, args...)
+			}
+			commandScripts = append(commandScripts, commandScript)
+		}
+
+		fake := exec.FakeExec{
+			CommandScript: commandScripts,
+		}
+
+		fakeMounter := ErrorMounter{&FakeMounter{}, 0, test.mountErrs}
+		mounter := SafeFormatAndMount{
+			Interface: &fakeMounter,
+			Runner:    &fake,
+		}
+
+		device := "/dev/foo"
+		dest := "/mnt/bar"
+		err := mounter.Mount(device, dest, test.fstype, test.mountOptions)
+		if test.expectedError == nil {
+			if err != nil {
+				t.Errorf("unexpected non-error: %v", err)
+			}
+
+			// Check that something was mounted on the directory
+			isNotMountPoint, err := fakeMounter.IsLikelyNotMountPoint(dest)
+			if err != nil || isNotMountPoint {
+				t.Errorf("the directory was not mounted")
+			}
+
+			//check that the correct device was mounted
+			mountedDevice, _, err := GetDeviceNameFromMount(fakeMounter.FakeMounter, dest)
+			if err != nil || mountedDevice != device {
+				t.Errorf("the correct device was not mounted")
+			}
+		} else {
+			if err == nil || test.expectedError.Error() != err.Error() {
+				t.Errorf("unexpected error: %v. Expecting %v", err, test.expectedError)
+			}
+		}
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/oom/oom.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/oom/oom.go
@@ -19,8 +19,8 @@ package oom
 // This is a struct instead of an interface to allow injection of process ID listers and
 // applying OOM score in tests.
 // TODO: make this an interface, and inject a mock ioutil struct for testing.
-type OomAdjuster struct {
+type OOMAdjuster struct {
 	pidLister                 func(cgroupName string) ([]int, error)
-	ApplyOomScoreAdj          func(pid int, oomScoreAdj int) error
-	ApplyOomScoreAdjContainer func(cgroupName string, oomScoreAdj, maxTries int) error
+	ApplyOOMScoreAdj          func(pid int, oomScoreAdj int) error
+	ApplyOOMScoreAdjContainer func(cgroupName string, oomScoreAdj, maxTries int) error
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/oom/oom_fake.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/oom/oom_fake.go
@@ -16,19 +16,20 @@ limitations under the License.
 
 package oom
 
-type FakeOomAdjuster struct{}
+type FakeOOMAdjuster struct{}
 
-func NewFakeOomAdjuster() *OomAdjuster {
-	return &OomAdjuster{
-		ApplyOomScoreAdj:          fakeApplyOomScoreAdj,
-		ApplyOomScoreAdjContainer: fakeApplyOomScoreAdjContainer,
+func NewFakeOOMAdjuster() *OOMAdjuster {
+	return &OOMAdjuster{
+		pidLister:                 func(cgroupName string) ([]int, error) { return make([]int, 0), nil },
+		ApplyOOMScoreAdj:          fakeApplyOOMScoreAdj,
+		ApplyOOMScoreAdjContainer: fakeApplyOOMScoreAdjContainer,
 	}
 }
 
-func fakeApplyOomScoreAdj(pid int, oomScoreAdj int) error {
+func fakeApplyOOMScoreAdj(pid int, oomScoreAdj int) error {
 	return nil
 }
 
-func fakeApplyOomScoreAdjContainer(cgroupName string, oomScoreAdj, maxTries int) error {
+func fakeApplyOOMScoreAdjContainer(cgroupName string, oomScoreAdj, maxTries int) error {
 	return nil
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/oom/oom_linux.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/oom/oom_linux.go
@@ -29,12 +29,12 @@ import (
 	"github.com/golang/glog"
 )
 
-func NewOomAdjuster() *OomAdjuster {
-	oomAdjuster := &OomAdjuster{
+func NewOOMAdjuster() *OOMAdjuster {
+	oomAdjuster := &OOMAdjuster{
 		pidLister:        getPids,
-		ApplyOomScoreAdj: applyOomScoreAdj,
+		ApplyOOMScoreAdj: applyOOMScoreAdj,
 	}
-	oomAdjuster.ApplyOomScoreAdjContainer = oomAdjuster.applyOomScoreAdjContainer
+	oomAdjuster.ApplyOOMScoreAdjContainer = oomAdjuster.applyOOMScoreAdjContainer
 	return oomAdjuster
 }
 
@@ -48,7 +48,7 @@ func getPids(cgroupName string) ([]int, error) {
 }
 
 // Writes 'value' to /proc/<pid>/oom_score_adj. PID = 0 means self
-func applyOomScoreAdj(pid int, oomScoreAdj int) error {
+func applyOOMScoreAdj(pid int, oomScoreAdj int) error {
 	if pid < 0 {
 		return fmt.Errorf("invalid PID %d specified for oom_score_adj", pid)
 	}
@@ -79,7 +79,7 @@ func applyOomScoreAdj(pid int, oomScoreAdj int) error {
 
 // Writes 'value' to /proc/<pid>/oom_score_adj for all processes in cgroup cgroupName.
 // Keeps trying to write until the process list of the cgroup stabilizes, or until maxTries tries.
-func (oomAdjuster *OomAdjuster) applyOomScoreAdjContainer(cgroupName string, oomScoreAdj, maxTries int) error {
+func (oomAdjuster *OOMAdjuster) applyOOMScoreAdjContainer(cgroupName string, oomScoreAdj, maxTries int) error {
 	adjustedProcessSet := make(map[int]bool)
 	for i := 0; i < maxTries; i++ {
 		continueAdjusting := false
@@ -93,7 +93,7 @@ func (oomAdjuster *OomAdjuster) applyOomScoreAdjContainer(cgroupName string, oom
 			for _, pid := range pidList {
 				if !adjustedProcessSet[pid] {
 					continueAdjusting = true
-					if err = oomAdjuster.ApplyOomScoreAdj(pid, oomScoreAdj); err == nil {
+					if err = oomAdjuster.ApplyOOMScoreAdj(pid, oomScoreAdj); err == nil {
 						adjustedProcessSet[pid] = true
 					}
 				}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/oom/oom_linux_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/oom/oom_linux_test.go
@@ -1,0 +1,110 @@
+// +build cgo,linux
+
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oom
+
+import (
+	"testing"
+)
+
+// Converts a sequence of PID lists into a PID lister.
+// The PID lister returns pidListSequence[i] on the ith call. If i >= length of pidListSequence
+// then return the last element of pidListSequence (the sequence is considered to have) stabilized.
+func sequenceToPidLister(pidListSequence [][]int) func(string) ([]int, error) {
+	var numCalls int
+	return func(cgroupName string) ([]int, error) {
+		numCalls++
+		if len(pidListSequence) == 0 {
+			return []int{}, nil
+		} else if numCalls > len(pidListSequence) {
+			return pidListSequence[len(pidListSequence)-1], nil
+		}
+		return pidListSequence[numCalls-1], nil
+	}
+}
+
+// Tests that applyOOMScoreAdjContainer correctly applies OOM scores to relevant processes, or
+// returns the right error.
+func applyOOMScoreAdjContainerTester(pidListSequence [][]int, maxTries int, appliedPids []int, expectedError bool, t *testing.T) {
+	pidOOMs := make(map[int]bool)
+
+	// Mock ApplyOOMScoreAdj and pidLister.
+	oomAdjuster := NewOOMAdjuster()
+	oomAdjuster.ApplyOOMScoreAdj = func(pid int, oomScoreAdj int) error {
+		pidOOMs[pid] = true
+		return nil
+	}
+	oomAdjuster.pidLister = sequenceToPidLister(pidListSequence)
+	err := oomAdjuster.ApplyOOMScoreAdjContainer("", 100, maxTries)
+
+	// Check error value.
+	if expectedError && err == nil {
+		t.Errorf("Expected error %+v when running ApplyOOMScoreAdjContainer but got no error", expectedError)
+		return
+	} else if !expectedError && err != nil {
+		t.Errorf("Expected no error but got error %+v when running ApplyOOMScoreAdjContainer", err)
+		return
+	} else if err != nil {
+		return
+	}
+
+	// Check that OOM scores were applied to the right processes.
+	if len(appliedPids) != len(pidOOMs) {
+		t.Errorf("Applied OOM scores to incorrect number of processes")
+		return
+	}
+	for _, pid := range appliedPids {
+		if !pidOOMs[pid] {
+			t.Errorf("Failed to apply OOM scores to process %d", pid)
+		}
+	}
+}
+
+func TestOOMScoreAdjContainer(t *testing.T) {
+	pidListSequenceEmpty := [][]int{}
+	applyOOMScoreAdjContainerTester(pidListSequenceEmpty, 3, nil, true, t)
+
+	pidListSequence1 := [][]int{
+		{1, 2},
+	}
+	applyOOMScoreAdjContainerTester(pidListSequence1, 1, nil, true, t)
+	applyOOMScoreAdjContainerTester(pidListSequence1, 2, []int{1, 2}, false, t)
+	applyOOMScoreAdjContainerTester(pidListSequence1, 3, []int{1, 2}, false, t)
+
+	pidListSequence3 := [][]int{
+		{1, 2},
+		{1, 2, 4, 5},
+		{2, 1, 4, 5, 3},
+	}
+	applyOOMScoreAdjContainerTester(pidListSequence3, 1, nil, true, t)
+	applyOOMScoreAdjContainerTester(pidListSequence3, 2, nil, true, t)
+	applyOOMScoreAdjContainerTester(pidListSequence3, 3, nil, true, t)
+	applyOOMScoreAdjContainerTester(pidListSequence3, 4, []int{1, 2, 3, 4, 5}, false, t)
+
+	pidListSequenceLag := [][]int{
+		{},
+		{},
+		{},
+		{1, 2, 4},
+		{1, 2, 4, 5},
+	}
+	for i := 1; i < 5; i++ {
+		applyOOMScoreAdjContainerTester(pidListSequenceLag, i, nil, true, t)
+	}
+	applyOOMScoreAdjContainerTester(pidListSequenceLag, 6, []int{1, 2, 4, 5}, false, t)
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/oom/oom_unsupported.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/oom/oom_unsupported.go
@@ -24,17 +24,17 @@ import (
 
 var unsupportedErr = errors.New("setting OOM scores is unsupported in this build")
 
-func NewOomAdjuster() *OomAdjuster {
-	return &OomAdjuster{
-		ApplyOomScoreAdj:          unsupportedApplyOomScoreAdj,
-		ApplyOomScoreAdjContainer: unsupportedApplyOomScoreAdjContainer,
+func NewOOMAdjuster() *OOMAdjuster {
+	return &OOMAdjuster{
+		ApplyOOMScoreAdj:          unsupportedApplyOOMScoreAdj,
+		ApplyOOMScoreAdjContainer: unsupportedApplyOOMScoreAdjContainer,
 	}
 }
 
-func unsupportedApplyOomScoreAdj(pid int, oomScoreAdj int) error {
+func unsupportedApplyOOMScoreAdj(pid int, oomScoreAdj int) error {
 	return unsupportedErr
 }
 
-func unsupportedApplyOomScoreAdjContainer(cgroupName string, oomScoreAdj, maxTries int) error {
+func unsupportedApplyOOMScoreAdjContainer(cgroupName string, oomScoreAdj, maxTries int) error {
 	return unsupportedErr
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/operationmanager/operationmanager_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/operationmanager/operationmanager_test.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Channel Manager keeps track of multiple channels
+package operationmanager
+
+import (
+	"testing"
+)
+
+func TestStart(t *testing.T) {
+	// Arrange
+	cm := NewOperationManager()
+	chanId := "testChanId"
+	testMsg := "test message"
+
+	// Act
+	ch, startErr := cm.Start(chanId, 1 /* bufferSize */)
+	sigErr := cm.Send(chanId, testMsg)
+
+	// Assert
+	verifyNoError(t, startErr, "Start")
+	verifyNoError(t, sigErr, "Send")
+	actualMsg := <-ch
+	verifyMsg(t, testMsg /* expected */, actualMsg.(string) /* actual */)
+}
+
+func TestStartIdExists(t *testing.T) {
+	// Arrange
+	cm := NewOperationManager()
+	chanId := "testChanId"
+
+	// Act
+	_, startErr1 := cm.Start(chanId, 1 /* bufferSize */)
+	_, startErr2 := cm.Start(chanId, 1 /* bufferSize */)
+
+	// Assert
+	verifyNoError(t, startErr1, "Start1")
+	verifyError(t, startErr2, "Start2")
+}
+
+func TestStartAndAdd2Chans(t *testing.T) {
+	// Arrange
+	cm := NewOperationManager()
+	chanId1 := "testChanId1"
+	chanId2 := "testChanId2"
+	testMsg1 := "test message 1"
+	testMsg2 := "test message 2"
+
+	// Act
+	ch1, startErr1 := cm.Start(chanId1, 1 /* bufferSize */)
+	ch2, startErr2 := cm.Start(chanId2, 1 /* bufferSize */)
+	sigErr1 := cm.Send(chanId1, testMsg1)
+	sigErr2 := cm.Send(chanId2, testMsg2)
+
+	// Assert
+	verifyNoError(t, startErr1, "Start1")
+	verifyNoError(t, startErr2, "Start2")
+	verifyNoError(t, sigErr1, "Send1")
+	verifyNoError(t, sigErr2, "Send2")
+	actualMsg1 := <-ch1
+	actualMsg2 := <-ch2
+	verifyMsg(t, testMsg1 /* expected */, actualMsg1.(string) /* actual */)
+	verifyMsg(t, testMsg2 /* expected */, actualMsg2.(string) /* actual */)
+}
+
+func TestStartAndAdd2ChansAndClose(t *testing.T) {
+	// Arrange
+	cm := NewOperationManager()
+	chanId1 := "testChanId1"
+	chanId2 := "testChanId2"
+	testMsg1 := "test message 1"
+	testMsg2 := "test message 2"
+
+	// Act
+	ch1, startErr1 := cm.Start(chanId1, 1 /* bufferSize */)
+	ch2, startErr2 := cm.Start(chanId2, 1 /* bufferSize */)
+	sigErr1 := cm.Send(chanId1, testMsg1)
+	sigErr2 := cm.Send(chanId2, testMsg2)
+	cm.Close(chanId1)
+	sigErr3 := cm.Send(chanId1, testMsg1)
+
+	// Assert
+	verifyNoError(t, startErr1, "Start1")
+	verifyNoError(t, startErr2, "Start2")
+	verifyNoError(t, sigErr1, "Send1")
+	verifyNoError(t, sigErr2, "Send2")
+	verifyError(t, sigErr3, "Send3")
+	actualMsg1 := <-ch1
+	actualMsg2 := <-ch2
+	verifyMsg(t, testMsg1 /* expected */, actualMsg1.(string) /* actual */)
+	verifyMsg(t, testMsg2 /* expected */, actualMsg2.(string) /* actual */)
+}
+
+func TestExists(t *testing.T) {
+	// Arrange
+	cm := NewOperationManager()
+	chanId1 := "testChanId1"
+	chanId2 := "testChanId2"
+
+	// Act & Assert
+	verifyExists(t, cm, chanId1, false /* expected */)
+	verifyExists(t, cm, chanId2, false /* expected */)
+
+	_, startErr1 := cm.Start(chanId1, 1 /* bufferSize */)
+	verifyNoError(t, startErr1, "Start1")
+	verifyExists(t, cm, chanId1, true /* expected */)
+	verifyExists(t, cm, chanId2, false /* expected */)
+
+	_, startErr2 := cm.Start(chanId2, 1 /* bufferSize */)
+	verifyNoError(t, startErr2, "Start2")
+	verifyExists(t, cm, chanId1, true /* expected */)
+	verifyExists(t, cm, chanId2, true /* expected */)
+
+	cm.Close(chanId1)
+	verifyExists(t, cm, chanId1, false /* expected */)
+	verifyExists(t, cm, chanId2, true /* expected */)
+
+	cm.Close(chanId2)
+	verifyExists(t, cm, chanId1, false /* expected */)
+	verifyExists(t, cm, chanId2, false /* expected */)
+}
+
+func verifyExists(t *testing.T, cm OperationManager, id string, expected bool) {
+	if actual := cm.Exists(id); expected != actual {
+		t.Fatalf("Unexpected Exists(%q) response. Expected: <%v> Actual: <%v>", id, expected, actual)
+	}
+}
+
+func verifyNoError(t *testing.T, err error, name string) {
+	if err != nil {
+		t.Fatalf("Unexpected response on %q. Expected: <no error> Actual: <%v>", name, err)
+	}
+}
+
+func verifyError(t *testing.T, err error, name string) {
+	if err == nil {
+		t.Fatalf("Unexpected response on %q. Expected: <error> Actual: <no error>", name)
+	}
+}
+
+func verifyMsg(t *testing.T, expected, actual string) {
+	if actual != expected {
+		t.Fatalf("Unexpected testMsg value. Expected: <%v> Actual: <%v>", expected, actual)
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/port_range_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/port_range_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	flag "github.com/spf13/pflag"
+)
+
+func TestPortRange(t *testing.T) {
+	testCases := []struct {
+		input    string
+		success  bool
+		expected string
+		included int
+		excluded int
+	}{
+		{"100-200", true, "100-200", 200, 201},
+		{" 100-200 ", true, "100-200", 200, 201},
+		{"0-0", true, "0-0", 0, 1},
+		{"", true, "", -1, 0},
+		{"100", false, "", -1, -1},
+		{"100 - 200", false, "", -1, -1},
+		{"-100", false, "", -1, -1},
+		{"100-", false, "", -1, -1},
+	}
+
+	for i := range testCases {
+		tc := &testCases[i]
+		pr := &PortRange{}
+		var f flag.Value = pr
+		err := f.Set(tc.input)
+		if err != nil && tc.success == true {
+			t.Errorf("expected success, got %q", err)
+			continue
+		} else if err == nil && tc.success == false {
+			t.Errorf("expected failure")
+			continue
+		} else if tc.success {
+			if f.String() != tc.expected {
+				t.Errorf("expected %q, got %q", tc.expected, f.String())
+			}
+			if tc.included >= 0 && !pr.Contains(tc.included) {
+				t.Errorf("expected %q to include %d", f.String(), tc.included)
+			}
+			if tc.excluded >= 0 && pr.Contains(tc.excluded) {
+				t.Errorf("expected %q to exclude %d", f.String(), tc.excluded)
+			}
+		}
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/port_split_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/port_split_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+)
+
+func TestSplitPort(t *testing.T) {
+	table := []struct {
+		in         string
+		name, port string
+		valid      bool
+	}{
+		{
+			in:    "aoeu:asdf",
+			name:  "aoeu",
+			port:  "asdf",
+			valid: true,
+		}, {
+			in:    "aoeu:",
+			name:  "aoeu",
+			valid: true,
+		}, {
+			in:   ":asdf",
+			name: "",
+			port: "asdf",
+		}, {
+			in: "aoeu:asdf:htns",
+		}, {
+			in:    "aoeu",
+			name:  "aoeu",
+			valid: true,
+		}, {
+			in: "",
+		},
+	}
+
+	for _, item := range table {
+		name, port, valid := SplitPort(item.in)
+		if e, a := item.name, name; e != a {
+			t.Errorf("%q: Wanted %q, got %q", item.in, e, a)
+		}
+		if e, a := item.port, port; e != a {
+			t.Errorf("%q: Wanted %q, got %q", item.in, e, a)
+		}
+		if e, a := item.valid, valid; e != a {
+			t.Errorf("%q: Wanted %t, got %t", item.in, e, a)
+		}
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/procfs/procfs_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/procfs/procfs_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package procfs
+
+import (
+	"io/ioutil"
+	"testing"
+)
+
+func verifyContainerName(procCgroupText, expectedName string, expectedErr bool, t *testing.T) {
+	name, err := containerNameFromProcCgroup(procCgroupText)
+	if expectedErr && err == nil {
+		t.Errorf("Expected error but did not get error in verifyContainerName")
+		return
+	} else if !expectedErr && err != nil {
+		t.Errorf("Expected no error, but got error %+v in verifyContainerName", err)
+		return
+	} else if expectedErr {
+		return
+	}
+	if name != expectedName {
+		t.Errorf("Expected container name %s but got name %s", expectedName, name)
+	}
+}
+
+func TestContainerNameFromProcCgroup(t *testing.T) {
+	procCgroupValid := "2:devices:docker/kubelet"
+	verifyContainerName(procCgroupValid, "docker/kubelet", false, t)
+
+	procCgroupEmpty := ""
+	verifyContainerName(procCgroupEmpty, "", true, t)
+
+	content, err := ioutil.ReadFile("example_proc_cgroup")
+	if err != nil {
+		t.Errorf("Could not read example /proc cgroup file")
+	}
+	verifyContainerName(string(content), "/user/1000.user/c1.session", false, t)
+
+	procCgroupNoDevice := "2:freezer:docker/kubelet\n5:cpuacct:pkg/kubectl"
+	verifyContainerName(procCgroupNoDevice, "", true, t)
+
+	procCgroupInvalid := "devices:docker/kubelet\ncpuacct:pkg/kubectl"
+	verifyContainerName(procCgroupInvalid, "", true, t)
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/proxy/transport.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/proxy/transport.go
@@ -136,8 +136,11 @@ func (t *Transport) rewriteURL(targetURL string, sourceURL *url.URL) string {
 	url.Scheme = t.Scheme
 	url.Host = t.Host
 	origPath := url.Path
+	// Do not rewrite URL if the sourceURL already contains the necessary prefix.
+	if strings.HasPrefix(url.Path, t.PathPrepend) {
+		return url.String()
+	}
 	url.Path = path.Join(t.PathPrepend, url.Path)
-
 	if strings.HasSuffix(origPath, "/") {
 		// Add back the trailing slash, which was stripped by path.Join().
 		url.Path += "/"

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/proxy/transport_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/proxy/transport_test.go
@@ -1,0 +1,223 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func parseURLOrDie(inURL string) *url.URL {
+	parsed, err := url.Parse(inURL)
+	if err != nil {
+		panic(err)
+	}
+	return parsed
+}
+
+func TestProxyTransport(t *testing.T) {
+	testTransport := &Transport{
+		Scheme:      "http",
+		Host:        "foo.com",
+		PathPrepend: "/proxy/minion/minion1:10250",
+	}
+	testTransport2 := &Transport{
+		Scheme:      "https",
+		Host:        "foo.com",
+		PathPrepend: "/proxy/minion/minion1:8080",
+	}
+	type Item struct {
+		input        string
+		sourceURL    string
+		transport    *Transport
+		output       string
+		contentType  string
+		forwardedURI string
+		redirect     string
+		redirectWant string
+	}
+
+	table := map[string]Item{
+		"normal": {
+			input:        `<pre><a href="kubelet.log">kubelet.log</a><a href="/google.log">google.log</a></pre>`,
+			sourceURL:    "http://myminion.com/logs/log.log",
+			transport:    testTransport,
+			output:       `<pre><a href="kubelet.log">kubelet.log</a><a href="http://foo.com/proxy/minion/minion1:10250/google.log">google.log</a></pre>`,
+			contentType:  "text/html",
+			forwardedURI: "/proxy/minion/minion1:10250/logs/log.log",
+		},
+		"full document": {
+			input:        `<html><header></header><body><pre><a href="kubelet.log">kubelet.log</a><a href="/google.log">google.log</a></pre></body></html>`,
+			sourceURL:    "http://myminion.com/logs/log.log",
+			transport:    testTransport,
+			output:       `<html><header></header><body><pre><a href="kubelet.log">kubelet.log</a><a href="http://foo.com/proxy/minion/minion1:10250/google.log">google.log</a></pre></body></html>`,
+			contentType:  "text/html",
+			forwardedURI: "/proxy/minion/minion1:10250/logs/log.log",
+		},
+		"trailing slash": {
+			input:        `<pre><a href="kubelet.log">kubelet.log</a><a href="/google.log/">google.log</a></pre>`,
+			sourceURL:    "http://myminion.com/logs/log.log",
+			transport:    testTransport,
+			output:       `<pre><a href="kubelet.log">kubelet.log</a><a href="http://foo.com/proxy/minion/minion1:10250/google.log/">google.log</a></pre>`,
+			contentType:  "text/html",
+			forwardedURI: "/proxy/minion/minion1:10250/logs/log.log",
+		},
+		"content-type charset": {
+			input:        `<pre><a href="kubelet.log">kubelet.log</a><a href="/google.log">google.log</a></pre>`,
+			sourceURL:    "http://myminion.com/logs/log.log",
+			transport:    testTransport,
+			output:       `<pre><a href="kubelet.log">kubelet.log</a><a href="http://foo.com/proxy/minion/minion1:10250/google.log">google.log</a></pre>`,
+			contentType:  "text/html; charset=utf-8",
+			forwardedURI: "/proxy/minion/minion1:10250/logs/log.log",
+		},
+		"content-type passthrough": {
+			input:        `<pre><a href="kubelet.log">kubelet.log</a><a href="/google.log">google.log</a></pre>`,
+			sourceURL:    "http://myminion.com/logs/log.log",
+			transport:    testTransport,
+			output:       `<pre><a href="kubelet.log">kubelet.log</a><a href="/google.log">google.log</a></pre>`,
+			contentType:  "text/plain",
+			forwardedURI: "/proxy/minion/minion1:10250/logs/log.log",
+		},
+		"subdir": {
+			input:        `<a href="kubelet.log">kubelet.log</a><a href="/google.log">google.log</a>`,
+			sourceURL:    "http://myminion.com/whatever/apt/somelog.log",
+			transport:    testTransport2,
+			output:       `<a href="kubelet.log">kubelet.log</a><a href="https://foo.com/proxy/minion/minion1:8080/google.log">google.log</a>`,
+			contentType:  "text/html",
+			forwardedURI: "/proxy/minion/minion1:8080/whatever/apt/somelog.log",
+		},
+		"image": {
+			input:        `<pre><img src="kubernetes.jpg"/><img src="/kubernetes_abs.jpg"/></pre>`,
+			sourceURL:    "http://myminion.com/",
+			transport:    testTransport,
+			output:       `<pre><img src="kubernetes.jpg"/><img src="http://foo.com/proxy/minion/minion1:10250/kubernetes_abs.jpg"/></pre>`,
+			contentType:  "text/html",
+			forwardedURI: "/proxy/minion/minion1:10250/",
+		},
+		"abs": {
+			input:        `<script src="http://google.com/kubernetes.js"/>`,
+			sourceURL:    "http://myminion.com/any/path/",
+			transport:    testTransport,
+			output:       `<script src="http://google.com/kubernetes.js"/>`,
+			contentType:  "text/html",
+			forwardedURI: "/proxy/minion/minion1:10250/any/path/",
+		},
+		"abs but same host": {
+			input:        `<script src="http://myminion.com/kubernetes.js"/>`,
+			sourceURL:    "http://myminion.com/any/path/",
+			transport:    testTransport,
+			output:       `<script src="http://foo.com/proxy/minion/minion1:10250/kubernetes.js"/>`,
+			contentType:  "text/html",
+			forwardedURI: "/proxy/minion/minion1:10250/any/path/",
+		},
+		"redirect rel": {
+			sourceURL:    "http://myminion.com/redirect",
+			transport:    testTransport,
+			redirect:     "/redirected/target/",
+			redirectWant: "http://foo.com/proxy/minion/minion1:10250/redirected/target/",
+			forwardedURI: "/proxy/minion/minion1:10250/redirect",
+		},
+		"redirect abs same host": {
+			sourceURL:    "http://myminion.com/redirect",
+			transport:    testTransport,
+			redirect:     "http://myminion.com/redirected/target/",
+			redirectWant: "http://foo.com/proxy/minion/minion1:10250/redirected/target/",
+			forwardedURI: "/proxy/minion/minion1:10250/redirect",
+		},
+		"redirect abs other host": {
+			sourceURL:    "http://myminion.com/redirect",
+			transport:    testTransport,
+			redirect:     "http://example.com/redirected/target/",
+			redirectWant: "http://example.com/redirected/target/",
+			forwardedURI: "/proxy/minion/minion1:10250/redirect",
+		},
+		"source contains the redirect already": {
+			input:        `<pre><a href="kubelet.log">kubelet.log</a><a href="http://foo.com/proxy/minion/minion1:10250/google.log">google.log</a></pre>`,
+			sourceURL:    "http://foo.com/logs/log.log",
+			transport:    testTransport,
+			output:       `<pre><a href="kubelet.log">kubelet.log</a><a href="http://foo.com/proxy/minion/minion1:10250/google.log">google.log</a></pre>`,
+			contentType:  "text/html",
+			forwardedURI: "/proxy/minion/minion1:10250/logs/log.log",
+		},
+	}
+
+	testItem := func(name string, item *Item) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Check request headers.
+			if got, want := r.Header.Get("X-Forwarded-Uri"), item.forwardedURI; got != want {
+				t.Errorf("%v: X-Forwarded-Uri = %q, want %q", name, got, want)
+			}
+			if got, want := r.Header.Get("X-Forwarded-Host"), item.transport.Host; got != want {
+				t.Errorf("%v: X-Forwarded-Host = %q, want %q", name, got, want)
+			}
+			if got, want := r.Header.Get("X-Forwarded-Proto"), item.transport.Scheme; got != want {
+				t.Errorf("%v: X-Forwarded-Proto = %q, want %q", name, got, want)
+			}
+
+			// Send response.
+			if item.redirect != "" {
+				http.Redirect(w, r, item.redirect, http.StatusMovedPermanently)
+				return
+			}
+			w.Header().Set("Content-Type", item.contentType)
+			fmt.Fprint(w, item.input)
+		}))
+		defer server.Close()
+
+		// Replace source URL with our test server address.
+		sourceURL := parseURLOrDie(item.sourceURL)
+		serverURL := parseURLOrDie(server.URL)
+		item.input = strings.Replace(item.input, sourceURL.Host, serverURL.Host, -1)
+		item.redirect = strings.Replace(item.redirect, sourceURL.Host, serverURL.Host, -1)
+		sourceURL.Host = serverURL.Host
+
+		req, err := http.NewRequest("GET", sourceURL.String(), nil)
+		if err != nil {
+			t.Errorf("%v: Unexpected error: %v", name, err)
+			return
+		}
+		resp, err := item.transport.RoundTrip(req)
+		if err != nil {
+			t.Errorf("%v: Unexpected error: %v", name, err)
+			return
+		}
+		if item.redirect != "" {
+			// Check that redirect URLs get rewritten properly.
+			if got, want := resp.Header.Get("Location"), item.redirectWant; got != want {
+				t.Errorf("%v: Location header = %q, want %q", name, got, want)
+			}
+			return
+		}
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			t.Errorf("%v: Unexpected error: %v", name, err)
+			return
+		}
+		if e, a := item.output, string(body); e != a {
+			t.Errorf("%v: expected %v, but got %v", name, e, a)
+		}
+	}
+
+	for name, item := range table {
+		testItem(name, &item)
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/rand/rand_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/rand/rand_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rand
+
+import (
+	"math/rand"
+	"strings"
+	"testing"
+)
+
+func TestString(t *testing.T) {
+	valid := "0123456789abcdefghijklmnopqrstuvwxyz"
+	for _, l := range []int{0, 1, 2, 10, 123} {
+		s := String(l)
+		if len(s) != l {
+			t.Errorf("expected string of size %d, got %q", l, s)
+		}
+		for _, c := range s {
+			if !strings.ContainsRune(valid, c) {
+				t.Errorf("expected valid charaters, got %v", c)
+			}
+		}
+	}
+}
+
+func TestPerm(t *testing.T) {
+	Seed(5)
+	rand.Seed(5)
+	for i := 1; i < 20; i++ {
+		actual := Perm(i)
+		expected := rand.Perm(i)
+		for j := 0; j < i; j++ {
+			if actual[j] != expected[j] {
+				t.Errorf("Perm call result is unexpected")
+			}
+		}
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/resource_container_linux.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/resource_container_linux.go
@@ -20,6 +20,7 @@ package util
 
 import (
 	"os"
+	"syscall"
 
 	"github.com/docker/libcontainer/cgroups/fs"
 	"github.com/docker/libcontainer/configs"
@@ -38,4 +39,8 @@ func RunInResourceContainer(containerName string) error {
 	}
 
 	return manager.Apply(os.Getpid())
+}
+
+func ApplyRLimitForSelf(maxOpenFiles uint64) {
+	syscall.Setrlimit(syscall.RLIMIT_NOFILE, &syscall.Rlimit{Max: maxOpenFiles, Cur: maxOpenFiles})
 }

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/resource_container_unsupported.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/resource_container_unsupported.go
@@ -25,3 +25,7 @@ import (
 func RunInResourceContainer(containerName string) error {
 	return errors.New("resource-only containers unsupported in this platform")
 }
+
+func ApplyRLimitForSelf(maxOpenFiles uint64) error {
+	return errors.New("SetRLimit unsupported in this platform")
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/runner_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/runner_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+func TestRunner(t *testing.T) {
+	var (
+		lock   sync.Mutex
+		events []string
+		funcs  []func(chan struct{})
+	)
+	done := make(chan struct{}, 20)
+	for i := 0; i < 10; i++ {
+		iCopy := i
+		funcs = append(funcs, func(c chan struct{}) {
+			lock.Lock()
+			events = append(events, fmt.Sprintf("%v starting\n", iCopy))
+			lock.Unlock()
+			<-c
+			lock.Lock()
+			events = append(events, fmt.Sprintf("%v stopping\n", iCopy))
+			lock.Unlock()
+			done <- struct{}{}
+		})
+	}
+
+	r := NewRunner(funcs...)
+	r.Start()
+	r.Stop()
+	for i := 0; i < 10; i++ {
+		<-done
+	}
+	if len(events) != 20 {
+		t.Errorf("expected 20 events, but got:\n%v\n", events)
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/sets/set_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/sets/set_test.go
@@ -1,0 +1,270 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sets
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestStringSet(t *testing.T) {
+	s := String{}
+	s2 := String{}
+	if len(s) != 0 {
+		t.Errorf("Expected len=0: %d", len(s))
+	}
+	s.Insert("a", "b")
+	if len(s) != 2 {
+		t.Errorf("Expected len=2: %d", len(s))
+	}
+	s.Insert("c")
+	if s.Has("d") {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+	if !s.Has("a") {
+		t.Errorf("Missing contents: %#v", s)
+	}
+	s.Delete("a")
+	if s.Has("a") {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+	s.Insert("a")
+	if s.HasAll("a", "b", "d") {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+	if !s.HasAll("a", "b") {
+		t.Errorf("Missing contents: %#v", s)
+	}
+	s2.Insert("a", "b", "d")
+	if s.IsSuperset(s2) {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+	s2.Delete("d")
+	if !s.IsSuperset(s2) {
+		t.Errorf("Missing contents: %#v", s)
+	}
+}
+
+func TestStringSetDeleteMultiples(t *testing.T) {
+	s := String{}
+	s.Insert("a", "b", "c")
+	if len(s) != 3 {
+		t.Errorf("Expected len=3: %d", len(s))
+	}
+
+	s.Delete("a", "c")
+	if len(s) != 1 {
+		t.Errorf("Expected len=1: %d", len(s))
+	}
+	if s.Has("a") {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+	if s.Has("c") {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+	if !s.Has("b") {
+		t.Errorf("Missing contents: %#v", s)
+	}
+
+}
+
+func TestNewStringSet(t *testing.T) {
+	s := NewString("a", "b", "c")
+	if len(s) != 3 {
+		t.Errorf("Expected len=3: %d", len(s))
+	}
+	if !s.Has("a") || !s.Has("b") || !s.Has("c") {
+		t.Errorf("Unexpected contents: %#v", s)
+	}
+}
+
+func TestStringSetList(t *testing.T) {
+	s := NewString("z", "y", "x", "a")
+	if !reflect.DeepEqual(s.List(), []string{"a", "x", "y", "z"}) {
+		t.Errorf("List gave unexpected result: %#v", s.List())
+	}
+}
+
+func TestStringSetDifference(t *testing.T) {
+	a := NewString("1", "2", "3")
+	b := NewString("1", "2", "4", "5")
+	c := a.Difference(b)
+	d := b.Difference(a)
+	if len(c) != 1 {
+		t.Errorf("Expected len=1: %d", len(c))
+	}
+	if !c.Has("3") {
+		t.Errorf("Unexpected contents: %#v", c.List())
+	}
+	if len(d) != 2 {
+		t.Errorf("Expected len=2: %d", len(d))
+	}
+	if !d.Has("4") || !d.Has("5") {
+		t.Errorf("Unexpected contents: %#v", d.List())
+	}
+}
+
+func TestStringSetHasAny(t *testing.T) {
+	a := NewString("1", "2", "3")
+
+	if !a.HasAny("1", "4") {
+		t.Errorf("expected true, got false")
+	}
+
+	if a.HasAny("0", "4") {
+		t.Errorf("expected false, got true")
+	}
+}
+
+func TestStringSetEquals(t *testing.T) {
+	// Simple case (order doesn't matter)
+	a := NewString("1", "2")
+	b := NewString("2", "1")
+	if !a.Equal(b) {
+		t.Errorf("Expected to be equal: %v vs %v", a, b)
+	}
+
+	// It is a set; duplicates are ignored
+	b = NewString("2", "2", "1")
+	if !a.Equal(b) {
+		t.Errorf("Expected to be equal: %v vs %v", a, b)
+	}
+
+	// Edge cases around empty sets / empty strings
+	a = NewString()
+	b = NewString()
+	if !a.Equal(b) {
+		t.Errorf("Expected to be equal: %v vs %v", a, b)
+	}
+
+	b = NewString("1", "2", "3")
+	if a.Equal(b) {
+		t.Errorf("Expected to be not-equal: %v vs %v", a, b)
+	}
+
+	b = NewString("1", "2", "")
+	if a.Equal(b) {
+		t.Errorf("Expected to be not-equal: %v vs %v", a, b)
+	}
+
+	// Check for equality after mutation
+	a = NewString()
+	a.Insert("1")
+	if a.Equal(b) {
+		t.Errorf("Expected to be not-equal: %v vs %v", a, b)
+	}
+
+	a.Insert("2")
+	if a.Equal(b) {
+		t.Errorf("Expected to be not-equal: %v vs %v", a, b)
+	}
+
+	a.Insert("")
+	if !a.Equal(b) {
+		t.Errorf("Expected to be equal: %v vs %v", a, b)
+	}
+
+	a.Delete("")
+	if a.Equal(b) {
+		t.Errorf("Expected to be not-equal: %v vs %v", a, b)
+	}
+}
+
+func TestStringUnion(t *testing.T) {
+	tests := []struct {
+		s1       String
+		s2       String
+		expected String
+	}{
+		{
+			NewString("1", "2", "3", "4"),
+			NewString("3", "4", "5", "6"),
+			NewString("1", "2", "3", "4", "5", "6"),
+		},
+		{
+			NewString("1", "2", "3", "4"),
+			NewString(),
+			NewString("1", "2", "3", "4"),
+		},
+		{
+			NewString(),
+			NewString("1", "2", "3", "4"),
+			NewString("1", "2", "3", "4"),
+		},
+		{
+			NewString(),
+			NewString(),
+			NewString(),
+		},
+	}
+
+	for _, test := range tests {
+		union := test.s1.Union(test.s2)
+		if union.Len() != test.expected.Len() {
+			t.Errorf("Expected union.Len()=%d but got %d", test.expected.Len(), union.Len())
+		}
+
+		if !union.Equal(test.expected) {
+			t.Errorf("Expected union.Equal(expected) but not true.  union:%v expected:%v", union.List(), test.expected.List())
+		}
+	}
+}
+
+func TestStringIntersection(t *testing.T) {
+	tests := []struct {
+		s1       String
+		s2       String
+		expected String
+	}{
+		{
+			NewString("1", "2", "3", "4"),
+			NewString("3", "4", "5", "6"),
+			NewString("3", "4"),
+		},
+		{
+			NewString("1", "2", "3", "4"),
+			NewString("1", "2", "3", "4"),
+			NewString("1", "2", "3", "4"),
+		},
+		{
+			NewString("1", "2", "3", "4"),
+			NewString(),
+			NewString(),
+		},
+		{
+			NewString(),
+			NewString("1", "2", "3", "4"),
+			NewString(),
+		},
+		{
+			NewString(),
+			NewString(),
+			NewString(),
+		},
+	}
+
+	for _, test := range tests {
+		intersection := test.s1.Intersection(test.s2)
+		if intersection.Len() != test.expected.Len() {
+			t.Errorf("Expected intersection.Len()=%d but got %d", test.expected.Len(), intersection.Len())
+		}
+
+		if !intersection.Equal(test.expected) {
+			t.Errorf("Expected intersection.Equal(expected) but not true.  intersection:%v expected:%v", intersection.List(), test.expected.List())
+		}
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/slice/slice_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/slice/slice_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package slice
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCopyStrings(t *testing.T) {
+	src := []string{"a", "c", "b"}
+	dest := CopyStrings(src)
+
+	if !reflect.DeepEqual(src, dest) {
+		t.Errorf("%v and %v are not equal", src, dest)
+	}
+
+	src[0] = "A"
+	if reflect.DeepEqual(src, dest) {
+		t.Errorf("CopyStrings didn't make a copy")
+	}
+}
+
+func TestSortStrings(t *testing.T) {
+	src := []string{"a", "c", "b"}
+	dest := SortStrings(src)
+	expected := []string{"a", "b", "c"}
+
+	if !reflect.DeepEqual(dest, expected) {
+		t.Errorf("SortString didn't sort the strings")
+	}
+
+	if !reflect.DeepEqual(src, expected) {
+		t.Errorf("SortString didn't sort in place")
+	}
+}
+
+func TestShuffleStrings(t *testing.T) {
+	src := []string{"a", "b", "c", "d", "e", "f"}
+	dest := ShuffleStrings(src)
+
+	if len(src) != len(dest) {
+		t.Errorf("Shuffled slice is wrong length, expected %v got %v", len(src), len(dest))
+	}
+
+	m := make(map[string]bool, len(dest))
+	for _, s := range dest {
+		m[s] = true
+	}
+
+	for _, k := range src {
+		if _, exists := m[k]; !exists {
+			t.Errorf("Element %v missing from shuffled slice", k)
+		}
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/ssh_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/ssh_test.go
@@ -1,0 +1,245 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/golang/glog"
+	"golang.org/x/crypto/ssh"
+)
+
+type testSSHServer struct {
+	Host       string
+	Port       string
+	Type       string
+	Data       []byte
+	PrivateKey []byte
+	PublicKey  []byte
+}
+
+func runTestSSHServer(user, password string) (*testSSHServer, error) {
+	result := &testSSHServer{}
+	// Largely derived from https://godoc.org/golang.org/x/crypto/ssh#example-NewServerConn
+	config := &ssh.ServerConfig{
+		PasswordCallback: func(c ssh.ConnMetadata, pass []byte) (*ssh.Permissions, error) {
+			if c.User() == user && string(pass) == password {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("password rejected for %s", c.User())
+		},
+		PublicKeyCallback: func(c ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permissions, error) {
+			result.Type = key.Type()
+			result.Data = ssh.MarshalAuthorizedKey(key)
+			return nil, nil
+		},
+	}
+
+	privateKey, publicKey, err := GenerateKey(2048)
+	if err != nil {
+		return nil, err
+	}
+	privateBytes := EncodePrivateKey(privateKey)
+	signer, err := ssh.ParsePrivateKey(privateBytes)
+	if err != nil {
+		return nil, err
+	}
+	config.AddHostKey(signer)
+	result.PrivateKey = privateBytes
+
+	publicBytes, err := EncodePublicKey(publicKey)
+	if err != nil {
+		return nil, err
+	}
+	result.PublicKey = publicBytes
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, err
+	}
+
+	host, port, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		return nil, err
+	}
+	result.Host = host
+	result.Port = port
+	go func() {
+		// TODO: return this port.
+		defer listener.Close()
+
+		conn, err := listener.Accept()
+		if err != nil {
+			glog.Errorf("Failed to accept: %v", err)
+		}
+		_, chans, reqs, err := ssh.NewServerConn(conn, config)
+		if err != nil {
+			glog.Errorf("Failed handshake: %v", err)
+		}
+		go ssh.DiscardRequests(reqs)
+		for newChannel := range chans {
+			if newChannel.ChannelType() != "direct-tcpip" {
+				newChannel.Reject(ssh.UnknownChannelType, fmt.Sprintf("unknown channel type: %s", newChannel.ChannelType()))
+				continue
+			}
+			channel, requests, err := newChannel.Accept()
+			if err != nil {
+				glog.Errorf("Failed to accept channel: %v", err)
+			}
+
+			for req := range requests {
+				glog.Infof("Got request: %v", req)
+			}
+
+			channel.Close()
+		}
+	}()
+	return result, nil
+}
+
+func TestSSHTunnel(t *testing.T) {
+	private, public, err := GenerateKey(2048)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+		t.FailNow()
+	}
+	server, err := runTestSSHServer("foo", "bar")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+		t.FailNow()
+	}
+
+	privateData := EncodePrivateKey(private)
+	tunnel, err := NewSSHTunnelFromBytes("foo", privateData, server.Host)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+		t.FailNow()
+	}
+	tunnel.SSHPort = server.Port
+
+	if err := tunnel.Open(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+		t.FailNow()
+	}
+
+	_, err = tunnel.Dial("tcp", "127.0.0.1:8080")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if server.Type != "ssh-rsa" {
+		t.Errorf("expected %s, got %s", "ssh-rsa", server.Type)
+	}
+
+	publicData, err := EncodeSSHKey(public)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(server.Data, publicData) {
+		t.Errorf("expected %s, got %s", string(server.Data), string(privateData))
+	}
+
+	if err := tunnel.Close(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+type mockSSHDialer struct {
+	network string
+	addr    string
+	config  *ssh.ClientConfig
+}
+
+func (d *mockSSHDialer) Dial(network, addr string, config *ssh.ClientConfig) (*ssh.Client, error) {
+	d.network = network
+	d.addr = addr
+	d.config = config
+	return nil, fmt.Errorf("mock error from Dial")
+}
+
+type mockSigner struct {
+}
+
+func (s *mockSigner) PublicKey() ssh.PublicKey {
+	panic("mockSigner.PublicKey not implemented")
+}
+
+func (s *mockSigner) Sign(rand io.Reader, data []byte) (*ssh.Signature, error) {
+	panic("mockSigner.Sign not implemented")
+}
+
+func TestSSHUser(t *testing.T) {
+	signer := &mockSigner{}
+
+	table := []struct {
+		title      string
+		user       string
+		host       string
+		signer     ssh.Signer
+		command    string
+		expectUser string
+	}{
+		{
+			title:      "all values provided",
+			user:       "testuser",
+			host:       "testhost",
+			signer:     signer,
+			command:    "uptime",
+			expectUser: "testuser",
+		},
+		{
+			title:      "empty user defaults to GetEnv(USER)",
+			user:       "",
+			host:       "testhost",
+			signer:     signer,
+			command:    "uptime",
+			expectUser: os.Getenv("USER"),
+		},
+	}
+
+	for _, item := range table {
+		dialer := &mockSSHDialer{}
+
+		_, _, _, err := runSSHCommand(dialer, item.command, item.user, item.host, item.signer)
+		if err == nil {
+			t.Errorf("expected error (as mock returns error); did not get one")
+		}
+		errString := err.Error()
+		if !strings.HasPrefix(errString, fmt.Sprintf("error getting SSH client to %s@%s:", item.expectUser, item.host)) {
+			t.Errorf("unexpected error: %v", errString)
+		}
+
+		if dialer.network != "tcp" {
+			t.Errorf("unexpected network: %v", dialer.network)
+		}
+
+		if dialer.config.User != item.expectUser {
+			t.Errorf("unexpected user: %v", dialer.config.User)
+		}
+		if len(dialer.config.Auth) != 1 {
+			t.Errorf("unexpected auth: %v", dialer.config.Auth)
+		}
+		// (No way to test Auth - nothing exported?)
+
+	}
+
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/strategicpatch/patch_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/strategicpatch/patch_test.go
@@ -1,0 +1,829 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package strategicpatch
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/ghodss/yaml"
+)
+
+type StrategicMergePatchTestCases struct {
+	TestCases []StrategicMergePatchTestCase
+}
+
+type SortMergeListTestCases struct {
+	TestCases []SortMergeListTestCase
+}
+
+type StrategicMergePatchTestCaseData struct {
+	Original map[string]interface{}
+	Patch    map[string]interface{}
+	Modified map[string]interface{}
+}
+
+type StrategicMergePatchTestCase struct {
+	Description string
+	StrategicMergePatchTestCaseData
+}
+
+type SortMergeListTestCase struct {
+	Description string
+	Original    map[string]interface{}
+	Sorted      map[string]interface{}
+}
+
+type MergeItem struct {
+	Name              string
+	Value             string
+	Other             string
+	MergingList       []MergeItem `patchStrategy:"merge" patchMergeKey:"name"`
+	NonMergingList    []MergeItem
+	MergingIntList    []int `patchStrategy:"merge"`
+	NonMergingIntList []int
+	MergeItemPtr      *MergeItem `patchStrategy:"merge" patchMergeKey:"name"`
+	SimpleMap         map[string]string
+}
+
+// These are test cases for SortMergeList, used to assert that it (recursively)
+// sorts both merging and non merging lists correctly.
+var sortMergeListTestCaseData = []byte(`
+testCases:
+  - description: sort one list of maps
+    original:
+      mergingList:
+        - name: 1
+        - name: 3
+        - name: 2
+    sorted:
+      mergingList:
+        - name: 1
+        - name: 2
+        - name: 3
+  - description: sort lists of maps but not nested lists of maps
+    original:
+      mergingList:
+        - name: 2
+          nonMergingList:
+            - name: 1
+            - name: 3
+            - name: 2
+        - name: 1
+          nonMergingList:
+            - name: 2
+            - name: 1
+    sorted:
+      mergingList:
+        - name: 1
+          nonMergingList:
+            - name: 2
+            - name: 1
+        - name: 2
+          nonMergingList:
+            - name: 1
+            - name: 3
+            - name: 2
+  - description: sort lists of maps and nested lists of maps
+    fieldTypes:
+    original:
+      mergingList:
+        - name: 2
+          mergingList:
+            - name: 1
+            - name: 3
+            - name: 2
+        - name: 1
+          mergingList:
+            - name: 2
+            - name: 1
+    sorted:
+      mergingList:
+        - name: 1
+          mergingList:
+            - name: 1
+            - name: 2
+        - name: 2
+          mergingList:
+            - name: 1
+            - name: 2
+            - name: 3
+  - description: merging list should NOT sort when nested in non merging list
+    original:
+      nonMergingList:
+        - name: 2
+          mergingList:
+            - name: 1
+            - name: 3
+            - name: 2
+        - name: 1
+          mergingList:
+            - name: 2
+            - name: 1
+    sorted:
+      nonMergingList:
+        - name: 2
+          mergingList:
+            - name: 1
+            - name: 3
+            - name: 2
+        - name: 1
+          mergingList:
+            - name: 2
+            - name: 1
+  - description: sort very nested list of maps
+    fieldTypes:
+    original:
+      mergingList:
+        - mergingList:
+            - mergingList:
+                - name: 2
+                - name: 1
+    sorted:
+      mergingList:
+        - mergingList:
+            - mergingList:
+                - name: 1
+                - name: 2
+  - description: sort nested lists of ints
+    original:
+      mergingList:
+        - name: 2
+          mergingIntList:
+            - 1
+            - 3
+            - 2
+        - name: 1
+          mergingIntList:
+            - 2
+            - 1
+    sorted:
+      mergingList:
+        - name: 1
+          mergingIntList:
+            - 1
+            - 2
+        - name: 2
+          mergingIntList:
+            - 1
+            - 2
+            - 3
+  - description: sort nested pointers of ints
+    original:
+      mergeItemPtr:
+        - name: 2
+          mergingIntList:
+            - 1
+            - 3
+            - 2
+        - name: 1
+          mergingIntList:
+            - 2
+            - 1
+    sorted:
+      mergeItemPtr:
+        - name: 1
+          mergingIntList:
+            - 1
+            - 2
+        - name: 2
+          mergingIntList:
+            - 1
+            - 2
+            - 3
+  - description: sort merging list by pointer
+    original:
+      mergeItemPtr:
+        - name: 1
+        - name: 3
+        - name: 2
+    sorted:
+      mergeItemPtr:
+        - name: 1
+        - name: 2
+        - name: 3
+`)
+
+func TestSortMergeLists(t *testing.T) {
+	tc := SortMergeListTestCases{}
+	err := yaml.Unmarshal(sortMergeListTestCaseData, &tc)
+	if err != nil {
+		t.Errorf("can't unmarshal test cases: %v", err)
+		return
+	}
+
+	var e MergeItem
+	for _, c := range tc.TestCases {
+		sorted, err := sortMergeListsByName(toJSONOrFail(c.Original, t), e)
+		if err != nil {
+			t.Errorf("sort arrays returned error: %v", err)
+		}
+
+		if !reflect.DeepEqual(sorted, toJSONOrFail(c.Sorted, t)) {
+			t.Errorf("sorting failed: %v\ntried to sort:\n%vexpected:\n%vgot:\n%v",
+				c.Description, toYAMLOrError(c.Original), toYAMLOrError(c.Sorted), jsonToYAMLOrError(sorted))
+		}
+	}
+}
+
+// These are test cases for StrategicMergePatch that cannot be generated using
+// CreateStrategicMergePatch because it doesn't use the replace directive, generate
+// duplicate integers for a merging list patch, or generate empty merging lists.
+var customStrategicMergePatchTestCaseData = []byte(`
+testCases:
+  - description: unique scalars when merging lists
+    original:
+      mergingIntList:
+        - 1
+        - 2
+    patch:
+      mergingIntList:
+        - 2
+        - 3
+    modified:
+      mergingIntList:
+        - 1
+        - 2
+        - 3
+  - description: delete all items from merging list
+    original:
+      mergingList:
+        - name: 1
+        - name: 2
+    patch:
+      mergingList:
+        - $patch: replace
+    modified:
+      mergingList: []
+  - description: merge empty merging lists
+    original:
+      mergingList: []
+    patch:
+      mergingList: []
+    modified:
+      mergingList: []
+  - description: delete all keys from map
+    original:
+      name: 1
+      value: 1
+    patch:
+      $patch: replace
+    modified: {}
+  - description: add key and delete all keys from map
+    original:
+      name: 1
+      value: 1
+    patch:
+      other: a
+      $patch: replace
+    modified:
+      other: a
+`)
+
+func TestCustomStrategicMergePatch(t *testing.T) {
+	tc := StrategicMergePatchTestCases{}
+	err := yaml.Unmarshal(customStrategicMergePatchTestCaseData, &tc)
+	if err != nil {
+		t.Errorf("can't unmarshal test cases: %v", err)
+		return
+	}
+
+	for _, c := range tc.TestCases {
+		cOriginal, cPatch, cModified := testCaseToJSONOrFail(t, c)
+		testPatchApplication(t, cOriginal, cPatch, cModified, c.Description)
+	}
+}
+
+func testCaseToJSONOrFail(t *testing.T, c StrategicMergePatchTestCase) ([]byte, []byte, []byte) {
+	var e MergeItem
+	cOriginal := toJSONOrFail(c.Original, t)
+	cPatch, err := sortMergeListsByName(toJSONOrFail(c.Patch, t), e)
+	if err != nil {
+		t.Errorf("error:%v sorting patch object:\n%v", err, c.Patch)
+	}
+
+	cModified, err := sortMergeListsByName(toJSONOrFail(c.Modified, t), e)
+	if err != nil {
+		t.Errorf("error: %v sorting modified object:\n%v", err, c.Modified)
+	}
+
+	return cOriginal, cPatch, cModified
+}
+
+func testPatchApplication(t *testing.T, cOriginal, cPatch, cModified []byte, description string) {
+	var e MergeItem
+	modified, err := StrategicMergePatch(cOriginal, cPatch, e)
+	if err != nil {
+		t.Errorf("error applying patch: %v:\noriginal:\n%vpatch:\n%v",
+			err, jsonToYAMLOrError(cOriginal), jsonToYAMLOrError(cPatch))
+	}
+
+	// Sort the lists that have merged maps, since order is not significant.
+	modified, err = sortMergeListsByName(modified, e)
+	if err != nil {
+		t.Errorf("error: %v sorting modified object:\n%v", err, modified)
+	}
+
+	if !reflect.DeepEqual(modified, cModified) {
+		t.Errorf("patch application failed: %v\noriginal:\n%vpatch:\n%vexpected modified:\n%vgot modified:\n%v",
+			description, jsonToYAMLOrError(cOriginal), jsonToYAMLOrError(cPatch),
+			jsonToYAMLOrError(cModified), jsonToYAMLOrError(modified))
+	}
+}
+
+// These are test cases for CreateStrategicMergePatch, used to assert that it
+// generates the correct patch for a given outcome. They are also test cases for
+// StrategicMergePatch, used to assert that applying a patch yields the correct
+// outcome.
+var createStrategicMergePatchTestCaseData = []byte(`
+testCases:
+  - description: add field to map
+    original:
+      name: 1
+    patch:
+      value: 1
+    modified:
+      name: 1
+      value: 1
+  - description: add field and delete field from map
+    original:
+      name: 1
+    patch:
+      name: null
+      value: 1
+    modified:
+      value: 1
+  - description: delete field from nested map
+    original:
+      simpleMap:
+        key1: 1
+        key2: 1
+    patch:
+      simpleMap:
+        key2: null
+    modified:
+      simpleMap:
+        key1: 1
+  - description: delete all fields from map
+    original:
+      name: 1
+      value: 1
+    patch:
+      name: null
+      value: null
+    modified: {}
+  - description: add field and delete all fields from map
+    original:
+      name: 1
+      value: 1
+    patch:
+      other: a
+      name: null
+      value: null
+    modified:
+      other: a
+  - description: replace list of scalars
+    original:
+      nonMergingIntList:
+        - 1
+        - 2
+    patch:
+      nonMergingIntList:
+        - 2
+        - 3
+    modified:
+      nonMergingIntList:
+        - 2
+        - 3
+  - description: merge lists of scalars
+    original:
+      mergingIntList:
+        - 1
+        - 2
+    patch:
+      mergingIntList:
+        - 3
+    modified:
+      mergingIntList:
+        - 1
+        - 2
+        - 3
+  - description: merge lists of maps
+    original:
+      mergingList:
+        - name: 1
+        - name: 2
+          value: 2
+    patch:
+      mergingList:
+        - name: 3
+          value: 3
+    modified:
+      mergingList:
+        - name: 1
+        - name: 2
+          value: 2
+        - name: 3
+          value: 3
+  - description: add field to map in merging list
+    original:
+      mergingList:
+        - name: 1
+        - name: 2
+          value: 2
+    patch:
+      mergingList:
+        - name: 1
+          value: 1
+    modified:
+      mergingList:
+        - name: 1
+          value: 1
+        - name: 2
+          value: 2
+  - description: add duplicate field to map in merging list
+    original:
+      mergingList:
+        - name: 1
+        - name: 2
+          value: 2
+    patch:
+      mergingList:
+        - name: 1
+          value: 1
+    modified:
+      mergingList:
+        - name: 1
+          value: 1
+        - name: 2
+          value: 2
+  - description: replace map field value in merging list
+    original:
+      mergingList:
+        - name: 1
+          value: 1
+        - name: 2
+          value: 2
+    patch:
+      mergingList:
+        - name: 1
+          value: a
+    modified:
+      mergingList:
+        - name: 1
+          value: a
+        - name: 2
+          value: 2
+  - description: delete map from merging list
+    original:
+      mergingList:
+        - name: 1
+        - name: 2
+    patch:
+      mergingList:
+        - name: 1
+          $patch: delete
+    modified:
+      mergingList:
+        - name: 2
+  - description: delete missing map from merging list
+    original:
+      mergingList:
+        - name: 1
+        - name: 2
+    patch:
+      mergingList:
+        - name: 1
+          $patch: delete
+    modified:
+      mergingList:
+        - name: 2
+  - description: add map and delete map from merging list
+    original:
+      merginglist:
+        - name: 1
+        - name: 2
+    patch:
+      merginglist:
+        - name: 1
+          $patch: delete
+        - name: 3
+    modified:
+      merginglist:
+        - name: 2
+        - name: 3
+  - description: delete all maps from merging list
+    original:
+      mergingList:
+        - name: 1
+        - name: 2
+    patch:
+      mergingList:
+        - name: 1
+          $patch: delete
+        - name: 2
+          $patch: delete
+    modified:
+      mergingList: []
+  - description: delete all maps from partially empty merging list
+    original:
+      mergingList:
+        - name: 1
+        - name: 2
+    patch:
+      mergingList:
+        - name: 1
+          $patch: delete
+        - name: 2
+          $patch: delete
+    modified:
+      mergingList: []
+  - description: delete all maps from empty merging list
+    original:
+      mergingList:
+        - name: 1
+        - name: 2
+    patch:
+      mergingList:
+        - name: 1
+          $patch: delete
+        - name: 2
+          $patch: delete
+    modified:
+      mergingList: []
+  - description: delete field from map in merging list
+    original:
+      mergingList:
+        - name: 1
+          value: 1
+        - name: 2
+          value: 2
+    patch:
+      mergingList:
+        - name: 1
+          value: null
+    modified:
+      mergingList:
+        - name: 1
+        - name: 2
+          value: 2
+  - description: replace non merging list nested in merging list
+    original:
+      mergingList:
+        - name: 1
+          nonMergingList:
+            - name: 1
+            - name: 2
+              value: 2
+        - name: 2
+    patch:
+      mergingList:
+        - name: 1
+          nonMergingList:
+            - name: 1
+              value: 1
+    modified:
+      mergingList:
+        - name: 1
+          nonMergingList:
+            - name: 1
+              value: 1
+        - name: 2
+  - description: add field to map in merging list nested in merging list
+    original:
+      mergingList:
+        - name: 1
+          mergingList:
+            - name: 1
+            - name: 2
+              value: 2
+        - name: 2
+    patch:
+      mergingList:
+        - name: 1
+          mergingList:
+            - name: 1
+              value: 1
+    modified:
+      mergingList:
+        - name: 1
+          mergingList:
+            - name: 1
+              value: 1
+            - name: 2
+              value: 2
+        - name: 2
+  - description: merge empty merging lists
+    original:
+      mergingList: []
+    patch:
+      {}
+    modified:
+      mergingList: []
+    current:
+      mergingList: []
+    result:
+      mergingList: []
+  - description: add map to merging list by pointer
+    original:
+      mergeItemPtr:
+        - name: 1
+    patch:
+      mergeItemPtr:
+        - name: 2
+    modified:
+      mergeItemPtr:
+        - name: 1
+        - name: 2
+  - description: add field to map in merging list by pointer
+    original:
+      mergeItemPtr:
+        - name: 1
+          mergeItemPtr:
+            - name: 1
+            - name: 2
+              value: 2
+        - name: 2
+    patch:
+      mergeItemPtr:
+        - name: 1
+          mergeItemPtr:
+            - name: 1
+              value: 1
+    modified:
+      mergeItemPtr:
+        - name: 1
+          mergeItemPtr:
+            - name: 1
+              value: 1
+            - name: 2
+              value: 2
+        - name: 2
+`)
+
+func TestStrategicMergePatch(t *testing.T) {
+	tc := StrategicMergePatchTestCases{}
+	err := yaml.Unmarshal(createStrategicMergePatchTestCaseData, &tc)
+	if err != nil {
+		t.Errorf("can't unmarshal test cases: %v", err)
+		return
+	}
+
+	var e MergeItem
+	for _, c := range tc.TestCases {
+		cOriginal, cPatch, cModified := testCaseToJSONOrFail(t, c)
+
+		// Test patch generation
+		patch, err := CreateStrategicMergePatch(cOriginal, cModified, e)
+		if err != nil {
+			t.Errorf("error generating patch: %s:\n%v", err, toYAMLOrError(c.StrategicMergePatchTestCaseData))
+		}
+
+		// Sort the lists that have merged maps, since order is not significant.
+		patch, err = sortMergeListsByName(patch, e)
+		if err != nil {
+			t.Errorf("error: %s sorting patch object:\n%v", err, patch)
+		}
+
+		if !reflect.DeepEqual(patch, cPatch) {
+			t.Errorf("patch generation failed:\n%vgot patch:\n%v", toYAMLOrError(c.StrategicMergePatchTestCaseData), jsonToYAMLOrError(patch))
+		}
+
+		// Test patch application
+		testPatchApplication(t, cOriginal, cPatch, cModified, c.Description)
+	}
+}
+
+func toYAMLOrError(v interface{}) string {
+	y, err := toYAML(v)
+	if err != nil {
+		return err.Error()
+	}
+
+	return y
+}
+
+func toJSONOrFail(v interface{}, t *testing.T) []byte {
+	theJSON, err := toJSON(v)
+	if err != nil {
+		t.Error(err)
+	}
+
+	return theJSON
+}
+
+func jsonToYAMLOrError(j []byte) string {
+	y, err := jsonToYAML(j)
+	if err != nil {
+		return err.Error()
+	}
+
+	return string(y)
+}
+
+func toYAML(v interface{}) (string, error) {
+	y, err := yaml.Marshal(v)
+	if err != nil {
+		return "", fmt.Errorf("yaml marshal failed: %v\n%v", err, spew.Sdump(v))
+	}
+
+	return string(y), nil
+}
+
+func toJSON(v interface{}) ([]byte, error) {
+	j, err := json.Marshal(v)
+	if err != nil {
+		return nil, fmt.Errorf("json marshal failed: %v\n%v", err, spew.Sdump(v))
+	}
+
+	return j, nil
+}
+
+func jsonToYAML(j []byte) ([]byte, error) {
+	y, err := yaml.JSONToYAML(j)
+	if err != nil {
+		return nil, fmt.Errorf("json to yaml failed: %v\n%v", err, j)
+	}
+
+	return y, nil
+}
+
+func TestHasConflicts(t *testing.T) {
+	testCases := []struct {
+		A   interface{}
+		B   interface{}
+		Ret bool
+	}{
+		{A: "hello", B: "hello", Ret: false}, // 0
+		{A: "hello", B: "hell", Ret: true},
+		{A: "hello", B: nil, Ret: true},
+		{A: "hello", B: 1, Ret: true},
+		{A: "hello", B: float64(1.0), Ret: true},
+		{A: "hello", B: false, Ret: true},
+		{A: 1, B: 1, Ret: false},
+		{A: false, B: false, Ret: false},
+		{A: float64(3), B: float64(3), Ret: false},
+
+		{A: "hello", B: []interface{}{}, Ret: true}, // 6
+		{A: []interface{}{1}, B: []interface{}{}, Ret: true},
+		{A: []interface{}{}, B: []interface{}{}, Ret: false},
+		{A: []interface{}{1}, B: []interface{}{1}, Ret: false},
+		{A: map[string]interface{}{}, B: []interface{}{1}, Ret: true},
+
+		{A: map[string]interface{}{}, B: map[string]interface{}{"a": 1}, Ret: false}, // 11
+		{A: map[string]interface{}{"a": 1}, B: map[string]interface{}{"a": 1}, Ret: false},
+		{A: map[string]interface{}{"a": 1}, B: map[string]interface{}{"a": 2}, Ret: true},
+		{A: map[string]interface{}{"a": 1}, B: map[string]interface{}{"b": 2}, Ret: false},
+
+		{ // 15
+			A:   map[string]interface{}{"a": []interface{}{1}},
+			B:   map[string]interface{}{"a": []interface{}{1}},
+			Ret: false,
+		},
+		{
+			A:   map[string]interface{}{"a": []interface{}{1}},
+			B:   map[string]interface{}{"a": []interface{}{}},
+			Ret: true,
+		},
+		{
+			A:   map[string]interface{}{"a": []interface{}{1}},
+			B:   map[string]interface{}{"a": 1},
+			Ret: true,
+		},
+	}
+
+	for i, testCase := range testCases {
+		out, err := HasConflicts(testCase.A, testCase.B)
+		if err != nil {
+			t.Errorf("%d: unexpected error: %v", i, err)
+		}
+		if out != testCase.Ret {
+			t.Errorf("%d: expected %t got %t", i, testCase.Ret, out)
+			continue
+		}
+		out, err = HasConflicts(testCase.B, testCase.A)
+		if err != nil {
+			t.Errorf("%d: unexpected error: %v", i, err)
+		}
+		if out != testCase.Ret {
+			t.Errorf("%d: expected reversed %t got %t", i, testCase.Ret, out)
+		}
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/template_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/template_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWrap(t *testing.T) {
+	tt := `before ->{{.Long | wrap "**"}}<- after`
+	data := struct {
+		Long string
+	}{
+		`Hodor, hodor; hodor hodor;
+hodor hodor... Hodor hodor hodor? Hodor. Hodor hodor hodor hodor...
+Hodor hodor hodor; hodor hodor hodor! Hodor, hodor. Hodor. Hodor,
+HODOR hodor, hodor hodor; hodor hodor; hodor HODOR hodor, hodor hodor?
+Hodor. Hodor hodor - hodor hodor. Hodor hodor HODOR! Hodor hodor - hodor...
+Hodor hodor HODOR hodor, hodor hodor hodor! Hodor, hodor... Hodor hodor
+hodor hodor hodor hodor! Hodor, hodor; hodor hodor. Hodor.`,
+	}
+	output, _ := ExecuteTemplateToString(tt, data)
+	t.Logf("%q", output)
+
+	assert.Equal(t, `before ->**Hodor, hodor; hodor hodor; hodor hodor... Hodor hodor hodor? Hodor. Hodor
+**hodor hodor hodor... Hodor hodor hodor; hodor hodor hodor! Hodor, hodor.
+**Hodor. Hodor, HODOR hodor, hodor hodor; hodor hodor; hodor HODOR hodor, hodor
+**hodor? Hodor. Hodor hodor - hodor hodor. Hodor hodor HODOR! Hodor hodor -
+**hodor... Hodor hodor HODOR hodor, hodor hodor hodor! Hodor, hodor... Hodor
+**hodor hodor hodor hodor hodor! Hodor, hodor; hodor hodor. Hodor.
+<- after`, output)
+}
+
+func TestTrim(t *testing.T) {
+	tt := `before ->{{.Messy | trim }}<- after`
+	data := struct {
+		Messy string
+	}{
+		"\t  stuff\n \r ",
+	}
+	output, _ := ExecuteTemplateToString(tt, data)
+	t.Logf("%q", output)
+
+	assert.Equal(t, `before ->stuff<- after`, output)
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/throttle_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/throttle_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBasicThrottle(t *testing.T) {
+	r := NewTokenBucketRateLimiter(1, 3)
+	for i := 0; i < 3; i++ {
+		if !r.CanAccept() {
+			t.Error("unexpected false accept")
+		}
+	}
+	if r.CanAccept() {
+		t.Error("unexpected true accept")
+	}
+}
+
+func TestIncrementThrottle(t *testing.T) {
+	r := NewTokenBucketRateLimiter(1, 1)
+	if !r.CanAccept() {
+		t.Error("unexpected false accept")
+	}
+	if r.CanAccept() {
+		t.Error("unexpected true accept")
+	}
+
+	// Allow to refill
+	time.Sleep(2 * time.Second)
+
+	if !r.CanAccept() {
+		t.Error("unexpected false accept")
+	}
+}
+
+func TestThrottle(t *testing.T) {
+	r := NewTokenBucketRateLimiter(10, 5)
+
+	// Should consume 5 tokens immediately, then
+	// the remaining 11 should take at least 1 second (0.1s each)
+	expectedFinish := time.Now().Add(time.Second * 1)
+	for i := 0; i < 16; i++ {
+		r.Accept()
+	}
+	if time.Now().Before(expectedFinish) {
+		t.Error("rate limit was not respected, finished too early")
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/util.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/util.go
@@ -41,6 +41,15 @@ import (
 // For testing, bypass HandleCrash.
 var ReallyCrash bool
 
+// For any test of the style:
+//   ...
+//   <- time.After(timeout):
+//      t.Errorf("Timed out")
+// The value for timeout should effectively be "forever." Obviously we don't want our tests to truly lock up forever, but 30s
+// is long enough that it is effectively forever for the things that can slow down a run on a heavily contended machine
+// (GC, seeks, etc), but not so long as to make a developer ctrl-c a test run if they do happen to break that test.
+var ForeverTestTimeout = time.Second * 30
+
 // PanicHandlers is a list of functions which will be invoked when a panic happens.
 var PanicHandlers = []func(interface{}){logPanic}
 

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/util_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/util_test.go
@@ -1,0 +1,612 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/ghodss/yaml"
+)
+
+func TestUntil(t *testing.T) {
+	ch := make(chan struct{})
+	close(ch)
+	Until(func() {
+		t.Fatal("should not have been invoked")
+	}, 0, ch)
+
+	ch = make(chan struct{})
+	called := make(chan struct{})
+	go func() {
+		Until(func() {
+			called <- struct{}{}
+		}, 0, ch)
+		close(called)
+	}()
+	<-called
+	close(ch)
+	<-called
+}
+
+func TestHandleCrash(t *testing.T) {
+	count := 0
+	expect := 10
+	for i := 0; i < expect; i = i + 1 {
+		defer HandleCrash()
+		if i%2 == 0 {
+			panic("Test Panic")
+		}
+		count = count + 1
+	}
+	if count != expect {
+		t.Errorf("Expected %d iterations, found %d", expect, count)
+	}
+}
+
+func TestCustomHandleCrash(t *testing.T) {
+	old := PanicHandlers
+	defer func() { PanicHandlers = old }()
+	var result interface{}
+	PanicHandlers = []func(interface{}){
+		func(r interface{}) {
+			result = r
+		},
+	}
+	func() {
+		defer HandleCrash()
+		panic("test")
+	}()
+	if result != "test" {
+		t.Errorf("did not receive custom handler")
+	}
+}
+
+func TestCustomHandleError(t *testing.T) {
+	old := ErrorHandlers
+	defer func() { ErrorHandlers = old }()
+	var result error
+	ErrorHandlers = []func(error){
+		func(err error) {
+			result = err
+		},
+	}
+	err := fmt.Errorf("test")
+	HandleError(err)
+	if result != err {
+		t.Errorf("did not receive custom handler")
+	}
+}
+
+func TestNewIntOrStringFromInt(t *testing.T) {
+	i := NewIntOrStringFromInt(93)
+	if i.Kind != IntstrInt || i.IntVal != 93 {
+		t.Errorf("Expected IntVal=93, got %+v", i)
+	}
+}
+
+func TestNewIntOrStringFromString(t *testing.T) {
+	i := NewIntOrStringFromString("76")
+	if i.Kind != IntstrString || i.StrVal != "76" {
+		t.Errorf("Expected StrVal=\"76\", got %+v", i)
+	}
+}
+
+type IntOrStringHolder struct {
+	IOrS IntOrString `json:"val"`
+}
+
+func TestIntOrStringUnmarshalYAML(t *testing.T) {
+	cases := []struct {
+		input  string
+		result IntOrString
+	}{
+		{"val: 123\n", IntOrString{Kind: IntstrInt, IntVal: 123}},
+		{"val: \"123\"\n", IntOrString{Kind: IntstrString, StrVal: "123"}},
+	}
+
+	for _, c := range cases {
+		var result IntOrStringHolder
+		if err := yaml.Unmarshal([]byte(c.input), &result); err != nil {
+			t.Errorf("Failed to unmarshal input '%v': %v", c.input, err)
+		}
+		if result.IOrS != c.result {
+			t.Errorf("Failed to unmarshal input '%v': expected: %+v, got %+v", c.input, c.result, result)
+		}
+	}
+}
+
+func TestIntOrStringMarshalYAML(t *testing.T) {
+	cases := []struct {
+		input  IntOrString
+		result string
+	}{
+		{IntOrString{Kind: IntstrInt, IntVal: 123}, "val: 123\n"},
+		{IntOrString{Kind: IntstrString, StrVal: "123"}, "val: \"123\"\n"},
+	}
+
+	for _, c := range cases {
+		input := IntOrStringHolder{c.input}
+		result, err := yaml.Marshal(&input)
+		if err != nil {
+			t.Errorf("Failed to marshal input '%v': %v", input, err)
+		}
+		if string(result) != c.result {
+			t.Errorf("Failed to marshal input '%v': expected: %+v, got %q", input, c.result, string(result))
+		}
+	}
+}
+
+func TestIntOrStringUnmarshalJSON(t *testing.T) {
+	cases := []struct {
+		input  string
+		result IntOrString
+	}{
+		{"{\"val\": 123}", IntOrString{Kind: IntstrInt, IntVal: 123}},
+		{"{\"val\": \"123\"}", IntOrString{Kind: IntstrString, StrVal: "123"}},
+	}
+
+	for _, c := range cases {
+		var result IntOrStringHolder
+		if err := json.Unmarshal([]byte(c.input), &result); err != nil {
+			t.Errorf("Failed to unmarshal input '%v': %v", c.input, err)
+		}
+		if result.IOrS != c.result {
+			t.Errorf("Failed to unmarshal input '%v': expected %+v, got %+v", c.input, c.result, result)
+		}
+	}
+}
+
+func TestIntOrStringMarshalJSON(t *testing.T) {
+	cases := []struct {
+		input  IntOrString
+		result string
+	}{
+		{IntOrString{Kind: IntstrInt, IntVal: 123}, "{\"val\":123}"},
+		{IntOrString{Kind: IntstrString, StrVal: "123"}, "{\"val\":\"123\"}"},
+	}
+
+	for _, c := range cases {
+		input := IntOrStringHolder{c.input}
+		result, err := json.Marshal(&input)
+		if err != nil {
+			t.Errorf("Failed to marshal input '%v': %v", input, err)
+		}
+		if string(result) != c.result {
+			t.Errorf("Failed to marshal input '%v': expected: %+v, got %q", input, c.result, string(result))
+		}
+	}
+}
+
+func TestIntOrStringMarshalJSONUnmarshalYAML(t *testing.T) {
+	cases := []struct {
+		input IntOrString
+	}{
+		{IntOrString{Kind: IntstrInt, IntVal: 123}},
+		{IntOrString{Kind: IntstrString, StrVal: "123"}},
+	}
+
+	for _, c := range cases {
+		input := IntOrStringHolder{c.input}
+		jsonMarshalled, err := json.Marshal(&input)
+		if err != nil {
+			t.Errorf("1: Failed to marshal input: '%v': %v", input, err)
+		}
+
+		var result IntOrStringHolder
+		err = yaml.Unmarshal(jsonMarshalled, &result)
+		if err != nil {
+			t.Errorf("2: Failed to unmarshal '%+v': %v", string(jsonMarshalled), err)
+		}
+
+		if !reflect.DeepEqual(input, result) {
+			t.Errorf("3: Failed to marshal input '%+v': got %+v", input, result)
+		}
+	}
+}
+
+func TestStringDiff(t *testing.T) {
+	diff := StringDiff("aaabb", "aaacc")
+	expect := "aaa\n\nA: bb\n\nB: cc\n\n"
+	if diff != expect {
+		t.Errorf("diff returned %v", diff)
+	}
+}
+
+func TestCompileRegex(t *testing.T) {
+	uncompiledRegexes := []string{"endsWithMe$", "^startingWithMe"}
+	regexes, err := CompileRegexps(uncompiledRegexes)
+
+	if err != nil {
+		t.Errorf("Failed to compile legal regexes: '%v': %v", uncompiledRegexes, err)
+	}
+	if len(regexes) != len(uncompiledRegexes) {
+		t.Errorf("Wrong number of regexes returned: '%v': %v", uncompiledRegexes, regexes)
+	}
+
+	if !regexes[0].MatchString("Something that endsWithMe") {
+		t.Errorf("Wrong regex returned: '%v': %v", uncompiledRegexes[0], regexes[0])
+	}
+	if regexes[0].MatchString("Something that doesn't endsWithMe.") {
+		t.Errorf("Wrong regex returned: '%v': %v", uncompiledRegexes[0], regexes[0])
+	}
+	if !regexes[1].MatchString("startingWithMe is very important") {
+		t.Errorf("Wrong regex returned: '%v': %v", uncompiledRegexes[1], regexes[1])
+	}
+	if regexes[1].MatchString("not startingWithMe should fail") {
+		t.Errorf("Wrong regex returned: '%v': %v", uncompiledRegexes[1], regexes[1])
+	}
+}
+
+func TestAllPtrFieldsNil(t *testing.T) {
+	testCases := []struct {
+		obj      interface{}
+		expected bool
+	}{
+		{struct{}{}, true},
+		{struct{ Foo int }{12345}, true},
+		{&struct{ Foo int }{12345}, true},
+		{struct{ Foo *int }{nil}, true},
+		{&struct{ Foo *int }{nil}, true},
+		{struct {
+			Foo int
+			Bar *int
+		}{12345, nil}, true},
+		{&struct {
+			Foo int
+			Bar *int
+		}{12345, nil}, true},
+		{struct {
+			Foo *int
+			Bar *int
+		}{nil, nil}, true},
+		{&struct {
+			Foo *int
+			Bar *int
+		}{nil, nil}, true},
+		{struct{ Foo *int }{new(int)}, false},
+		{&struct{ Foo *int }{new(int)}, false},
+		{struct {
+			Foo *int
+			Bar *int
+		}{nil, new(int)}, false},
+		{&struct {
+			Foo *int
+			Bar *int
+		}{nil, new(int)}, false},
+		{(*struct{})(nil), true},
+	}
+	for i, tc := range testCases {
+		if AllPtrFieldsNil(tc.obj) != tc.expected {
+			t.Errorf("case[%d]: expected %t, got %t", i, tc.expected, !tc.expected)
+		}
+	}
+}
+
+func TestSplitQualifiedName(t *testing.T) {
+	testCases := []struct {
+		input  string
+		output []string
+	}{
+		{"kubernetes.io/blah", []string{"kubernetes.io", "blah"}},
+		{"blah", []string{"", "blah"}},
+		{"kubernetes.io/blah/blah", []string{"kubernetes.io", "blah"}},
+	}
+	for i, tc := range testCases {
+		namespace, name := SplitQualifiedName(tc.input)
+		if namespace != tc.output[0] || name != tc.output[1] {
+			t.Errorf("case[%d]: expected (%q, %q), got (%q, %q)", i, tc.output[0], tc.output[1], namespace, name)
+		}
+	}
+}
+
+func TestJoinQualifiedName(t *testing.T) {
+	testCases := []struct {
+		input  []string
+		output string
+	}{
+		{[]string{"kubernetes.io", "blah"}, "kubernetes.io/blah"},
+		{[]string{"blah", ""}, "blah"},
+		{[]string{"kubernetes.io", "blah"}, "kubernetes.io/blah"},
+	}
+	for i, tc := range testCases {
+		res := JoinQualifiedName(tc.input[0], tc.input[1])
+		if res != tc.output {
+			t.Errorf("case[%d]: expected %q, got %q", i, tc.output, res)
+		}
+	}
+}
+
+const gatewayfirst = `Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT                                                       
+eth3	00000000	0100FE0A	0003	0	0	1024	00000000	0	0	0                                                                   
+eth3	0000FE0A	00000000	0001	0	0	0	0080FFFF	0	0	0                                                                      
+docker0	000011AC	00000000	0001	0	0	0	0000FFFF	0	0	0                                                                            
+virbr0	007AA8C0	00000000	0001	0	0	0	00FFFFFF	0	0	0
+`
+const gatewaylast = `Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT  
+docker0	000011AC	00000000	0001	0	0	0	0000FFFF	0	0	0                                                                            
+virbr0	007AA8C0	00000000	0001	0	0	0	00FFFFFF	0	0	0                                                                                                                     
+eth3	0000FE0A	00000000	0001	0	0	0	0080FFFF	0	0	0       
+eth3	00000000	0100FE0A	0003	0	0	1024	00000000	0	0	0                                                                 
+`
+const gatewaymiddle = `Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT                                                                                                                     
+eth3	0000FE0A	00000000	0001	0	0	0	0080FFFF	0	0	0                                                                      
+docker0	000011AC	00000000	0001	0	0	0	0000FFFF	0	0	0       
+eth3	00000000	0100FE0A	0003	0	0	1024	00000000	0	0	0                                                                         
+virbr0	007AA8C0	00000000	0001	0	0	0	00FFFFFF	0	0	0
+`
+const noInternetConnection = `Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT                                                       
+docker0	000011AC	00000000	0001	0	0	0	0000FFFF	0	0	0                                                                            
+virbr0	007AA8C0	00000000	0001	0	0	0	00FFFFFF	0	0	0            
+`
+const nothing = `Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT                                                            
+`
+const gatewayfirstIpv6_1 = `Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT                                                       
+eth3	00000000	0100FE0A	0003	0	0	1024	00000000	0	0	0                                                                   
+eth3	0000FE0AA1	00000000	0001	0	0	0	0080FFFF	0	0	0                                                                      
+docker0	000011AC	00000000	0001	0	0	0	0000FFFF	0	0	0                                                                            
+virbr0	007AA8C0	00000000	0001	0	0	0	00FFFFFF	0	0	0
+`
+const gatewayfirstIpv6_2 = `Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT                                                       
+eth3	00000000	0100FE0AA1	0003	0	0	1024	00000000	0	0	0                                                                   
+eth3	0000FE0A	00000000	0001	0	0	0	0080FFFF	0	0	0                                                                      
+docker0	000011AC	00000000	0001	0	0	0	0000FFFF	0	0	0                                                                            
+virbr0	007AA8C0	00000000	0001	0	0	0	00FFFFFF	0	0	0
+`
+const route_Invalidhex = `Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT                                                       
+eth3	00000000	0100FE0AA	0003	0	0	1024	00000000	0	0	0                                                                   
+eth3	0000FE0A	00000000	0001	0	0	0	0080FFFF	0	0	0                                                                      
+docker0	000011AC	00000000	0001	0	0	0	0000FFFF	0	0	0                                                                            
+virbr0	007AA8C0	00000000	0001	0	0	0	00FFFFFF	0	0	0
+`
+
+// Based on DigitalOcean COREOS
+const gatewayfirstLinkLocal = `Iface   Destination     Gateway         Flags   RefCnt  Use     Metric  Mask            MTU     Window  IRTT                                                       
+eth0    00000000        0120372D        0001    0       0       0       00000000        0       0       0                                                                               
+eth0    00000000        00000000        0001    0       0       2048    00000000        0       0       0                                                                            
+`
+
+func TestGetRoutes(t *testing.T) {
+	testCases := []struct {
+		tcase    string
+		route    string
+		expected int
+	}{
+		{"gatewayfirst", gatewayfirst, 4},
+		{"gatewaymiddle", gatewaymiddle, 4},
+		{"gatewaylast", gatewaylast, 4},
+		{"nothing", nothing, 0},
+		{"gatewayfirstIpv6_1", gatewayfirstIpv6_1, 0},
+		{"gatewayfirstIpv6_2", gatewayfirstIpv6_2, 0},
+		{"route_Invalidhex", route_Invalidhex, 0},
+	}
+	for _, tc := range testCases {
+		r := strings.NewReader(tc.route)
+		routes, err := getRoutes(r)
+		if len(routes) != tc.expected {
+			t.Errorf("case[%v]: expected %v, got %v .err : %v", tc.tcase, tc.expected, len(routes), err)
+		}
+	}
+}
+
+func TestParseIP(t *testing.T) {
+	testCases := []struct {
+		tcase    string
+		ip       string
+		success  bool
+		expected net.IP
+	}{
+		{"empty", "", false, nil},
+		{"too short", "AA", false, nil},
+		{"too long", "0011223344", false, nil},
+		{"invalid", "invalid!", false, nil},
+		{"zero", "00000000", true, net.IP{0, 0, 0, 0}},
+		{"ffff", "FFFFFFFF", true, net.IP{0xff, 0xff, 0xff, 0xff}},
+		{"valid", "12345678", true, net.IP{120, 86, 52, 18}},
+	}
+	for _, tc := range testCases {
+		ip, err := parseIP(tc.ip)
+		if !ip.Equal(tc.expected) {
+			t.Errorf("case[%v]: expected %q, got %q . err : %v", tc.tcase, tc.expected, ip, err)
+		}
+	}
+}
+
+func TestIsInterfaceUp(t *testing.T) {
+	testCases := []struct {
+		tcase    string
+		intf     net.Interface
+		expected bool
+	}{
+		{"up", net.Interface{Index: 0, MTU: 0, Name: "eth3", HardwareAddr: nil, Flags: net.FlagUp}, true},
+		{"down", net.Interface{Index: 0, MTU: 0, Name: "eth3", HardwareAddr: nil, Flags: 0}, false},
+		{"nothing", net.Interface{}, false},
+	}
+	for _, tc := range testCases {
+		it := isInterfaceUp(&tc.intf)
+		if it != tc.expected {
+			t.Errorf("case[%v]: expected %v, got %v .", tc.tcase, tc.expected, it)
+		}
+	}
+}
+
+type addrStruct struct{ val string }
+
+func (a addrStruct) Network() string {
+	return a.val
+}
+func (a addrStruct) String() string {
+	return a.val
+}
+
+func TestFinalIP(t *testing.T) {
+	testCases := []struct {
+		tcase    string
+		addr     []net.Addr
+		expected net.IP
+	}{
+		{"ipv6", []net.Addr{addrStruct{val: "fe80::2f7:6fff:fe6e:2956/64"}}, nil},
+		{"invalidCIDR", []net.Addr{addrStruct{val: "fe80::2f7:67fff:fe6e:2956/64"}}, nil},
+		{"loopback", []net.Addr{addrStruct{val: "127.0.0.1/24"}}, nil},
+		{"ip4", []net.Addr{addrStruct{val: "10.254.12.132/17"}}, net.ParseIP("10.254.12.132")},
+
+		{"nothing", []net.Addr{}, nil},
+	}
+	for _, tc := range testCases {
+		ip, err := getFinalIP(tc.addr)
+		if !ip.Equal(tc.expected) {
+			t.Errorf("case[%v]: expected %v, got %v .err : %v", tc.tcase, tc.expected, ip, err)
+		}
+	}
+}
+
+func TestAddrs(t *testing.T) {
+	var nw networkInterfacer = validNetworkInterface{}
+	intf := net.Interface{Index: 0, MTU: 0, Name: "eth3", HardwareAddr: nil, Flags: 0}
+	addrs, err := nw.Addrs(&intf)
+	if err != nil {
+		t.Errorf("expected no error got : %v", err)
+	}
+	if len(addrs) != 2 {
+		t.Errorf("expected addrs: 2 got null")
+	}
+}
+
+type validNetworkInterface struct {
+}
+
+func (_ validNetworkInterface) InterfaceByName(intfName string) (*net.Interface, error) {
+	c := net.Interface{Index: 0, MTU: 0, Name: "eth3", HardwareAddr: nil, Flags: net.FlagUp}
+	return &c, nil
+}
+func (_ validNetworkInterface) Addrs(intf *net.Interface) ([]net.Addr, error) {
+	var ifat []net.Addr
+	ifat = []net.Addr{
+		addrStruct{val: "fe80::2f7:6fff:fe6e:2956/64"}, addrStruct{val: "10.254.71.145/17"}}
+	return ifat, nil
+}
+
+type validNetworkInterfaceWithLinkLocal struct {
+}
+
+func (_ validNetworkInterfaceWithLinkLocal) InterfaceByName(intfName string) (*net.Interface, error) {
+	c := net.Interface{Index: 0, MTU: 0, Name: "eth0", HardwareAddr: nil, Flags: net.FlagUp}
+	return &c, nil
+}
+func (_ validNetworkInterfaceWithLinkLocal) Addrs(intf *net.Interface) ([]net.Addr, error) {
+	var ifat []net.Addr
+	ifat = []net.Addr{addrStruct{val: "169.254.162.166/16"}, addrStruct{val: "45.55.47.146/19"}}
+	return ifat, nil
+}
+
+type validNetworkInterfacewithIpv6Only struct {
+}
+
+func (_ validNetworkInterfacewithIpv6Only) InterfaceByName(intfName string) (*net.Interface, error) {
+	c := net.Interface{Index: 0, MTU: 0, Name: "eth3", HardwareAddr: nil, Flags: net.FlagUp}
+	return &c, nil
+}
+func (_ validNetworkInterfacewithIpv6Only) Addrs(intf *net.Interface) ([]net.Addr, error) {
+	var ifat []net.Addr
+	ifat = []net.Addr{addrStruct{val: "fe80::2f7:6fff:fe6e:2956/64"}}
+	return ifat, nil
+}
+
+type noNetworkInterface struct {
+}
+
+func (_ noNetworkInterface) InterfaceByName(intfName string) (*net.Interface, error) {
+	return nil, fmt.Errorf("unable get Interface")
+}
+func (_ noNetworkInterface) Addrs(intf *net.Interface) ([]net.Addr, error) {
+	return nil, nil
+}
+
+type networkInterfacewithNoAddrs struct {
+}
+
+func (_ networkInterfacewithNoAddrs) InterfaceByName(intfName string) (*net.Interface, error) {
+	c := net.Interface{Index: 0, MTU: 0, Name: "eth3", HardwareAddr: nil, Flags: net.FlagUp}
+	return &c, nil
+}
+func (_ networkInterfacewithNoAddrs) Addrs(intf *net.Interface) ([]net.Addr, error) {
+	return nil, fmt.Errorf("unable get Addrs")
+}
+
+type networkInterfacewithIpv6addrs struct {
+}
+
+func (_ networkInterfacewithIpv6addrs) InterfaceByName(intfName string) (*net.Interface, error) {
+	c := net.Interface{Index: 0, MTU: 0, Name: "eth3", HardwareAddr: nil, Flags: net.FlagUp}
+	return &c, nil
+}
+func (_ networkInterfacewithIpv6addrs) Addrs(intf *net.Interface) ([]net.Addr, error) {
+	var ifat []net.Addr
+	ifat = []net.Addr{addrStruct{val: "fe80::2f7:6ffff:fe6e:2956/64"}}
+	return ifat, nil
+}
+
+func TestGetIPFromInterface(t *testing.T) {
+	testCases := []struct {
+		tcase    string
+		nwname   string
+		nw       networkInterfacer
+		expected net.IP
+	}{
+		{"valid", "eth3", validNetworkInterface{}, net.ParseIP("10.254.71.145")},
+		{"ipv6", "eth3", validNetworkInterfacewithIpv6Only{}, nil},
+		{"nothing", "eth3", noNetworkInterface{}, nil},
+	}
+	for _, tc := range testCases {
+		ip, err := getIPFromInterface(tc.nwname, tc.nw)
+		if !ip.Equal(tc.expected) {
+			t.Errorf("case[%v]: expected %v, got %+v .err : %v", tc.tcase, tc.expected, ip, err)
+		}
+	}
+}
+
+func TestChooseHostInterfaceFromRoute(t *testing.T) {
+	testCases := []struct {
+		tcase    string
+		inFile   io.Reader
+		nw       networkInterfacer
+		expected net.IP
+	}{
+		{"valid_routefirst", strings.NewReader(gatewayfirst), validNetworkInterface{}, net.ParseIP("10.254.71.145")},
+		{"valid_routelast", strings.NewReader(gatewaylast), validNetworkInterface{}, net.ParseIP("10.254.71.145")},
+		{"valid_routemiddle", strings.NewReader(gatewaymiddle), validNetworkInterface{}, net.ParseIP("10.254.71.145")},
+		{"valid_routemiddle_ipv6", strings.NewReader(gatewaymiddle), validNetworkInterfacewithIpv6Only{}, nil},
+		{"no internet connection", strings.NewReader(noInternetConnection), validNetworkInterface{}, nil},
+		{"no non-link-local ip", strings.NewReader(gatewayfirstLinkLocal), validNetworkInterfaceWithLinkLocal{}, net.ParseIP("45.55.47.146")},
+		{"no route", strings.NewReader(nothing), validNetworkInterface{}, nil},
+		{"no route file", nil, validNetworkInterface{}, nil},
+		{"no interfaces", nil, noNetworkInterface{}, nil},
+		{"no interface Addrs", strings.NewReader(gatewaymiddle), networkInterfacewithNoAddrs{}, nil},
+		{"Invalid Addrs", strings.NewReader(gatewaymiddle), networkInterfacewithIpv6addrs{}, nil},
+	}
+	for _, tc := range testCases {
+		ip, err := chooseHostInterfaceFromRoute(tc.inFile, tc.nw)
+		if !ip.Equal(tc.expected) {
+			t.Errorf("case[%v]: expected %v, got %+v .err : %v", tc.tcase, tc.expected, ip, err)
+		}
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/validation/validation_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/validation/validation_test.go
@@ -1,0 +1,278 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIsDNS1123Label(t *testing.T) {
+	goodValues := []string{
+		"a", "ab", "abc", "a1", "a-1", "a--1--2--b",
+		"0", "01", "012", "1a", "1-a", "1--a--b--2",
+		strings.Repeat("a", 63),
+	}
+	for _, val := range goodValues {
+		if !IsDNS1123Label(val) {
+			t.Errorf("expected true for '%s'", val)
+		}
+	}
+
+	badValues := []string{
+		"", "A", "ABC", "aBc", "A1", "A-1", "1-A",
+		"-", "a-", "-a", "1-", "-1",
+		"_", "a_", "_a", "a_b", "1_", "_1", "1_2",
+		".", "a.", ".a", "a.b", "1.", ".1", "1.2",
+		" ", "a ", " a", "a b", "1 ", " 1", "1 2",
+		strings.Repeat("a", 64),
+	}
+	for _, val := range badValues {
+		if IsDNS1123Label(val) {
+			t.Errorf("expected false for '%s'", val)
+		}
+	}
+}
+
+func TestIsDNS1123Subdomain(t *testing.T) {
+	goodValues := []string{
+		"a", "ab", "abc", "a1", "a-1", "a--1--2--b",
+		"0", "01", "012", "1a", "1-a", "1--a--b--2",
+		"a.a", "ab.a", "abc.a", "a1.a", "a-1.a", "a--1--2--b.a",
+		"a.1", "ab.1", "abc.1", "a1.1", "a-1.1", "a--1--2--b.1",
+		"0.a", "01.a", "012.a", "1a.a", "1-a.a", "1--a--b--2",
+		"0.1", "01.1", "012.1", "1a.1", "1-a.1", "1--a--b--2.1",
+		"a.b.c.d.e", "aa.bb.cc.dd.ee", "1.2.3.4.5", "11.22.33.44.55",
+		strings.Repeat("a", 253),
+	}
+	for _, val := range goodValues {
+		if !IsDNS1123Subdomain(val) {
+			t.Errorf("expected true for '%s'", val)
+		}
+	}
+
+	badValues := []string{
+		"", "A", "ABC", "aBc", "A1", "A-1", "1-A",
+		"-", "a-", "-a", "1-", "-1",
+		"_", "a_", "_a", "a_b", "1_", "_1", "1_2",
+		".", "a.", ".a", "a..b", "1.", ".1", "1..2",
+		" ", "a ", " a", "a b", "1 ", " 1", "1 2",
+		"A.a", "aB.a", "ab.A", "A1.a", "a1.A",
+		"A.1", "aB.1", "A1.1", "1A.1",
+		"0.A", "01.A", "012.A", "1A.a", "1a.A",
+		"A.B.C.D.E", "AA.BB.CC.DD.EE", "a.B.c.d.e", "aa.bB.cc.dd.ee",
+		"a@b", "a,b", "a_b", "a;b",
+		"a:b", "a%b", "a?b", "a$b",
+		strings.Repeat("a", 254),
+	}
+	for _, val := range badValues {
+		if IsDNS1123Subdomain(val) {
+			t.Errorf("expected false for '%s'", val)
+		}
+	}
+}
+
+func TestIsDNS952Label(t *testing.T) {
+	goodValues := []string{
+		"a", "ab", "abc", "a1", "a-1", "a--1--2--b",
+		strings.Repeat("a", 24),
+	}
+	for _, val := range goodValues {
+		if !IsDNS952Label(val) {
+			t.Errorf("expected true for '%s'", val)
+		}
+	}
+
+	badValues := []string{
+		"0", "01", "012", "1a", "1-a", "1--a--b--2",
+		"", "A", "ABC", "aBc", "A1", "A-1", "1-A",
+		"-", "a-", "-a", "1-", "-1",
+		"_", "a_", "_a", "a_b", "1_", "_1", "1_2",
+		".", "a.", ".a", "a.b", "1.", ".1", "1.2",
+		" ", "a ", " a", "a b", "1 ", " 1", "1 2",
+		strings.Repeat("a", 25),
+	}
+	for _, val := range badValues {
+		if IsDNS952Label(val) {
+			t.Errorf("expected false for '%s'", val)
+		}
+	}
+}
+
+func TestIsCIdentifier(t *testing.T) {
+	goodValues := []string{
+		"a", "ab", "abc", "a1", "_a", "a_", "a_b", "a_1", "a__1__2__b", "__abc_123",
+		"A", "AB", "AbC", "A1", "_A", "A_", "A_B", "A_1", "A__1__2__B", "__123_ABC",
+	}
+	for _, val := range goodValues {
+		if !IsCIdentifier(val) {
+			t.Errorf("expected true for '%s'", val)
+		}
+	}
+
+	badValues := []string{
+		"", "1", "123", "1a",
+		"-", "a-", "-a", "1-", "-1", "1_", "1_2",
+		".", "a.", ".a", "a.b", "1.", ".1", "1.2",
+		" ", "a ", " a", "a b", "1 ", " 1", "1 2",
+		"#a#",
+	}
+	for _, val := range badValues {
+		if IsCIdentifier(val) {
+			t.Errorf("expected false for '%s'", val)
+		}
+	}
+}
+
+func TestIsValidPortNum(t *testing.T) {
+	goodValues := []int{1, 2, 1000, 16384, 32768, 65535}
+	for _, val := range goodValues {
+		if !IsValidPortNum(val) {
+			t.Errorf("expected true for '%d'", val)
+		}
+	}
+
+	badValues := []int{0, -1, 65536, 100000}
+	for _, val := range badValues {
+		if IsValidPortNum(val) {
+			t.Errorf("expected false for '%d'", val)
+		}
+	}
+}
+
+func TestIsValidPortName(t *testing.T) {
+	goodValues := []string{"telnet", "re-mail-ck", "pop3", "a", "a-1", "1-a", "a-1-b-2-c", "1-a-2-b-3"}
+	for _, val := range goodValues {
+		if !IsValidPortName(val) {
+			t.Errorf("expected true for %q", val)
+		}
+	}
+
+	badValues := []string{"longerthan15characters", "", "12345", "1-2-3-4", "-begin", "end-", "two--hyphens", "1-2", "whois++"}
+	for _, val := range badValues {
+		if IsValidPortName(val) {
+			t.Errorf("expected false for %q", val)
+		}
+	}
+}
+
+func TestIsQualifiedName(t *testing.T) {
+	successCases := []string{
+		"simple",
+		"now-with-dashes",
+		"1-starts-with-num",
+		"1234",
+		"simple/simple",
+		"now-with-dashes/simple",
+		"now-with-dashes/now-with-dashes",
+		"now.with.dots/simple",
+		"now-with.dashes-and.dots/simple",
+		"1-num.2-num/3-num",
+		"1234/5678",
+		"1.2.3.4/5678",
+		"Uppercase_Is_OK_123",
+		"example.com/Uppercase_Is_OK_123",
+		strings.Repeat("a", 63),
+		strings.Repeat("a", 253) + "/" + strings.Repeat("b", 63),
+	}
+	for i := range successCases {
+		if !IsQualifiedName(successCases[i]) {
+			t.Errorf("case[%d]: %q: expected success", i, successCases[i])
+		}
+	}
+
+	errorCases := []string{
+		"nospecialchars%^=@",
+		"cantendwithadash-",
+		"-cantstartwithadash-",
+		"only/one/slash",
+		"Example.com/abc",
+		"example_com/abc",
+		"example.com/",
+		"/simple",
+		strings.Repeat("a", 64),
+		strings.Repeat("a", 254) + "/abc",
+	}
+	for i := range errorCases {
+		if IsQualifiedName(errorCases[i]) {
+			t.Errorf("case[%d]: %q: expected failure", i, errorCases[i])
+		}
+	}
+}
+
+func TestIsValidLabelValue(t *testing.T) {
+	successCases := []string{
+		"simple",
+		"now-with-dashes",
+		"1-starts-with-num",
+		"end-with-num-1",
+		"1234",                  // only num
+		strings.Repeat("a", 63), // to the limit
+		"", // empty value
+	}
+	for i := range successCases {
+		if !IsValidLabelValue(successCases[i]) {
+			t.Errorf("case %s expected success", successCases[i])
+		}
+	}
+
+	errorCases := []string{
+		"nospecialchars%^=@",
+		"Tama-nui-te-rā.is.Māori.sun",
+		"\\backslashes\\are\\bad",
+		"-starts-with-dash",
+		"ends-with-dash-",
+		".starts.with.dot",
+		"ends.with.dot.",
+		strings.Repeat("a", 64), // over the limit
+	}
+	for i := range errorCases {
+		if IsValidLabelValue(errorCases[i]) {
+			t.Errorf("case[%d] expected failure", i)
+		}
+	}
+}
+
+func TestIsValidIP(t *testing.T) {
+	goodValues := []string{
+		"1.1.1.1",
+		"1.1.1.01",
+		"255.0.0.1",
+		"1.0.0.0",
+		"0.0.0.0",
+	}
+	for _, val := range goodValues {
+		if !IsValidIPv4(val) {
+			t.Errorf("expected true for %q", val)
+		}
+	}
+
+	badValues := []string{
+		"2a00:79e0:2:0:f1c3:e797:93c1:df80", // This is valid IPv6
+		"a",
+		"myhost.mydomain",
+		"-1.0.0.0",
+		"1.0.0.256",
+		"1.0.0.1.1",
+		"1.0.0.1.",
+	}
+	for _, val := range badValues {
+		if IsValidIPv4(val) {
+			t.Errorf("expected false for %q", val)
+		}
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/wait/wait.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/wait/wait.go
@@ -45,9 +45,25 @@ type ConditionFunc func() (done bool, err error)
 // may be missed if the condition takes too long or the time window is too short.
 // If you want to Poll something forever, see PollInfinite.
 // Poll always waits the interval before the first check of the condition.
-// TODO: create a separate PollImmediate function that does not wait.
 func Poll(interval, timeout time.Duration, condition ConditionFunc) error {
-	return WaitFor(poller(interval, timeout), condition)
+	return pollInternal(poller(interval, timeout), condition)
+}
+func pollInternal(wait WaitFunc, condition ConditionFunc) error {
+	return WaitFor(wait, condition)
+}
+
+func PollImmediate(interval, timeout time.Duration, condition ConditionFunc) error {
+	return pollImmediateInternal(poller(interval, timeout), condition)
+}
+func pollImmediateInternal(wait WaitFunc, condition ConditionFunc) error {
+	done, err := condition()
+	if err != nil {
+		return err
+	}
+	if done {
+		return nil
+	}
+	return pollInternal(wait, condition)
 }
 
 // PollInfinite polls forever.
@@ -59,16 +75,16 @@ func PollInfinite(interval time.Duration, condition ConditionFunc) error {
 // should be executed and is closed when the last test should be invoked.
 type WaitFunc func() <-chan struct{}
 
-// WaitFor gets a channel from wait(), and then invokes c once for every value
-// placed on the channel and once more when the channel is closed.  If c
-// returns an error the loop ends and that error is returned, and if c returns
+// WaitFor gets a channel from wait(), and then invokes fn once for every value
+// placed on the channel and once more when the channel is closed.  If fn
+// returns an error the loop ends and that error is returned, and if fn returns
 // true the loop ends and nil is returned. ErrWaitTimeout will be returned if
-// the channel is closed without c ever returning true.
-func WaitFor(wait WaitFunc, c ConditionFunc) error {
-	w := wait()
+// the channel is closed without fn ever returning true.
+func WaitFor(wait WaitFunc, fn ConditionFunc) error {
+	c := wait()
 	for {
-		_, open := <-w
-		ok, err := c()
+		_, open := <-c
+		ok, err := fn()
 		if err != nil {
 			return err
 		}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/wait/wait_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/wait/wait_test.go
@@ -1,0 +1,248 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wait
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"k8s.io/kubernetes/pkg/util"
+)
+
+func TestPoller(t *testing.T) {
+	w := poller(time.Millisecond, 2*time.Millisecond)
+	ch := w()
+	count := 0
+DRAIN:
+	for {
+		select {
+		case _, open := <-ch:
+			if !open {
+				break DRAIN
+			}
+			count++
+		case <-time.After(util.ForeverTestTimeout):
+			t.Errorf("unexpected timeout after poll")
+		}
+	}
+	if count > 3 {
+		t.Errorf("expected up to three values, got %d", count)
+	}
+}
+
+func fakeTicker(max int, used *int32) WaitFunc {
+	return func() <-chan struct{} {
+		ch := make(chan struct{})
+		go func() {
+			for i := 0; i < max; i++ {
+				ch <- struct{}{}
+				if used != nil {
+					atomic.AddInt32(used, 1)
+				}
+			}
+			close(ch)
+		}()
+		return ch
+	}
+}
+
+type fakePoller struct {
+	max  int
+	used int32 // accessed with atomics
+}
+
+func (fp *fakePoller) GetWaitFunc(interval, timeout time.Duration) WaitFunc {
+	return fakeTicker(fp.max, &fp.used)
+}
+
+func TestPoll(t *testing.T) {
+	invocations := 0
+	f := ConditionFunc(func() (bool, error) {
+		invocations++
+		return true, nil
+	})
+	fp := fakePoller{max: 1}
+	if err := pollInternal(fp.GetWaitFunc(time.Microsecond, time.Microsecond), f); err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+	if invocations != 1 {
+		t.Errorf("Expected exactly one invocation, got %d", invocations)
+	}
+	used := atomic.LoadInt32(&fp.used)
+	if used != 1 {
+		t.Errorf("Expected exactly one tick, got %d", used)
+	}
+
+	expectedError := errors.New("Expected error")
+	f = ConditionFunc(func() (bool, error) {
+		return false, expectedError
+	})
+	fp = fakePoller{max: 1}
+	if err := pollInternal(fp.GetWaitFunc(time.Microsecond, time.Microsecond), f); err == nil || err != expectedError {
+		t.Fatalf("Expected error %v, got none %v", expectedError, err)
+	}
+	if invocations != 1 {
+		t.Errorf("Expected exactly one invocation, got %d", invocations)
+	}
+	used = atomic.LoadInt32(&fp.used)
+	if used != 1 {
+		t.Errorf("Expected exactly one tick, got %d", used)
+	}
+}
+
+func TestPollImmediate(t *testing.T) {
+	invocations := 0
+	f := ConditionFunc(func() (bool, error) {
+		invocations++
+		return true, nil
+	})
+	fp := fakePoller{max: 0}
+	if err := pollImmediateInternal(fp.GetWaitFunc(time.Microsecond, time.Microsecond), f); err != nil {
+		t.Fatalf("unexpected error %v", err)
+	}
+	if invocations != 1 {
+		t.Errorf("Expected exactly one invocation, got %d", invocations)
+	}
+	used := atomic.LoadInt32(&fp.used)
+	if used != 0 {
+		t.Errorf("Expected exactly zero ticks, got %d", used)
+	}
+
+	expectedError := errors.New("Expected error")
+	f = ConditionFunc(func() (bool, error) {
+		return false, expectedError
+	})
+	fp = fakePoller{max: 0}
+	if err := pollImmediateInternal(fp.GetWaitFunc(time.Microsecond, time.Microsecond), f); err == nil || err != expectedError {
+		t.Fatalf("Expected error %v, got none %v", expectedError, err)
+	}
+	if invocations != 1 {
+		t.Errorf("Expected exactly one invocation, got %d", invocations)
+	}
+	used = atomic.LoadInt32(&fp.used)
+	if used != 0 {
+		t.Errorf("Expected exactly zero ticks, got %d", used)
+	}
+}
+
+func TestPollForever(t *testing.T) {
+	ch := make(chan struct{})
+	done := make(chan struct{}, 1)
+	complete := make(chan struct{})
+	go func() {
+		f := ConditionFunc(func() (bool, error) {
+			ch <- struct{}{}
+			select {
+			case <-done:
+				return true, nil
+			default:
+			}
+			return false, nil
+		})
+		if err := PollInfinite(time.Microsecond, f); err != nil {
+			t.Fatalf("unexpected error %v", err)
+		}
+
+		close(ch)
+		complete <- struct{}{}
+	}()
+
+	// ensure the condition is opened
+	<-ch
+
+	// ensure channel sends events
+	for i := 0; i < 10; i++ {
+		select {
+		case _, open := <-ch:
+			if !open {
+				t.Fatalf("did not expect channel to be closed")
+			}
+		case <-time.After(util.ForeverTestTimeout):
+			t.Fatalf("channel did not return at least once within the poll interval")
+		}
+	}
+
+	// at most two poll notifications should be sent once we return from the condition
+	done <- struct{}{}
+	go func() {
+		for i := 0; i < 2; i++ {
+			_, open := <-ch
+			if open {
+				<-complete
+				return
+			}
+		}
+		t.Fatalf("expected closed channel after two iterations")
+	}()
+	<-complete
+}
+
+func TestWaitFor(t *testing.T) {
+	var invocations int
+	testCases := map[string]struct {
+		F       ConditionFunc
+		Ticks   int
+		Invoked int
+		Err     bool
+	}{
+		"invoked once": {
+			ConditionFunc(func() (bool, error) {
+				invocations++
+				return true, nil
+			}),
+			2,
+			1,
+			false,
+		},
+		"invoked and returns a timeout": {
+			ConditionFunc(func() (bool, error) {
+				invocations++
+				return false, nil
+			}),
+			2,
+			3, // the contract of WaitFor() says the func is called once more at the end of the wait
+			true,
+		},
+		"returns immediately on error": {
+			ConditionFunc(func() (bool, error) {
+				invocations++
+				return false, errors.New("test")
+			}),
+			2,
+			1,
+			true,
+		},
+	}
+	for k, c := range testCases {
+		invocations = 0
+		ticker := fakeTicker(c.Ticks, nil)
+		err := WaitFor(ticker, c.F)
+		switch {
+		case c.Err && err == nil:
+			t.Errorf("%s: Expected error, got nil", k)
+			continue
+		case !c.Err && err != nil:
+			t.Errorf("%s: Expected no error, got: %#v", k, err)
+			continue
+		}
+		if invocations != c.Invoked {
+			t.Errorf("%s: Expected %d invocations, got %d", k, c.Invoked, invocations)
+		}
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/workqueue/queue_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/workqueue/queue_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workqueue_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"k8s.io/kubernetes/pkg/util/workqueue"
+)
+
+func TestBasic(t *testing.T) {
+	// If something is seriously wrong this test will never complete.
+	q := workqueue.New()
+
+	// Start producers
+	const producers = 50
+	producerWG := sync.WaitGroup{}
+	producerWG.Add(producers)
+	for i := 0; i < producers; i++ {
+		go func(i int) {
+			defer producerWG.Done()
+			for j := 0; j < 50; j++ {
+				q.Add(i)
+				time.Sleep(time.Millisecond)
+			}
+		}(i)
+	}
+
+	// Start consumers
+	const consumers = 10
+	consumerWG := sync.WaitGroup{}
+	consumerWG.Add(consumers)
+	for i := 0; i < consumers; i++ {
+		go func(i int) {
+			defer consumerWG.Done()
+			for {
+				item, quit := q.Get()
+				if item == "added after shutdown!" {
+					t.Errorf("Got an item added after shutdown.")
+				}
+				if quit {
+					return
+				}
+				t.Logf("Worker %v: begin processing %v", i, item)
+				time.Sleep(3 * time.Millisecond)
+				t.Logf("Worker %v: done processing %v", i, item)
+				q.Done(item)
+			}
+		}(i)
+	}
+
+	producerWG.Wait()
+	q.ShutDown()
+	q.Add("added after shutdown!")
+	consumerWG.Wait()
+}
+
+func TestAddWhileProcessing(t *testing.T) {
+	q := workqueue.New()
+
+	// Start producers
+	const producers = 50
+	producerWG := sync.WaitGroup{}
+	producerWG.Add(producers)
+	for i := 0; i < producers; i++ {
+		go func(i int) {
+			defer producerWG.Done()
+			q.Add(i)
+		}(i)
+	}
+
+	// Start consumers
+	const consumers = 10
+	consumerWG := sync.WaitGroup{}
+	consumerWG.Add(consumers)
+	for i := 0; i < consumers; i++ {
+		go func(i int) {
+			defer consumerWG.Done()
+			// Every worker will re-add every item up to two times.
+			// This tests the dirty-while-processing case.
+			counters := map[interface{}]int{}
+			for {
+				item, quit := q.Get()
+				if quit {
+					return
+				}
+				counters[item]++
+				if counters[item] < 2 {
+					q.Add(item)
+				}
+				q.Done(item)
+			}
+		}(i)
+	}
+
+	producerWG.Wait()
+	q.ShutDown()
+	consumerWG.Wait()
+}
+
+func TestLen(t *testing.T) {
+	q := workqueue.New()
+	q.Add("foo")
+	if e, a := 1, q.Len(); e != a {
+		t.Errorf("Expected %v, got %v", e, a)
+	}
+	q.Add("bar")
+	if e, a := 2, q.Len(); e != a {
+		t.Errorf("Expected %v, got %v", e, a)
+	}
+	q.Add("foo") // should not increase the queue length.
+	if e, a := 2, q.Len(); e != a {
+		t.Errorf("Expected %v, got %v", e, a)
+	}
+}

--- a/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/yaml/decoder_test.go
+++ b/Godeps/_workspace/src/k8s.io/kubernetes/pkg/util/yaml/decoder_test.go
@@ -1,0 +1,217 @@
+/*
+Copyright 2014 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package yaml
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"testing"
+)
+
+func TestSplitYAMLDocument(t *testing.T) {
+	testCases := []struct {
+		input  string
+		atEOF  bool
+		expect string
+		adv    int
+	}{
+		{"foo", true, "foo", 3},
+		{"fo", false, "", 0},
+
+		{"---", true, "---", 3},
+		{"---\n", true, "---\n", 4},
+		{"---\n", false, "", 0},
+
+		{"\n---\n", false, "", 5},
+		{"\n---\n", true, "", 5},
+
+		{"abc\n---\ndef", true, "abc", 8},
+		{"def", true, "def", 3},
+		{"", true, "", 0},
+	}
+	for i, testCase := range testCases {
+		adv, token, err := splitYAMLDocument([]byte(testCase.input), testCase.atEOF)
+		if err != nil {
+			t.Errorf("%d: unexpected error: %v", i, err)
+			continue
+		}
+		if adv != testCase.adv {
+			t.Errorf("%d: advance did not match: %d %d", i, testCase.adv, adv)
+		}
+		if testCase.expect != string(token) {
+			t.Errorf("%d: token did not match: %q %q", i, testCase.expect, string(token))
+		}
+	}
+}
+
+func TestGuessJSON(t *testing.T) {
+	if r, isJSON := guessJSONStream(bytes.NewReader([]byte(" \n{}")), 100); !isJSON {
+		t.Fatalf("expected stream to be JSON")
+	} else {
+		b := make([]byte, 30)
+		n, err := r.Read(b)
+		if err != nil || n != 4 {
+			t.Fatalf("unexpected body: %d / %v", n, err)
+		}
+		if string(b[:n]) != " \n{}" {
+			t.Fatalf("unexpected body: %q", string(b[:n]))
+		}
+	}
+}
+
+func TestScanYAML(t *testing.T) {
+	s := bufio.NewScanner(bytes.NewReader([]byte(`---
+stuff: 1
+
+---       
+  `)))
+	s.Split(splitYAMLDocument)
+	if !s.Scan() {
+		t.Fatalf("should have been able to scan")
+	}
+	t.Logf("scan: %s", s.Text())
+	if !s.Scan() {
+		t.Fatalf("should have been able to scan")
+	}
+	t.Logf("scan: %s", s.Text())
+	if s.Scan() {
+		t.Fatalf("scan should have been done")
+	}
+	if s.Err() != nil {
+		t.Fatalf("err should have been nil: %v", s.Err())
+	}
+}
+
+func TestDecodeYAML(t *testing.T) {
+	s := NewYAMLToJSONDecoder(bytes.NewReader([]byte(`---
+stuff: 1
+
+---       
+  `)))
+	obj := generic{}
+	if err := s.Decode(&obj); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if fmt.Sprintf("%#v", obj) != `yaml.generic{"stuff":1}` {
+		t.Errorf("unexpected object: %#v", obj)
+	}
+	obj = generic{}
+	if err := s.Decode(&obj); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(obj) != 0 {
+		t.Fatalf("unexpected object: %#v", obj)
+	}
+	obj = generic{}
+	if err := s.Decode(&obj); err != io.EOF {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+type generic map[string]interface{}
+
+func TestYAMLOrJSONDecoder(t *testing.T) {
+	testCases := []struct {
+		input  string
+		buffer int
+		isJSON bool
+		err    bool
+		out    []generic
+	}{
+		{` {"1":2}{"3":4}`, 2, true, false, []generic{
+			{"1": 2},
+			{"3": 4},
+		}},
+		{" \n{}", 3, true, false, []generic{
+			{},
+		}},
+		{" \na: b", 2, false, false, []generic{
+			{"a": "b"},
+		}},
+		{" \n{\"a\": \"b\"}", 2, false, true, []generic{
+			{"a": "b"},
+		}},
+		{" \n{\"a\": \"b\"}", 3, true, false, []generic{
+			{"a": "b"},
+		}},
+		{`   {"a":"b"}`, 100, true, false, []generic{
+			{"a": "b"},
+		}},
+		{"", 1, false, false, []generic{}},
+		{"foo: bar\n---\nbaz: biz", 100, false, false, []generic{
+			{"foo": "bar"},
+			{"baz": "biz"},
+		}},
+		{"foo: bar\n---\n", 100, false, false, []generic{
+			{"foo": "bar"},
+		}},
+		{"foo: bar\n---", 100, false, false, []generic{
+			{"foo": "bar"},
+		}},
+		{"foo: bar\n--", 100, false, true, []generic{
+			{"foo": "bar"},
+		}},
+		{"foo: bar\n-", 100, false, true, []generic{
+			{"foo": "bar"},
+		}},
+		{"foo: bar\n", 100, false, false, []generic{
+			{"foo": "bar"},
+		}},
+	}
+	for i, testCase := range testCases {
+		decoder := NewYAMLOrJSONDecoder(bytes.NewReader([]byte(testCase.input)), testCase.buffer)
+		objs := []generic{}
+
+		var err error
+		for {
+			out := make(generic)
+			err = decoder.Decode(&out)
+			if err != nil {
+				break
+			}
+			objs = append(objs, out)
+		}
+		if err != io.EOF {
+			switch {
+			case testCase.err && err == nil:
+				t.Errorf("%d: unexpected non-error", i)
+				continue
+			case !testCase.err && err != nil:
+				t.Errorf("%d: unexpected error: %v", i, err)
+				continue
+			case err != nil:
+				continue
+			}
+		}
+		switch decoder.decoder.(type) {
+		case *YAMLToJSONDecoder:
+			if testCase.isJSON {
+				t.Errorf("%d: expected JSON decoder, got YAML", i)
+			}
+		case *json.Decoder:
+			if !testCase.isJSON {
+				t.Errorf("%d: expected YAML decoder, got JSON", i)
+			}
+		}
+		if fmt.Sprintf("%#v", testCase.out) != fmt.Sprintf("%#v", objs) {
+			t.Errorf("%d: objects were not equal: \n%#v\n%#v", i, testCase.out, objs)
+		}
+	}
+}

--- a/sources/kube_factory.go
+++ b/sources/kube_factory.go
@@ -172,6 +172,7 @@ func CreateKubeSources(uri *url.URL, c cache.Cache) ([]api.Source, error) {
 		Port:            uint(kubeletPort),
 		EnableHttps:     kubeletHttps,
 		TLSClientConfig: kubeConfig.TLSClientConfig,
+		BearerToken:     kubeConfig.BearerToken,
 	}
 
 	kubeletApi, err := datasource.NewKubelet(kubeletConfig)


### PR DESCRIPTION
Update kubernetes/pkg/util and kubernetes/pkg/client/unversioned to support BearerToken authentication to Kubelets. (Kubernetes PR #14700 adds server support and Kubernetes PR #15101 adds client support).

It seems Github removed all the interesting bits as too long.. (well, there's a single line to the kube_factory.go that copies BearerToken from KubeConfig -> KubeletConfig)