### PR TITLE
Updating HEAD to use heapster canary image 

### DIFF
--- a/deploy/docker/canary/Dockerfile
+++ b/deploy/docker/canary/Dockerfile
@@ -4,6 +4,6 @@ MAINTAINER vishnuk@google.com
 
 RUN apt-get install -y git
 RUN git clone https://github.com/kubernetes/heapster.git /go/src/k8s.io/heapster
-RUN cd /go/src/k8s.io/heapster && make
+RUN cd /go/src/k8s.io/heapster && make && mv heapster /heapster
 
-ENTRYPOINT ["/go/src/k8s.io/heapster/heapster"]
+ENTRYPOINT ["/heapster"]

--- a/deploy/kube-config/google/heapster-controller.yaml
+++ b/deploy/kube-config/google/heapster-controller.yaml
@@ -20,7 +20,8 @@ spec:
     spec:
       containers:
       - name: heapster
-        image: kubernetes/heapster:v0.18.1
+        image: kubernetes/heapster:canary
+        imagePullPolicy: Always
         command:
         - /heapster
         - --source=kubernetes:https://kubernetes.default

--- a/deploy/kube-config/influxdb/grafana-service.yaml
+++ b/deploy/kube-config/influxdb/grafana-service.yaml
@@ -7,7 +7,9 @@ metadata:
   name: monitoring-grafana
   namespace: kube-system
 spec:
-  type: LoadBalancer
+  # In a production setup, we recommend accessing Grafana through an external Loadbalancer
+  # or through a public IP. 
+  # type: LoadBalancer
   ports:
   - port: 80
     targetPort: 3000

--- a/deploy/kube-config/influxdb/heapster-controller.yaml
+++ b/deploy/kube-config/influxdb/heapster-controller.yaml
@@ -20,7 +20,8 @@ spec:
     spec:
       containers:
       - name: heapster
-        image: kubernetes/heapster:v0.18.1
+        image: kubernetes/heapster:canary
+        imagePullPolicy: Always
         command:
         - /heapster
         - --source=kubernetes:https://kubernetes.default

--- a/deploy/kube-config/influxdb/influxdb-grafana-controller.yaml
+++ b/deploy/kube-config/influxdb/influxdb-grafana-controller.yaml
@@ -3,7 +3,7 @@ kind: ReplicationController
 metadata:
   labels:
     name: influxGrafana
-  name: infludb-grafana
+  name: influxdb-grafana
   namespace: kube-system
 spec:
   replicas: 1
@@ -23,8 +23,20 @@ spec:
       - name: grafana
         image: kubernetes/heapster_grafana:v2.1.0
         env:
-          - name: "INFLUXDB_SERVICE_URL"
-            value: "http://monitoring-influxdb:8086"
+          - name: INFLUXDB_SERVICE_URL
+            value: http://monitoring-influxdb:8086
+            # The following env variables are required to make Grafana accessible via
+            # the kubernetes api-server proxy. On production clusters, we recommend
+            # removing these env variables, setup auth for grafana, and expose the grafana
+            # service using a LoadBalancer or a public IP.
+          - name: GF_AUTH_BASIC_ENABLED
+            value: "false"
+          - name: GF_AUTH_ANONYMOUS_ENABLED
+            value: "true"
+          - name: GF_AUTH_ANONYMOUS_ORG_ROLE
+            value: Admin
+          - name: GF_SERVER_ROOT_URL
+            value: /api/v1/proxy/namespaces/kube-system/services/monitoring-grafana/
         volumeMounts:
         - mountPath: /var
           name: grafana-storage

--- a/deploy/kube-config/standalone-test/heapster-controller.yaml
+++ b/deploy/kube-config/standalone-test/heapster-controller.yaml
@@ -17,7 +17,8 @@ spec:
     spec:
       containers:
       - name: heapster-test
-        image: kubernetes/heapster:v0.18.0
+        image: kubernetes/heapster:canary
+        imagePullPolicy: Always
         command:
         - /heapster
         - --source=kubernetes:https://kubernetes.default

--- a/deploy/kube-config/standalone/heapster-controller.yaml
+++ b/deploy/kube-config/standalone/heapster-controller.yaml
@@ -20,7 +20,8 @@ spec:
     spec:
       containers:
       - name: heapster
-        image: kubernetes/heapster:v0.18.1
+        image: kubernetes/heapster:canary
+        imagePullPolicy: Always
         command:
         - /heapster
         - --source=kubernetes:https://kubernetes.default


### PR DESCRIPTION
`kubernetes/heapster:canary` image will be built and pushed every night.

Fixes #625 