### PR TITLE
correct the comments of interface Cache

### DIFF
--- a/sinks/cache/cache.go
+++ b/sinks/cache/cache.go
@@ -82,19 +82,19 @@ type Cache interface {
 	StorePods([]source_api.Pod) error
 	StoreContainers([]source_api.Container) error
 	// TODO: Handle events.
-	// GetPods returns a list of pod elements in the cache between 'start' and 'end'.
+	// GetPods returns a list of pod elements holding the metrics between 'start' and 'end' in the cache.
 	// If 'start' is zero, it returns all the elements up until 'end'.
 	// If 'end' is zero, it returns all the elements from 'start'.
 	// If both 'start' and 'end' are zero, it returns all the elements in the cache.
 	GetPods(start, end time.Time) []*PodElement
 
-	// GetNodes returns a list of pod elements in the cache between 'start' and 'end'.
+	// GetNodes returns a list of container elements holding the node level metrics between 'start' and 'end' in the cache.
 	// If 'start' is zero, it returns all the elements up until 'end'.
 	// If 'end' is zero, it returns all the elements from 'start'.
 	// If both 'start' and 'end' are zero, it returns all the elements in the cache.
 	GetNodes(start, end time.Time) []*ContainerElement
 
-	// GetFreeContainers returns a list of pod elements in the cache between 'start' and 'end'.
+	// GetFreeContainers returns a list of container elements holding the metrics between 'start' and 'end' in the cache.
 	// If 'start' is zero, it returns all the elements up until 'end'.
 	// If 'end' is zero, it returns all the elements from 'start'.
 	// If both 'start' and 'end' are zero, it returns all the elements in the cache.


### PR DESCRIPTION
I try to dig into the sources of heapster, and find some comments of interface Cache (in heapster/sinks/cache/cache.go line 91 and 97) may just copy from line 85, and if just
see the comments and method definition, user may get confused.

After reading the implementation in heapster/sinks/cache/impl.go, i modify the method comments 
of Cache, aiming at making the methods comments more readable and meaningful.