### PR TITLE
correct the node level metrics api

### DIFF
--- a/docs/model.md
+++ b/docs/model.md
@@ -47,7 +47,7 @@ under a given node, along with their latest CPU and Memory Usage values.
 `/api/v1/model/nodes/{node-name}/metrics/`: Returns a list of available
 node-level metrics.
 
-`/api/v1/model/metrics/nodes/{node-name}/{metric-name}?start=X&end=Y`: Returns a set of (Timestamp, Value) 
+`/api/v1/model/nodes/{node-name}/metrics/{metric-name}?start=X&end=Y`: Returns a set of (Timestamp, Value) 
 pairs for the requested node-level metric, within the time range specified by `start` and `end`. 
 
 `/api/v1/model/nodes/{node-name}/stats/`: Exposes the average, max and 95th


### PR DESCRIPTION
When I tried the node level metrics api of heapster according the api descriptions in current model.md, I found it was wrong. After correcting the wrong node level metrics api according to the modification in this pr, the heapster then can reply with right response.
