### PR TITLE
failures log at Error instead of Info

### DIFF
--- a/integration/framework.go
+++ b/integration/framework.go
@@ -224,7 +224,7 @@ func requireNewCluster(baseDir, version string) bool {
 	glog.V(1).Infof("checking if existing cluster can be used")
 	versionInfo, err := kubeClient.ServerVersion()
 	if err != nil {
-		glog.V(1).Infof("failed to get kube version info - %q", err)
+		glog.Errorf("failed to get kube version info - %q", err)
 		return true
 	}
 	return !strings.Contains(versionInfo.GitVersion, version)

--- a/integration/heapster_api_test.go
+++ b/integration/heapster_api_test.go
@@ -57,7 +57,7 @@ func deleteAll(fm kubeFramework, ns string, service *kube_api.Service, rc *kube_
 	glog.V(2).Infof("Deleting ns %s...", ns)
 	err := fm.DeleteNs(ns)
 	if err != nil {
-		glog.V(2).Infof("Failed to delete %s", ns)
+		glog.Errorf("Failed to delete %s", ns)
 		return err
 	}
 	glog.V(2).Infof("Deleted ns %s.", ns)
@@ -76,7 +76,7 @@ func createAll(fm kubeFramework, ns string, service **kube_api.Service, rc **kub
 		},
 	}
 	if _, err := fm.CreateNs(&namespace); err != nil {
-		glog.V(2).Infof("Failed to create ns: %v", err)
+		glog.Errorf("Failed to create ns: %v", err)
 		return err
 	}
 
@@ -84,7 +84,7 @@ func createAll(fm kubeFramework, ns string, service **kube_api.Service, rc **kub
 
 	glog.V(2).Infof("Creating rc %s/%s...", ns, (*rc).Name)
 	if newRc, err := fm.CreateRC(ns, *rc); err != nil {
-		glog.V(2).Infof("Failed to create rc: %v", err)
+		glog.Errorf("Failed to create rc: %v", err)
 		return err
 	} else {
 		*rc = newRc
@@ -93,7 +93,7 @@ func createAll(fm kubeFramework, ns string, service **kube_api.Service, rc **kub
 
 	glog.V(2).Infof("Creating service %s/%s...", ns, (*service).Name)
 	if newSvc, err := fm.CreateService(ns, *service); err != nil {
-		glog.V(2).Infof("Failed to create service: %v", err)
+		glog.Errorf("Failed to create service: %v", err)
 		return err
 	} else {
 		*service = newSvc

--- a/sinks/gcmautoscaling/driver.go
+++ b/sinks/gcmautoscaling/driver.go
@@ -239,13 +239,13 @@ func (self gcmAutocalingSink) StoreTimeseries(input []sink_api.Timeseries) error
 			continue
 		}
 		if err != nil || ts == nil {
-			glog.Infof("Failed to create Timeseries for metric %v, host %v. Error %v.", autoscalingMetrics[metric.Name].name, metric.Labels[sink_api.LabelHostname.Key], err)
+			glog.Errorf("Failed to create Timeseries for metric %v, host %v. Error %v.", autoscalingMetrics[metric.Name].name, metric.Labels[sink_api.LabelHostname.Key], err)
 			continue
 		}
 
 		val := self.getNewValue(metric, ts)
 		if val == nil {
-			glog.Infof("Failed to compute new value for metric %v, host %v.", autoscalingMetrics[metric.Name].name, metric.Labels[sink_api.LabelHostname.Key])
+			glog.Errorf("Failed to compute new value for metric %v, host %v.", autoscalingMetrics[metric.Name].name, metric.Labels[sink_api.LabelHostname.Key])
 			continue
 		}
 		ts.Point.Int64Value = nil

--- a/sinks/util/client.go
+++ b/sinks/util/client.go
@@ -55,7 +55,7 @@ func (cii *clientInitializerImpl) setup() {
 	}
 	err := cii.initializer()
 	if err != nil {
-		glog.V(2).Infof("Failed to initialize client %q- %v", cii.name, err)
+		glog.Errorf("Failed to initialize client %q- %v", cii.name, err)
 		return
 	}
 	cii.setClientConfigured(true)

--- a/sources/datasource/kubelet.go
+++ b/sources/datasource/kubelet.go
@@ -93,7 +93,7 @@ func (self *kubeletSource) getContainer(url string, start, end time.Time) (*api.
 	}
 	err = self.postRequestAndGetValue(client, req, &containerInfo)
 	if err != nil {
-		glog.V(2).Infof("failed to get stats from kubelet url: %s - %s\n", url, err)
+		glog.Errorf("failed to get stats from kubelet url: %s - %s\n", url, err)
 		return nil, err
 	}
 	glog.V(4).Infof("url: %q, body: %q, data: %+v", url, string(body), containerInfo)

--- a/sources/kube_nodes.go
+++ b/sources/kube_nodes.go
@@ -56,7 +56,7 @@ func (self *kubeNodeMetrics) updateStats(host nodes.Host, info nodes.Info, start
 	// Get information for all containers.
 	containers, err := self.kubeletApi.GetAllRawContainers(datasource.Host{IP: info.InternalIP, Port: self.kubeletPort}, start, end)
 	if err != nil {
-		glog.V(3).Infof("Failed to get container stats from Kubelet on node %q", host)
+		glog.Errorf("Failed to get container stats from Kubelet on node %q", host)
 		return nil, []api.Container{}, fmt.Errorf("failed to get container stats from Kubelet on node %q: %v", host, err)
 	}
 	if len(containers) == 0 {

--- a/sources/kube_pods.go
+++ b/sources/kube_pods.go
@@ -107,7 +107,7 @@ func (self *kubePodsSource) getPodInfo(nodeList *nodes.NodeList, start, end time
 				rawContainer, err := self.getStatsFromKubelet(pod, container.Name, start, end)
 				if err != nil {
 					// Containers could be in the process of being setup or restarting while the pod is alive.
-					glog.V(2).Infof("failed to get stats for container %q in pod %q/%q", container.Name, pod.Namespace, pod.Name)
+					glog.Errorf("failed to get stats for container %q in pod %q/%q", container.Name, pod.Namespace, pod.Name)
 					self.recordPodError(*pod)
 					continue
 				}

--- a/sources/nodes/coreos.go
+++ b/sources/nodes/coreos.go
@@ -41,7 +41,7 @@ func (self *fleetNodes) List() (*NodeList, error) {
 	if err != nil {
 		self.apiErrors++
 		self.recentApiError = err
-		glog.V(1).Infof("failed to get list of machines from fleet - %q", err)
+		glog.Errorf("failed to get list of machines from fleet - %q", err)
 		return nil, err
 	}
 	nodeList := newNodeList()


### PR DESCRIPTION
fixes #757

All instances of `Infof("failed to ...")` have been replaced with `Errorf("failed to ...")` (preserving case). [`glog.Verbose`](https://godoc.org/github.com/golang/glog#Verbose) has no `Errorf` func, and error messages should be logged regardless of the verbosity with which the program was started; so, `glog.V([0-9]).Infof` has been replaced with `glog.Errorf`.

I compared the output of `godep go test ./...` on my branch with the output on `master`. All the failing tests are failing in the same way on my branch, so I take that to mean nothing has broken as a result of this change.
