### PR TITLE
Supplement descriptions of pluggable storage backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Heapster supports multiple sources of data.
 More information [here](docs/source-configuration.md).
 
 Heapster supports a pluggable storage backend.
-It supports [InfluxDB](http://influxdb.com) with [Grafana](http://grafana.org/docs/features/influxdb), [Google Cloud Monitoring](https://cloud.google.com/monitoring/), [Google Cloud Logging](https://cloud.google.com/logging/) and [Hawkular](http://www.hawkular.org).
+It supports [InfluxDB](http://influxdb.com) with [Grafana](http://grafana.org/docs/features/influxdb), [Google Cloud Monitoring](https://cloud.google.com/monitoring/), [Google Cloud Logging](https://cloud.google.com/logging/), [Hawkular](http://www.hawkular.org), [Riemann](http://riemann.io) and [Kafka](http://kafka.apache.org/).
 We welcome patches that add additional storage backends.
 Documentation on storage sinks [here](docs/sink-configuration.md)
 The current version of Storage Schema is documented [here](docs/storage-schema.md).


### PR DESCRIPTION
Currently the supporting pluggable storage backends of heapster have been expanded to Riemann(https://github.com/kubernetes/heapster/pull/687) and Kafka (https://github.com/kubernetes/heapster/pull/683). 

Here is the PR to refresh the descriptions of pluggable storage backends in the global README.md to let outside know heapster's newly supporting storage backends.
