### PR TITLE
time synchronous check between heapster and kubelet

### DIFF
--- a/timesync/timesync.go
+++ b/timesync/timesync.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package timesync implements to check time skew between all kubernetes nodes and heapster
+// If detect time skew, heapster will send a warning to users.
 package timesync
 
 import (

--- a/timesync/timesync.go
+++ b/timesync/timesync.go
@@ -1,0 +1,199 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package timesync
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/golang/glog"
+	"k8s.io/heapster/sources/nodes"
+	kube_client "k8s.io/kubernetes/pkg/client/unversioned"
+	kubeClientCmd "k8s.io/kubernetes/pkg/client/unversioned/clientcmd"
+	kubeClientCmdApi "k8s.io/kubernetes/pkg/client/unversioned/clientcmd/api"
+)
+
+const (
+	APIVersion                = "v1"
+	defaultKubeletPort        = 10255
+	defaultKubeletHttps       = false
+	defaultUseServiceAccount  = false
+	defaultServiceAccountFile = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+	defaultInClusterConfig    = true
+	CheckDuration             = 5 * time.Minute
+	CadvisorPort              = "4194"
+	HttpScheme                = "http"
+)
+
+type timeSync struct {
+	NodesApi      nodes.NodesApi
+	Host          string
+	CacheDuration time.Duration
+}
+
+func getConfigOverrides(uri *url.URL) (*kubeClientCmd.ConfigOverrides, error) {
+	kubeConfigOverride := kubeClientCmd.ConfigOverrides{
+		ClusterInfo: kubeClientCmdApi.Cluster{
+			APIVersion: APIVersion,
+		},
+	}
+	if len(uri.Scheme) != 0 && len(uri.Host) != 0 {
+		kubeConfigOverride.ClusterInfo.Server = fmt.Sprintf("%s://%s", uri.Scheme, uri.Host)
+	}
+
+	opts := uri.Query()
+
+	if len(opts["apiVersion"]) >= 1 {
+		kubeConfigOverride.ClusterInfo.APIVersion = opts["apiVersion"][0]
+	}
+
+	if len(opts["insecure"]) > 0 {
+		insecure, err := strconv.ParseBool(opts["insecure"][0])
+		if err != nil {
+			return nil, err
+		}
+		kubeConfigOverride.ClusterInfo.InsecureSkipTLSVerify = insecure
+	}
+
+	return &kubeConfigOverride, nil
+}
+
+func NewTimeSyncChecker(uri *url.URL, cacheDuration time.Duration) (*timeSync, error) {
+	var (
+		kubeConfig *kube_client.Config
+		err        error
+	)
+
+	opts := uri.Query()
+	configOverrides, err := getConfigOverrides(uri)
+	if err != nil {
+		return nil, err
+	}
+
+	inClusterConfig := defaultInClusterConfig
+	if len(opts["inClusterConfig"]) > 0 {
+		inClusterConfig, err = strconv.ParseBool(opts["inClusterConfig"][0])
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if inClusterConfig {
+		kubeConfig, err = kube_client.InClusterConfig()
+		if err != nil {
+			return nil, err
+		}
+
+		if configOverrides.ClusterInfo.Server != "" {
+			kubeConfig.Host = configOverrides.ClusterInfo.Server
+		}
+		kubeConfig.Version = configOverrides.ClusterInfo.APIVersion
+		kubeConfig.Insecure = configOverrides.ClusterInfo.InsecureSkipTLSVerify
+		if configOverrides.ClusterInfo.InsecureSkipTLSVerify {
+			kubeConfig.TLSClientConfig.CAFile = ""
+		}
+	} else {
+		authFile := ""
+		if len(opts["auth"]) > 0 {
+			authFile = opts["auth"][0]
+		}
+
+		if authFile != "" {
+			if kubeConfig, err = kubeClientCmd.NewNonInteractiveDeferredLoadingClientConfig(
+				&kubeClientCmd.ClientConfigLoadingRules{ExplicitPath: authFile},
+				configOverrides).ClientConfig(); err != nil {
+				return nil, err
+			}
+		} else {
+			kubeConfig = &kube_client.Config{
+				Host:     configOverrides.ClusterInfo.Server,
+				Version:  configOverrides.ClusterInfo.APIVersion,
+				Insecure: configOverrides.ClusterInfo.InsecureSkipTLSVerify,
+			}
+		}
+	}
+	if len(kubeConfig.Host) == 0 {
+		return nil, fmt.Errorf("invalid kubernetes master url specified")
+	}
+	if len(kubeConfig.Version) == 0 {
+		return nil, fmt.Errorf("invalid kubernetes API version specified")
+	}
+
+	useServiceAccount := defaultUseServiceAccount
+	if len(opts["useServiceAccount"]) >= 1 {
+		useServiceAccount, err = strconv.ParseBool(opts["useServiceAccount"][0])
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if useServiceAccount {
+		// If a readable service account token exists, then use it
+		if contents, err := ioutil.ReadFile(defaultServiceAccountFile); err == nil {
+			kubeConfig.BearerToken = string(contents)
+		}
+	}
+
+	kubeClient := kube_client.NewOrDie(kubeConfig)
+
+	nodesApi, err := nodes.NewKubeNodes(kubeClient)
+	if err != nil {
+		return nil, err
+	}
+	return &timeSync{NodesApi: nodesApi, Host: kubeConfig.Host, CacheDuration: cacheDuration}, nil
+}
+
+func (self *timeSync) CheckTimeSync() {
+	kubeNodes, err := self.NodesApi.List()
+	if err == nil && len(kubeNodes.Items) > 0 {
+		for _, info := range kubeNodes.Items {
+			host := info.InternalIP
+			url := fmt.Sprintf("%s://%s:%s/api/v2.0/summary", HttpScheme, host, CadvisorPort)
+			resp, err := http.Get(url)
+			if err == nil && resp.StatusCode == http.StatusOK {
+				defer resp.Body.Close()
+				body, err := ioutil.ReadAll(resp.Body)
+				if err == nil {
+					var bodyInfc interface{}
+					err = json.Unmarshal(body, &bodyInfc)
+					if err == nil {
+						//Because we know structure of response json, so here
+						//we use type assertion to parse the response json.
+						bodyMap := bodyInfc.(map[string]interface{})
+						summaryMap := bodyMap["/"].(map[string]interface{})
+						timestamp := summaryMap["timestamp"].(string)
+						tNode, err := time.Parse("2006-01-02T15:04:05.000000000Z", timestamp)
+						if err == nil {
+							var duration time.Duration
+							if time.Now().After(tNode) {
+								duration = time.Now().Sub(tNode)
+							} else {
+								duration = tNode.Sub(time.Now())
+							}
+							if duration > self.CacheDuration {
+								glog.Warning("Warning: Timestamp of Node: %v is not synchronous with heapster, duration is: %v", self.Host, duration)
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
related  issue https://github.com/kubernetes/heapster/issues/802

This PR is for checking time synchronous between heapster and kubernetes nodes. With requesting the **cadvisor's RESTapi**, to get timestamp about the node,like this:

```
Requst:
GET /api/v2.0/summary
Response:
{
	"/": {
		"timestamp": "2015-12-21T20:43:33.893425812Z"
		"latest_usage": {
		...
		}
		"minute_usage": {
		...
		}
		"hour_usage": {
		...
		}
		"day_usage": {
		...
		}
	}
}
```
The period of checking is 5 minutes, if the duration is bigger than heapster config parameter `argCacheDuration`, the check process will return a warning: `Warning: Timestamp of Node: %v is not synchronous with heapster, duration is: %v`
