### PR TITLE
grafana: bump version to 2.5.0

### DIFF
--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -2,7 +2,7 @@
 # Stock Grafana + a few custom dashboards
 #
 
-FROM grafana/grafana:2.1.0
+FROM grafana/grafana:2.5.0
 
 RUN apt-get update && \
     apt-get install -y curl

--- a/grafana/Makefile
+++ b/grafana/Makefile
@@ -1,5 +1,5 @@
 
-TAG = v2.1.0
+TAG = v2.5.0
 PREFIX = kubernetes
 
 all: container

--- a/grafana/run.sh
+++ b/grafana/run.sh
@@ -32,7 +32,7 @@ echo "Using the following backend access mode for InfluxDB: ${BACKEND_ACCESS_MOD
 
 set -m
 echo "Starting Grafana in the background"
-exec /usr/sbin/grafana-server --config=/etc/grafana/grafana.ini cfg:default.paths.data=/var/lib/grafana cfg:default.paths.logs=/var/log/grafana &
+exec /usr/sbin/grafana-server --homepath=/usr/share/grafana --config=/etc/grafana/grafana.ini cfg:default.paths.data=/var/lib/grafana cfg:default.paths.logs=/var/log/grafana &
 
 echo "Waiting for Grafana to come up..."
 until $(curl --fail --output /dev/null --silent http://${GRAFANA_USER}:${GRAFANA_PASSWD}@localhost:${GRAFANA_PORT}/api/org); do
@@ -42,7 +42,7 @@ done
 echo "Grafana is up and running."
 echo "Creating default influxdb datasource..."
 curl -i -XPOST -H "${HEADER_ACCEPT}" -H "${HEADER_CONTENT_TYPE}" "http://${GRAFANA_USER}:${GRAFANA_PASSWD}@localhost:${GRAFANA_PORT}/api/datasources" -d '
-{ 
+{
   "name": "influxdb-datasource",
   "type": "influxdb",
   "access": "'"${BACKEND_ACCESS_MODE}"'",


### PR DESCRIPTION
needed to add `--homepath` to grafana start args, other than that, just a simple version bump.