### PR TITLE
Clarify the doc about getting set up with Google Cloud Monitoring

### DIFF
--- a/docs/google.md
+++ b/docs/google.md
@@ -2,7 +2,13 @@
 
 The Google Cloud Monitoring and Logging backends only works in Google Compute Engine today.
 
-### Setup a Kubernetes cluster
+Note: this doc is intended for people setting up their own Kubernetes environment.
+If you're using Google Container Engine, Heapster will already be set up for
+you with much tighter integration into Google Cloud Monitoring, and all your
+clusters' metrics and events will be organized for you at [https://app.google.stackdriver.com/gke](https://app.google.stackdriver.com/gke).
+Please allow up to an hour after your cluster is created for it to show up there.
+
+### Set up a Kubernetes cluster
 [Bring up a Kubernetes cluster](https://github.com/kubernetes/kubernetes), if you haven't already. Ensure that `kubecfg.sh` is exported.
 
 ### Start all of the pods and services
@@ -19,6 +25,9 @@ Heapster metrics are now being exported to Google Cloud Monitoring as custom met
 To access the Google Cloud Monitoring dashboard go to: [https://app.google.stackdriver.com/](https://app.google.stackdriver.com/). Create a new dashboard and add the desired charts. Select the *Custom Metric* Resource Type and all Heapster metrics are under the `kubernetes.io` namespace. You can narrow down the query by the metric labels provided.
 
 It is also possible to query the Google Cloud Monitoring data directly using their [custom metric read API](https://cloud.google.com/monitoring/v2beta2/timeseries/list).
+
+Note: as mentioned in the intro, this section only applies if you've set up
+Heapster as described in this doc, not if you're using Container Engine.
 
 ### Events Dashboard
 To access events via Google Cloud Logging dashboard go to [Google Developer Console](https://cloud.google.com) and select 'Logs' under 'Monitoring' in your project. In the Logs dashboard, select `custom.googleapis.com` as the logs source.


### PR DESCRIPTION
with respect to where Container Engine metrics will be. Multiple users
have been confused by this doc.

@vishh 