### PR TITLE
Refresh description of using gunzip in standalone.md 

### DIFF
--- a/docs/standalone.md
+++ b/docs/standalone.md
@@ -94,7 +94,7 @@ I0911 13:42:03.662594   21041 heapster.go:68] Starting heapster on port 8082
 
 ### Test it out
 If you got debug information as before, means that the heapster is working normally.You can test it by calling its [RESTful API](https://github.com/kubernetes/heapster/blob/master/docs/model.md).  
-You can use some restful tools to test, or just run a `curl` command (_ heapster implements gzip encoding, so we need add gunzip in command "curl"_).  
+You can use some restful tools to test, or just run a `curl` command. 
 
 	curl http://0.0.0.0:8082/api/v1/model/stats/
 
@@ -227,3 +227,7 @@ and you will get the response like this:
  }
 
 ```
+By default, API responses are not compressed. Heapster supports gzip compression of responses via standard [content negotiation](https://en.wikipedia.org/wiki/Content_negotiation). To enable, set the value of the `Accept-Encoding` to `gzip`. The corresponding `curl` command will be like:
+
+    curl http://0.0.0.0:8082/api/v1/model/stats/ -H "Accept-Encoding:gzip" | gunzip
+


### PR DESCRIPTION
After v0.18.2, heapster has been removed the ability of encoding gzip(https://github.com/kubernetes/heapster/commit/99d5b63f0ff8790ea77815f04d08ee7146d4df2d), so the doc should be refreshed accordingly. Here is the pr.

Besides, @jimmidyson could you tell me why the gzip encoding is removed from heapster. Currently we use v0.18.2 in production environment, i think the gzip encoding may reduce the consumption of network transmission.
Shall we just still keep this ability, but just add a new start parameter to indicate whether to use gzip or not and by default the value is false?

``` go
argUseGzipEncoding = flag.Bool("use_gzip_encoding", false, "Indicate whether to use gzip encoding in rest api response")
```

Now, i update heapster with latest codes in master branch in our production environment, and reopen ability of gzip encoding by this flag and some other codes, as well as the removed codes in (https://github.com/kubernetes/heapster/commit/99d5b63f0ff8790ea77815f04d08ee7146d4df2d).
I don't know the reason why the community removed the gzip encoding, i can contribute the codes
to coordinate both the scenes with and without gzip encoding.
If your guys agree with this proposal, i'm willing to submit the corresponding pr and just close pr, or just keep current implementation and merge this doc refresh.
I am expecting your guys' kindness advices.
