### PR TITLE
add docs of the usage of multiple sinks

### DIFF
--- a/docs/sink-configuration.md
+++ b/docs/sink-configuration.md
@@ -127,9 +127,9 @@ echo '["gcm", "influxdb:http://monitoring-influxdb:8086"]' | curl \
 
 ## Using multiple sinks
 
-It can activate multiple sinks described in the above sections for a heapster by using multiple `--sink=...` flags.
+Heapster can be configured to send k8s metrics and events to multiple sinks by specifying the`--sink=...` flag multiple times.
 
-For example, to use gcm and influxdb as sinks of the given heapster at the same time, you can use the following:
+For example, to send data to both gcm and influxdb at the same time, you can use the following:
 
 ```shell
     --sink=gcm --sink=influxdb:http://monitoring-influxdb:80/

--- a/docs/sink-configuration.md
+++ b/docs/sink-configuration.md
@@ -124,3 +124,13 @@ echo '["gcm", "influxdb:http://monitoring-influxdb:8086"]' | curl \
     -H "Accept: application/json" -H "Content-Type: application/json" \
     https://<master-ip>/api/v1/proxy/namespaces/kube-system/services/monitoring-heapster/api/v1/sinks
 ```
+
+## Using multiple sinks
+
+It can activate multiple sinks described in the above sections for a heapster by using multiple `--sink=...` flags.
+
+For example, to use gcm and influxdb as sinks of the given heapster at the same time, you can use the following:
+
+```shell
+    --sink=gcm --sink=influxdb:http://monitoring-influxdb:80/
+```


### PR DESCRIPTION
@vishh @jimmidyson 
As we discuss usage of multiple sinks in the end of (https://github.com/kubernetes/heapster/pull/712),
here is the pr to modify the sinks document to provide examples for using multiple sinks without changing current usage of `--sink` flag.
