### PR TITLE
Correct comments of deleteFreeContainer and add corresponding test

### DIFF
--- a/model/impl.go
+++ b/model/impl.go
@@ -505,7 +505,8 @@ func (rc *realModel) updateFreeContainer(ce *cache.ContainerElement) (time.Time,
 	return latest_time, err
 }
 
-// updateFreeContainer updates Free Container-level information from a ContainerElement
+// deleteFreeContainer deletes a free container from the belonging node.
+// deleteFreeContainer receives a host name of the belonging node, and a name of the free container.
 func (rc *realModel) deleteFreeContainer(hostname, name string) {
 	rc.lock.Lock()
 	defer rc.lock.Unlock()

--- a/model/impl_test.go
+++ b/model/impl_test.go
@@ -1026,3 +1026,34 @@ func cacheFactory() cache.Cache {
 
 	return source_cache
 }
+
+// TestDeleteFreeContainer tests all flows of deleteFreeContainer.
+func TestDeleteFreeContainer(t *testing.T) {
+	var (
+		cluster           = newRealModel(time.Minute)
+		ce                = containerElementFactory(nil)
+		assert            = assert.New(t)
+		freeContainerName = "testFreeContainerName"
+		hostName          = "testhost"
+	)
+
+	// Add a free container with the specific container name and host name
+	ce.Name = freeContainerName
+	ce.Hostname = hostName
+	_, err := cluster.updateFreeContainer(ce)
+	assert.NoError(err)
+	nodeInfo := cluster.Nodes[hostName]
+	assert.NotNil(nodeInfo)
+	assert.Equal(1, len(nodeInfo.FreeContainers))
+
+	// First call : try to delete newly added free container
+	cluster.deleteFreeContainer(hostName, freeContainerName)
+	nodeInfo = cluster.Nodes[hostName]
+	assert.NotNil(nodeInfo)
+	assert.Equal(0, len(nodeInfo.FreeContainers))
+	assert.Nil(nodeInfo.FreeContainers[freeContainerName])
+
+	// Second call: already deleted
+	cluster.deleteFreeContainer(hostName, freeContainerName)
+	// No panic etc.
+}


### PR DESCRIPTION
I read into sources of heapster, and find out the comments of deleteFreeContainer in model/impl.go are just copy from the method updateFreeContainer, which will make confusion and be meaningless.
So I correct the comments of deleteFreeContainer (), and add the corresponding method test in model/impl_test.go.