### PR TITLE
Better connection handling for InfluxDB

### DIFF
--- a/sinks/external.go
+++ b/sinks/external.go
@@ -146,7 +146,16 @@ func (esm *externalSinkManager) store() error {
 	var errors []string
 	for i := 0; i < errorsLen; i++ {
 		if err := <-errorsChan; err != nil {
-			errors = append(errors, fmt.Sprintf("%v ", err))
+			strError := fmt.Sprintf("%v ", err)
+			found := false
+			for _, otherError := range errors {
+				if otherError == strError {
+					found = true
+				}
+			}
+			if !found {
+				errors = append(errors, strError)
+			}
 		}
 	}
 	if len(errors) > 0 {


### PR DESCRIPTION
Sample logs from the new code:

Scenario:
1. No influxdb at startup
2. Influxdb started
3. Influxdb down
4. Influxdb restarted

```
I1211 17:30:41.493098       1 heapster.go:61] /heapster --source=kubernetes:'' --sink=influxdb:http://monitoring-influxdb:8086 --stats_resolution=30s --sink_frequency=1m
I1211 17:30:41.493212       1 heapster.go:62] Heapster version 0.19.0
I1211 17:30:41.510179       1 kube_factory.go:172] Using Kubernetes client with master "https://10.0.0.1:443" and version "v1"
I1211 17:30:41.510229       1 kube_factory.go:173] Using kubelet port 10255
I1211 17:30:41.510496       1 driver.go:347] Creating influxdb {root root monitoring-influxdb:8086 k8s false} 
I1211 17:30:41.526161       1 driver.go:352] created influxdb sink with options: {root root monitoring-influxdb:8086 k8s false}
E1211 17:30:41.533804       1 driver.go:77] failed to ping InfluxDB server at "monitoring-influxdb:8086" - Get http://monitoring-influxdb:8086/ping: dial tcp: lookup monitoring-influxdb: no such host
I1211 17:30:41.537848       1 heapster.go:72] Starting heapster on port 8082
E1211 17:31:41.532992       1 external.go:87] failed to sync data to sinks - encountered the following errors: failed to ping InfluxDB server at "monitoring-influxdb:8086" - Get http://monitoring-influxdb:8086/ping: dial tcp: lookup monitoring-influxdb: no such host 
E1211 17:32:41.553945       1 external.go:87] failed to sync data to sinks - encountered the following errors: failed to ping InfluxDB server at "monitoring-influxdb:8086" - Get http://monitoring-influxdb:8086/ping: dial tcp: lookup monitoring-influxdb: no such host 
[...]
E1211 17:39:41.674717       1 external.go:87] failed to sync data to sinks - encountered the following errors: Database creation failed: Get http://monitoring-influxdb:8086/query?db=&q=CREATE+DATABASE+k8s: dial tcp 10.0.33.192:8086: i/o timeout 
I1211 17:40:41.691026       1 driver.go:272] Created database "k8s" on influxDB server at "monitoring-influxdb:8086"
E1211 17:45:30.026824       1 kubelet.go:96] failed to get stats from kubelet url: http://10.240.0.4:10255/stats/default/monitoring-influxdb-grafana-v2-uc1jv/034eff2e-a02e-11e5-ba5f-42010af00002/influxdb - request failed - "404 Not Found", response: "no matching container\n"
E1211 17:45:30.034410       1 kube_pods.go:110] failed to get stats for container "influxdb" in pod "default"/"monitoring-influxdb-grafana-v2-uc1jv"
E1211 17:45:42.360107       1 driver.go:207] failed to write stats to influxDB - Post http://monitoring-influxdb:8086/write?consistency=&db=k8s&precision=&rp=default: dial tcp: lookup monitoring-influxdb: no such host
E1211 17:45:42.377189       1 driver.go:210] InfluxDB ping failed: Get http://monitoring-influxdb:8086/ping: dial tcp: lookup monitoring-influxdb: no such host
I1211 17:45:42.377241       1 driver.go:149] Influxdb connection reset
E1211 17:45:42.385832       1 external.go:87] failed to sync data to sinks - encountered the following errors: Post http://monitoring-influxdb:8086/write?consistency=&db=k8s&precision=&rp=default: dial tcp: lookup monitoring-influxdb: no such host ;
failed to ping InfluxDB server at "monitoring-influxdb:8086" - Get http://monitoring-influxdb:8086/ping: dial tcp: lookup monitoring-influxdb: no such host 
I1211 17:46:42.430877       1 driver.go:272] Created database "k8s" on influxDB server at "monitoring-influxdb:8086"
```
