### PR TITLE
Support multiple sinks

### DIFF
--- a/manager/flags.go
+++ b/manager/flags.go
@@ -68,10 +68,13 @@ func (us *Uris) String() string {
 }
 
 func (us *Uris) Set(value string) error {
-	var u Uri
-	if err := u.Set(value); err != nil {
-		return err
+	values := strings.Split(value, ",")
+	for _, item := range values {
+		var u Uri
+		if err := u.Set(item); err != nil {
+			return err
+		}
+		*us = append(*us, u)
 	}
-	*us = append(*us, u)
 	return nil
 }

--- a/manager/flags_test.go
+++ b/manager/flags_test.go
@@ -121,7 +121,7 @@ func TestUrisString(t *testing.T) {
 	}
 }
 
-func TestUrisSet(t *testing.T) {
+func TestUrisSetWithOneSinkInput(t *testing.T) {
 	tests := [...]struct {
 		in      []string
 		want    Uris
@@ -163,4 +163,19 @@ func TestUrisSet(t *testing.T) {
 			assert.Equal(t, c.want, uris)
 		}
 	}
+}
+
+func TestUrisSetWithMultipleSinksInput(t *testing.T) {
+	expectedUris := Uris{
+		Uri{Key: "gcm"},
+		Uri{
+			Key: "influxdb",
+			Val: url.URL{Path: "foo"},
+		},
+	}
+	testInput := "gcm,influxdb:foo"
+	var actualUris Uris
+	err := actualUris.Set(testInput)
+	assert.Nil(t, err)
+	assert.Equal(t, expectedUris, actualUris)
 }


### PR DESCRIPTION
Currently only one sink can be set into the start parameter 'sink' of heapster. If one uses "--sink=sink1:xxxx,sink2:yyyy" to start heapster aiming at using multiple sinks to report metrics and events to multiple backends, the heapster will fail to start. The following sample log info shows current status:
```shell
I1118 17:51:32.427589   30938 heapster.go:61] ./heapster --source=kubernetes:http://127.0.0.1:8080 --use_model=true --model_resolution=15s --cache_duration=30s --stats_resolution=3s --sink=gcm,gcmautoscaling --sink_frequency=15s
I1118 17:51:32.427854   30938 heapster.go:62] Heapster version 0.18.0
I1118 17:51:32.428811   30938 kube_factory.go:172] Using Kubernetes client with master "http://127.0.0.1:8080" and version "v1"
I1118 17:51:32.429452   30938 kube_factory.go:173] Using kubelet port 10255
F1118 17:51:32.429744   30938 heapster.go:68] Unknown sink: gcm,gcmautoscaling
```
 I dig into the source of  flags.go and flags_test.go, find out that Uris currently only supports set
one sink parameter in calling of *Uris.Set()(https://github.com/kubernetes/heapster/blob/master/manager/flags.go#L72).
```go
func (us *Uris) Set(value string) error {
	var u Uri
	if err := u.Set(value); err != nil {
		return err
	}
	*us = append(*us, u)
	return nil
}
```
However,  I think the original design of heapster may supports multiple sinks setting in the start parameter based on the following two aspects:
- The comments of 'sink' start parameter (https://github.com/kubernetes/heapster/blob/master/heapster.go#L58) shows it should be set by multiple sinks:
```go
flag.Var(&argSinks, "sink", "external sink(s) that receive data")
```
- The externalSinkManager also wants to send k8s metrics & events to multiple sinks():
```go
	for idx := range esm.externalSinks {
		sink := esm.externalSinks[idx]
		go func(sink sink_api.ExternalSink) {
			glog.V(2).Infof("Storing Timeseries to %q", sink.Name())
			errorsChan <- sink.StoreTimeseries(timeseries)
		}(sink)
		go func(sink sink_api.ExternalSink) {
			glog.V(2).Infof("Storing Events to %q", sink.Name())
			errorsChan <- sink.StoreEvents(kEvents)
		}(sink)
	}
```

So here is this pr to achieve the scene of supporting multiple sinks for heapster.