### PR TITLE
Update Grafana and default dashboards

### DIFF
--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -2,7 +2,7 @@
 # Stock Grafana + a few custom dashboards
 #
 
-FROM grafana/grafana:2.5.0
+FROM grafana/grafana:2.6.0
 
 RUN apt-get update && \
     apt-get install -y curl

--- a/grafana/Makefile
+++ b/grafana/Makefile
@@ -1,5 +1,5 @@
 
-TAG = v2.5.0
+TAG = v2.6.0
 PREFIX = kubernetes
 
 all: container

--- a/grafana/RELEASES.md
+++ b/grafana/RELEASES.md
@@ -1,5 +1,12 @@
 # Release Notes for Grafana container.
 
+## 2.6.0 (29-12-2015)
+- Support Grafana 2.6.0.
+- Improve default dashboards
+  - Accurate CPU metrics
+  - Cluster network graphs
+  - Fix data aggregation
+
 ## 2.5.0 (12-11-2015)
 - Support Grafana 2.5.0.
 

--- a/grafana/dashboards/cluster.json
+++ b/grafana/dashboards/cluster.json
@@ -16,7 +16,7 @@
         "height": "100px",
         "panels": [
           {
-            "content": "#### This dashboard displays Memory, CPU and Disk metrics at both cluster and node levels. Select a node from the above dropdown to see metrics specific to that node. Select \"All\" to see metrics for all nodes side by side.\n\n##### * Cluster metrics are sum across all nodes.\n##### * Node metrics are displayed on one panel for easy comparison.\n##### * There's also a panel for each node so one could \"double-click\" into the node for further analysis.\n",
+            "content": "#### This dashboard displays Memory, CPU, Disk and Network metrics at both cluster and node levels. Select a node from the above dropdown to see metrics specific to that node. Select \"All\" to see metrics for all nodes side by side.\n\n##### * Cluster metrics are sum across all nodes.\n##### * Node metrics are displayed on one panel for easy comparison.\n##### * There's also a panel for each node so one could \"double-click\" into the node for further analysis.\n",
             "editable": true,
             "error": false,
             "id": 1,
@@ -185,7 +185,7 @@
             "decimals": 2,
             "editable": true,
             "error": false,
-            "fill": 3,
+            "fill": 1,
             "grid": {
               "leftLogBase": 1,
               "leftMax": null,
@@ -223,7 +223,7 @@
             "steppedLine": false,
             "targets": [
               {
-                "alias": "",
+                "alias": "Limit {$tag_hostname}",
                 "fields": [
                   {
                     "func": "max",
@@ -251,7 +251,7 @@
                 ]
               },
               {
-                "alias": "",
+                "alias": "Usage {$tag_hostname}",
                 "fields": [
                   {
                     "func": "max",
@@ -509,7 +509,7 @@
             "steppedLine": false,
             "targets": [
               {
-                "alias": "",
+                "alias": "Limit {$tag_hostname}",
                 "fields": [
                   {
                     "func": "last",
@@ -537,7 +537,7 @@
                 ]
               },
               {
-                "alias": "",
+                "alias": "Usage {$tag_hostname}",
                 "query": "SELECT non_negative_derivative(max(value),1u) FROM \"cpu/usage_ns_cumulative\" WHERE \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval), \"hostname\"",
                 "rawQuery": true,
                 "refId": "B",
@@ -575,7 +575,7 @@
             "decimals": 2,
             "editable": true,
             "error": false,
-            "fill": 1,
+            "fill": 3,
             "grid": {
               "leftLogBase": 1,
               "leftMax": null,
@@ -683,7 +683,7 @@
             "decimals": 2,
             "editable": true,
             "error": false,
-            "fill": 1,
+            "fill": 3,
             "grid": {
               "leftLogBase": 1,
               "leftMax": null,
@@ -838,7 +838,7 @@
             "steppedLine": false,
             "targets": [
               {
-                "alias": "",
+                "alias": "Limit {$tag_hostname}",
                 "fields": [
                   {
                     "func": "last",
@@ -866,7 +866,7 @@
                 ]
               },
               {
-                "alias": "",
+                "alias": "Usage {$tag_hostname}",
                 "fields": [
                   {
                     "func": "last",
@@ -925,7 +925,7 @@
             "decimals": 2,
             "editable": true,
             "error": false,
-            "fill": 1,
+            "fill": 3,
             "grid": {
               "leftLogBase": 1,
               "leftMax": null,
@@ -1042,10 +1042,184 @@
         ],
         "showTitle": true,
         "title": "Individual Node Disk Usage"
+      },
+      {
+        "collapse": false,
+        "editable": true,
+        "height": "250px",
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": null,
+            "decimals": 2,
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {
+              "leftLogBase": 1,
+              "leftMax": null,
+              "leftMin": null,
+              "rightLogBase": 1,
+              "rightMax": null,
+              "rightMin": null,
+              "threshold1": null,
+              "threshold1Color": "rgba(216, 200, 27, 0.27)",
+              "threshold2": null,
+              "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "id": 10,
+            "interval": ">30s",
+            "legend": {
+              "avg": false,
+              "current": true,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 3,
+            "links": [],
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+              {
+                "alias": "/Rx /",
+                "transform": "negative-Y"
+              }
+            ],
+            "span": 12,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "alias": "Tx {$tag_hostname}",
+                "query": "SELECT non_negative_derivative(max(value),1s) FROM \"network/tx_bytes_cumulative\" WHERE \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval), \"hostname\"",
+                "rawQuery": true,
+                "refId": "A",
+                "target": ""
+              },
+              {
+                "alias": "Rx {$tag_hostname}",
+                "query": "SELECT non_negative_derivative(max(value),1s) FROM \"network/rx_bytes_cumulative\" WHERE \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval), \"hostname\"",
+                "rawQuery": true,
+                "refId": "B",
+                "target": ""
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "",
+            "tooltip": {
+              "shared": true,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "x-axis": true,
+            "y-axis": true,
+            "y_formats": [
+              "Bps",
+              "Bps"
+            ]
+          }
+        ],
+        "showTitle": true,
+        "title": "Network Usage Group By Node"
+      },
+      {
+        "collapse": false,
+        "editable": true,
+        "height": "250px",
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "datasource": null,
+            "decimals": 2,
+            "editable": true,
+            "error": false,
+            "fill": 3,
+            "grid": {
+              "leftLogBase": 1,
+              "leftMax": null,
+              "leftMin": null,
+              "rightLogBase": 1,
+              "rightMax": null,
+              "rightMin": null,
+              "threshold1": null,
+              "threshold1Color": "rgba(216, 200, 27, 0.27)",
+              "threshold2": null,
+              "threshold2Color": "rgba(234, 112, 112, 0.22)"
+            },
+            "id": 11,
+            "interval": ">30s",
+            "legend": {
+              "avg": false,
+              "current": true,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 3,
+            "links": [],
+            "minSpan": 6,
+            "nullPointMode": "connected",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": "node",
+            "scopedVars": {},
+            "seriesOverrides": [],
+            "span": 6,
+            "stack": true,
+            "steppedLine": false,
+            "targets": [
+              {
+                "alias": "Tx",
+                "query": "SELECT non_negative_derivative(max(value),1s) FROM \"network/tx_bytes_cumulative\" WHERE \"container_name\" = 'machine' AND \"hostname\" =~ /$node/ AND $timeFilter GROUP BY time($interval)",
+                "rawQuery": true,
+                "refId": "A",
+                "target": ""
+              },
+              {
+                "alias": "Rx",
+                "query": "SELECT non_negative_derivative(max(value),1s) FROM \"network/rx_bytes_cumulative\" WHERE \"container_name\" = 'machine' AND \"hostname\" =~ /$node/ AND $timeFilter GROUP BY time($interval)",
+                "rawQuery": true,
+                "refId": "B",
+                "target": ""
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "$node Network Usage",
+            "tooltip": {
+              "shared": true,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "x-axis": true,
+            "y-axis": true,
+            "y_formats": [
+              "Bps",
+              "Bps"
+            ]
+          }
+        ],
+        "showTitle": true,
+        "title": "Individual Node Network Usage"
       }
     ],
     "time": {
-      "from": "now-6h",
+      "from": "now-30m",
       "to": "now"
     },
     "timepicker": {
@@ -1067,15 +1241,14 @@
       ],
       "status": "Stable",
       "time_options": [
-        "5m",
         "15m",
         "1h",
+        "3h",
         "6h",
         "12h",
         "24h",
         "2d",
-        "7d",
-        "30d"
+        "7d"
       ],
       "type": "timepicker"
     },

--- a/grafana/dashboards/cluster.json
+++ b/grafana/dashboards/cluster.json
@@ -1,6 +1,6 @@
 {
-  "dashboard":
-  {
+  "dashboard": {
+    "id": null,
     "title": "Kubernetes Cluster",
     "originalTitle": "Kubernetes Cluster",
     "tags": [],
@@ -19,7 +19,7 @@
             "content": "#### This dashboard displays Memory, CPU and Disk metrics at both cluster and node levels. Select a node from the above dropdown to see metrics specific to that node. Select \"All\" to see metrics for all nodes side by side.\n\n##### * Cluster metrics are sum across all nodes.\n##### * Node metrics are displayed on one panel for easy comparison.\n##### * There's also a panel for each node so one could \"double-click\" into the node for further analysis.\n",
             "editable": true,
             "error": false,
-            "id": 23,
+            "id": 1,
             "links": [],
             "mode": "markdown",
             "span": 12,
@@ -57,9 +57,8 @@
               "threshold2": null,
               "threshold2Color": "rgba(234, 112, 112, 0.22)"
             },
-            "id": 6,
-            "interval": "",
-            "leftYAxisLabel": "",
+            "id": 2,
+            "interval": ">30s",
             "legend": {
               "avg": false,
               "current": true,
@@ -77,20 +76,7 @@
             "pointradius": 5,
             "points": false,
             "renderer": "flot",
-            "seriesOverrides": [
-              {
-                "alias": "Used Memory",
-                "yaxis": 2
-              },
-              {
-                "alias": "Total Used Memory",
-                "yaxis": 1
-              },
-              {
-                "alias": "Total Working Set",
-                "yaxis": 1
-              }
-            ],
+            "seriesOverrides": [],
             "span": 12,
             "stack": false,
             "steppedLine": false,
@@ -103,17 +89,17 @@
                     "name": "value"
                   }
                 ],
-                "groupByTags": [],
+                "groupBy": [
+                  {
+                    "interval": "auto",
+                    "type": "time"
+                  }
+                ],
                 "measurement": "memory/limit_bytes_gauge",
-                "query": "SELECT sum(value) FROM \"memory/limit_bytes_gauge\" WHERE \"container_name\" = 'machine' AND $timeFilter GROUP BY time(10s)",
-                "rawQuery": true,
+                "query": "SELECT sum(\"value\") AS \"value\" FROM \"memory/limit_bytes_gauge\" WHERE \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval)",
+                "refId": "A",
                 "tags": [
                   {
-                    "key": "hostname",
-                    "value": "/$node/"
-                  },
-                  {
-                    "condition": "AND",
                     "key": "container_name",
                     "value": "machine"
                   }
@@ -123,21 +109,21 @@
                 "alias": "Usage",
                 "fields": [
                   {
-                    "func": "last",
+                    "func": "sum",
                     "name": "value"
                   }
                 ],
-                "groupByTags": [],
+                "groupBy": [
+                  {
+                    "interval": "auto",
+                    "type": "time"
+                  }
+                ],
                 "measurement": "memory/usage_bytes_gauge",
-                "query": "SELECT sum(value) FROM \"memory/usage_bytes_gauge\" WHERE \"container_name\" = 'machine' AND $timeFilter GROUP BY time(10s)",
-                "rawQuery": true,
+                "query": "SELECT sum(\"value\") AS \"value\" FROM \"memory/usage_bytes_gauge\" WHERE \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval)",
+                "refId": "B",
                 "tags": [
                   {
-                    "key": "hostname",
-                    "value": "/$node/"
-                  },
-                  {
-                    "condition": "AND",
                     "key": "container_name",
                     "value": "machine"
                   }
@@ -147,21 +133,21 @@
                 "alias": "Working Set",
                 "fields": [
                   {
-                    "func": "last",
+                    "func": "sum",
                     "name": "value"
                   }
                 ],
-                "groupByTags": [],
-                "measurement": "memory/usage_bytes_gauge",
-                "query": "SELECT sum(value) FROM \"memory/working_set_bytes_gauge\" WHERE \"container_name\" = 'machine' AND $timeFilter GROUP BY time(10s)",
-                "rawQuery": true,
+                "groupBy": [
+                  {
+                    "interval": "auto",
+                    "type": "time"
+                  }
+                ],
+                "measurement": "memory/working_set_bytes_gauge",
+                "query": "SELECT sum(\"value\") AS \"value\" FROM \"memory/working_set_bytes_gauge\" WHERE \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval)",
+                "refId": "C",
                 "tags": [
                   {
-                    "key": "hostname",
-                    "value": "/$node/"
-                  },
-                  {
-                    "condition": "AND",
                     "key": "container_name",
                     "value": "machine"
                   }
@@ -212,9 +198,8 @@
               "threshold2": null,
               "threshold2Color": "rgba(234, 112, 112, 0.22)"
             },
-            "id": 15,
-            "interval": "",
-            "leftYAxisLabel": "",
+            "id": 3,
+            "interval": ">30s",
             "legend": {
               "avg": false,
               "current": true,
@@ -232,20 +217,7 @@
             "pointradius": 5,
             "points": false,
             "renderer": "flot",
-            "seriesOverrides": [
-              {
-                "alias": "Used Memory",
-                "yaxis": 2
-              },
-              {
-                "alias": "Total Used Memory",
-                "yaxis": 1
-              },
-              {
-                "alias": "Total Working Set",
-                "yaxis": 1
-              }
-            ],
+            "seriesOverrides": [],
             "span": 12,
             "stack": false,
             "steppedLine": false,
@@ -254,16 +226,23 @@
                 "alias": "",
                 "fields": [
                   {
-                    "func": "mean",
+                    "func": "max",
                     "name": "value"
                   }
                 ],
-                "groupByTags": [
-                  "hostname"
+                "groupBy": [
+                  {
+                    "interval": "auto",
+                    "type": "time"
+                  },
+                  {
+                    "key": "hostname",
+                    "type": "tag"
+                  }
                 ],
                 "measurement": "memory/limit_bytes_gauge",
-                "query": "SELECT mean(value) FROM \"memory/limit_bytes_gauge\" WHERE \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval), \"hostname\"",
-                "rawQuery": false,
+                "query": "SELECT max(\"value\") AS \"value\" FROM \"memory/limit_bytes_gauge\" WHERE \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval), \"hostname\"",
+                "refId": "A",
                 "tags": [
                   {
                     "key": "container_name",
@@ -275,16 +254,23 @@
                 "alias": "",
                 "fields": [
                   {
-                    "func": "mean",
+                    "func": "max",
                     "name": "value"
                   }
                 ],
-                "groupByTags": [
-                  "hostname"
+                "groupBy": [
+                  {
+                    "interval": "auto",
+                    "type": "time"
+                  },
+                  {
+                    "key": "hostname",
+                    "type": "tag"
+                  }
                 ],
                 "measurement": "memory/working_set_bytes_gauge",
-                "query": "SELECT mean(value) FROM \"memory/working_set_bytes_gauge\" WHERE \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval), \"hostname\"",
-                "rawQuery": false,
+                "query": "SELECT max(\"value\") AS \"value\" FROM \"memory/working_set_bytes_gauge\" WHERE \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval), \"hostname\"",
+                "refId": "B",
                 "tags": [
                   {
                     "key": "container_name",
@@ -337,8 +323,8 @@
               "threshold2": null,
               "threshold2Color": "rgba(234, 112, 112, 0.22)"
             },
-            "id": 7,
-            "leftYAxisLabel": "",
+            "id": 4,
+            "interval": ">30s",
             "legend": {
               "avg": false,
               "current": true,
@@ -358,20 +344,9 @@
             "points": false,
             "renderer": "flot",
             "repeat": "node",
-            "repeatIteration": 1443041003983,
-            "scopedVars": {
-            },
-            "seriesOverrides": [
-              {
-                "alias": "Used Memory",
-                "yaxis": 1
-              },
-              {
-                "alias": "Working Set",
-                "yaxis": 1
-              }
-            ],
-            "span": 12,
+            "scopedVars": {},
+            "seriesOverrides": [],
+            "span": 6,
             "stack": false,
             "steppedLine": false,
             "targets": [
@@ -379,13 +354,19 @@
                 "alias": "Limit",
                 "fields": [
                   {
-                    "func": "last",
+                    "func": "max",
                     "name": "value"
                   }
                 ],
-                "groupByTags": [],
+                "groupBy": [
+                  {
+                    "interval": "auto",
+                    "type": "time"
+                  }
+                ],
                 "measurement": "memory/limit_bytes_gauge",
-                "query": "SELECT last(value) FROM \"memory/limit_bytes_gauge\" WHERE \"hostname\" =~ /$node/ AND \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval)",
+                "query": "SELECT max(\"value\") AS \"value\" FROM \"memory/limit_bytes_gauge\" WHERE \"hostname\" =~ /$node/ AND \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval)",
+                "refId": "A",
                 "tags": [
                   {
                     "key": "hostname",
@@ -402,13 +383,19 @@
                 "alias": "Usage",
                 "fields": [
                   {
-                    "func": "last",
+                    "func": "max",
                     "name": "value"
                   }
                 ],
-                "groupByTags": [],
+                "groupBy": [
+                  {
+                    "interval": "auto",
+                    "type": "time"
+                  }
+                ],
                 "measurement": "memory/usage_bytes_gauge",
-                "query": "SELECT last(value) FROM \"memory/usage_bytes_gauge\" WHERE \"hostname\" =~ /$node/ AND \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval)",
+                "query": "SELECT max(\"value\") AS \"value\" FROM \"memory/usage_bytes_gauge\" WHERE \"hostname\" =~ /$node/ AND \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval)",
+                "refId": "B",
                 "tags": [
                   {
                     "key": "hostname",
@@ -425,13 +412,19 @@
                 "alias": "Working Set",
                 "fields": [
                   {
-                    "func": "last",
+                    "func": "max",
                     "name": "value"
                   }
                 ],
-                "groupByTags": [],
+                "groupBy": [
+                  {
+                    "interval": "auto",
+                    "type": "time"
+                  }
+                ],
                 "measurement": "memory/working_set_bytes_gauge",
-                "query": "SELECT last(value) FROM \"memory/working_set_bytes_gauge\" WHERE \"hostname\" =~ /$node/ AND \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval)",
+                "query": "SELECT max(\"value\") AS \"value\" FROM \"memory/working_set_bytes_gauge\" WHERE \"hostname\" =~ /$node/ AND \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval)",
+                "refId": "C",
                 "tags": [
                   {
                     "key": "hostname",
@@ -462,8 +455,7 @@
           }
         ],
         "repeat": null,
-        "scopedVars": {
-        },
+        "scopedVars": {},
         "showTitle": true,
         "title": "Individual Node Memory Usage"
       },
@@ -492,8 +484,8 @@
               "threshold2": null,
               "threshold2Color": "rgba(234, 112, 112, 0.22)"
             },
-            "id": 11,
-            "interval": "10s",
+            "id": 5,
+            "interval": ">30s",
             "legend": {
               "avg": false,
               "current": true,
@@ -504,19 +496,14 @@
               "values": true
             },
             "lines": true,
-            "linewidth": 2,
+            "linewidth": 3,
             "links": [],
             "nullPointMode": "connected",
             "percentage": false,
             "pointradius": 5,
             "points": false,
             "renderer": "flot",
-            "seriesOverrides": [
-              {
-                "alias": "usage",
-                "yaxis": 2
-              }
-            ],
+            "seriesOverrides": [],
             "span": 12,
             "stack": false,
             "steppedLine": false,
@@ -525,16 +512,23 @@
                 "alias": "",
                 "fields": [
                   {
-                    "func": "mean",
+                    "func": "last",
                     "name": "value"
                   }
                 ],
-                "groupByTags": [
-                  "hostname"
+                "groupBy": [
+                  {
+                    "interval": "auto",
+                    "type": "time"
+                  },
+                  {
+                    "key": "hostname",
+                    "type": "tag"
+                  }
                 ],
                 "measurement": "cpu/limit_gauge",
-                "query": "SELECT mean(value) FROM \"cpu/limit_gauge\" WHERE \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval), \"hostname\"",
-                "rawQuery": true,
+                "query": "SELECT last(\"value\") AS \"value\" FROM \"cpu/limit_gauge\" WHERE \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval), \"hostname\"",
+                "refId": "A",
                 "tags": [
                   {
                     "key": "container_name",
@@ -544,27 +538,9 @@
               },
               {
                 "alias": "",
-                "fields": [
-                  {
-                    "func": "derivative",
-                    "name": "value"
-                  }
-                ],
-                "groupByTags": [],
-                "measurement": "cpu/usage_ns_cumulative",
-                "query": "SELECT non_negative_derivative(mean(value), $interval)/10000000 FROM \"cpu/usage_ns_cumulative\" WHERE \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval), \"hostname\"",
+                "query": "SELECT non_negative_derivative(max(value),1u) FROM \"cpu/usage_ns_cumulative\" WHERE \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval), \"hostname\"",
                 "rawQuery": true,
-                "tags": [
-                  {
-                    "key": "container_name",
-                    "value": "machine"
-                  },
-                  {
-                    "condition": "AND",
-                    "key": "hostname",
-                    "value": "/$node/"
-                  }
-                ],
+                "refId": "B",
                 "target": ""
               }
             ],
@@ -612,8 +588,8 @@
               "threshold2": null,
               "threshold2Color": "rgba(234, 112, 112, 0.22)"
             },
-            "id": 16,
-            "interval": "10s",
+            "id": 6,
+            "interval": ">30s",
             "legend": {
               "avg": false,
               "current": true,
@@ -624,7 +600,7 @@
               "values": true
             },
             "lines": true,
-            "linewidth": 2,
+            "linewidth": 3,
             "links": [],
             "minSpan": 6,
             "nullPointMode": "connected",
@@ -633,15 +609,9 @@
             "points": false,
             "renderer": "flot",
             "repeat": "node",
-            "scopedVars": {
-            },
-            "seriesOverrides": [
-              {
-                "alias": "usage",
-                "yaxis": 2
-              }
-            ],
-            "span": 12,
+            "scopedVars": {},
+            "seriesOverrides": [],
+            "span": 6,
             "stack": false,
             "steppedLine": false,
             "targets": [
@@ -649,14 +619,19 @@
                 "alias": "Limit",
                 "fields": [
                   {
-                    "func": "mean",
+                    "func": "last",
                     "name": "value"
                   }
                 ],
-                "groupByTags": [],
+                "groupBy": [
+                  {
+                    "interval": "auto",
+                    "type": "time"
+                  }
+                ],
                 "measurement": "cpu/limit_gauge",
-                "query": "SELECT mean(value) FROM \"cpu/limit_gauge\" WHERE \"container_name\" = 'machine' AND \"hostname\" =~ /$node/ AND $timeFilter GROUP BY time($interval)",
-                "rawQuery": false,
+                "query": "SELECT last(\"value\") AS \"value\" FROM \"cpu/limit_gauge\" WHERE \"container_name\" = 'machine' AND \"hostname\" =~ /$node/ AND $timeFilter GROUP BY time($interval)",
+                "refId": "A",
                 "tags": [
                   {
                     "key": "container_name",
@@ -671,27 +646,9 @@
               },
               {
                 "alias": "Usage",
-                "fields": [
-                  {
-                    "func": "derivative",
-                    "name": "value"
-                  }
-                ],
-                "groupByTags": [],
-                "measurement": "cpu/usage_ns_cumulative",
-                "query": "SELECT non_negative_derivative(mean(value), $interval)/10000000 FROM \"cpu/usage_ns_cumulative\" WHERE \"container_name\" = 'machine' AND \"hostname\" =~ /$node/ AND $timeFilter GROUP BY time($interval)",
+                "query": "SELECT non_negative_derivative(max(value),1u) FROM \"cpu/usage_ns_cumulative\" WHERE \"container_name\" = 'machine' AND \"hostname\" =~ /$node/ AND $timeFilter GROUP BY time($interval)",
                 "rawQuery": true,
-                "tags": [
-                  {
-                    "key": "container_name",
-                    "value": "machine"
-                  },
-                  {
-                    "condition": "AND",
-                    "key": "hostname",
-                    "value": "/$node/"
-                  }
-                ],
+                "refId": "B",
                 "target": ""
               }
             ],
@@ -739,34 +696,26 @@
               "threshold2": null,
               "threshold2Color": "rgba(234, 112, 112, 0.22)"
             },
-            "id": 9,
+            "id": 7,
+            "interval": ">30s",
             "legend": {
-              "avg": true,
+              "avg": false,
               "current": true,
-              "max": true,
+              "max": false,
               "min": false,
               "show": true,
               "total": false,
               "values": true
             },
             "lines": true,
-            "linewidth": 2,
+            "linewidth": 3,
             "links": [],
             "nullPointMode": "connected",
             "percentage": false,
             "pointradius": 5,
             "points": false,
             "renderer": "flot",
-            "seriesOverrides": [
-              {
-                "alias": "Used Disk",
-                "yaxis": 2
-              },
-              {
-                "alias": "Total Used Disk",
-                "yaxis": 2
-              }
-            ],
+            "seriesOverrides": [],
             "span": 12,
             "stack": false,
             "steppedLine": false,
@@ -775,27 +724,49 @@
                 "alias": "Limit",
                 "fields": [
                   {
-                    "func": "mean",
+                    "func": "sum",
                     "name": "value"
                   }
                 ],
-                "groupByTags": [],
-                "query": "SELECT sum(value) FROM \"filesystem/limit_bytes_gauge\" WHERE \"container_name\" = 'machine' AND $timeFilter GROUP BY time(10s)",
-                "rawQuery": true,
-                "tags": []
+                "groupBy": [
+                  {
+                    "interval": "auto",
+                    "type": "time"
+                  }
+                ],
+                "measurement": "filesystem/limit_bytes_gauge",
+                "query": "SELECT sum(\"value\") AS \"value\" FROM \"filesystem/limit_bytes_gauge\" WHERE \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval)",
+                "refId": "A",
+                "tags": [
+                  {
+                    "key": "container_name",
+                    "value": "machine"
+                  }
+                ]
               },
               {
                 "alias": "Usage",
                 "fields": [
                   {
-                    "func": "mean",
+                    "func": "sum",
                     "name": "value"
                   }
                 ],
-                "groupByTags": [],
-                "query": "SELECT sum(value) FROM \"filesystem/usage_bytes_gauge\" WHERE \"container_name\" = 'machine' AND $timeFilter GROUP BY time(10s)",
-                "rawQuery": true,
-                "tags": []
+                "groupBy": [
+                  {
+                    "interval": "auto",
+                    "type": "time"
+                  }
+                ],
+                "measurement": "filesystem/usage_bytes_gauge",
+                "query": "SELECT sum(\"value\") AS \"value\" FROM \"filesystem/usage_bytes_gauge\" WHERE \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval)",
+                "refId": "B",
+                "tags": [
+                  {
+                    "key": "container_name",
+                    "value": "machine"
+                  }
+                ]
               }
             ],
             "timeFrom": null,
@@ -842,7 +813,8 @@
               "threshold2": null,
               "threshold2Color": "rgba(234, 112, 112, 0.22)"
             },
-            "id": 19,
+            "id": 8,
+            "interval": ">30s",
             "legend": {
               "avg": false,
               "current": true,
@@ -853,23 +825,14 @@
               "values": true
             },
             "lines": true,
-            "linewidth": 2,
+            "linewidth": 3,
             "links": [],
             "nullPointMode": "connected",
             "percentage": false,
             "pointradius": 5,
             "points": false,
             "renderer": "flot",
-            "seriesOverrides": [
-              {
-                "alias": "Used Disk",
-                "yaxis": 2
-              },
-              {
-                "alias": "Total Used Disk",
-                "yaxis": 2
-              }
-            ],
+            "seriesOverrides": [],
             "span": 12,
             "stack": false,
             "steppedLine": false,
@@ -878,16 +841,23 @@
                 "alias": "",
                 "fields": [
                   {
-                    "func": "mean",
+                    "func": "last",
                     "name": "value"
                   }
                 ],
-                "groupByTags": [
-                  "hostname"
+                "groupBy": [
+                  {
+                    "interval": "auto",
+                    "type": "time"
+                  },
+                  {
+                    "key": "hostname",
+                    "type": "tag"
+                  }
                 ],
                 "measurement": "filesystem/limit_bytes_gauge",
-                "query": "SELECT mean(value) FROM \"filesystem/limit_bytes_gauge\" WHERE \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval), \"hostname\"",
-                "rawQuery": false,
+                "query": "SELECT last(\"value\") AS \"value\" FROM \"filesystem/limit_bytes_gauge\" WHERE \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval), \"hostname\"",
+                "refId": "A",
                 "tags": [
                   {
                     "key": "container_name",
@@ -899,16 +869,23 @@
                 "alias": "",
                 "fields": [
                   {
-                    "func": "mean",
+                    "func": "last",
                     "name": "value"
                   }
                 ],
-                "groupByTags": [
-                  "hostname"
+                "groupBy": [
+                  {
+                    "interval": "auto",
+                    "type": "time"
+                  },
+                  {
+                    "key": "hostname",
+                    "type": "tag"
+                  }
                 ],
                 "measurement": "filesystem/usage_bytes_gauge",
-                "query": "SELECT mean(value) FROM \"filesystem/usage_bytes_gauge\" WHERE \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval), \"hostname\"",
-                "rawQuery": false,
+                "query": "SELECT last(\"value\") AS \"value\" FROM \"filesystem/usage_bytes_gauge\" WHERE \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval), \"hostname\"",
+                "refId": "B",
                 "tags": [
                   {
                     "key": "container_name",
@@ -961,18 +938,19 @@
               "threshold2": null,
               "threshold2Color": "rgba(234, 112, 112, 0.22)"
             },
-            "id": 10,
+            "id": 9,
+            "interval": ">30s",
             "legend": {
-              "avg": true,
+              "avg": false,
               "current": true,
-              "max": true,
+              "max": false,
               "min": false,
               "show": true,
               "total": false,
               "values": true
             },
             "lines": true,
-            "linewidth": 2,
+            "linewidth": 3,
             "links": [],
             "minSpan": 6,
             "nullPointMode": "connected",
@@ -981,15 +959,9 @@
             "points": false,
             "renderer": "flot",
             "repeat": "node",
-            "scopedVars": {
-            },
-            "seriesOverrides": [
-              {
-                "alias": "Used Disk",
-                "yaxis": 2
-              }
-            ],
-            "span": 12,
+            "scopedVars": {},
+            "seriesOverrides": [],
+            "span": 6,
             "stack": false,
             "steppedLine": false,
             "targets": [
@@ -997,27 +969,59 @@
                 "alias": "Limit",
                 "fields": [
                   {
-                    "func": "mean",
+                    "func": "last",
                     "name": "value"
                   }
                 ],
-                "groupByTags": [],
-                "query": "SELECT last(value) FROM \"filesystem/limit_bytes_gauge\" WHERE \"hostname\" =~ /$node/ AND \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval)",
-                "rawQuery": true,
-                "tags": []
+                "groupBy": [
+                  {
+                    "interval": "auto",
+                    "type": "time"
+                  }
+                ],
+                "measurement": "filesystem/limit_bytes_gauge",
+                "query": "SELECT last(\"value\") AS \"value\" FROM \"filesystem/limit_bytes_gauge\" WHERE \"container_name\" = 'machine' AND \"hostname\" =~ /$node/ AND $timeFilter GROUP BY time($interval)",
+                "refId": "A",
+                "tags": [
+                  {
+                    "key": "container_name",
+                    "value": "machine"
+                  },
+                  {
+                    "condition": "AND",
+                    "key": "hostname",
+                    "value": "/$node/"
+                  }
+                ]
               },
               {
                 "alias": "Usage",
                 "fields": [
                   {
-                    "func": "mean",
+                    "func": "last",
                     "name": "value"
                   }
                 ],
-                "groupByTags": [],
-                "query": "SELECT last(value) FROM \"filesystem/usage_bytes_gauge\" WHERE \"hostname\" =~ /$node/ AND \"container_name\" = 'machine' AND $timeFilter GROUP BY time($interval)",
-                "rawQuery": true,
-                "tags": []
+                "groupBy": [
+                  {
+                    "interval": "auto",
+                    "type": "time"
+                  }
+                ],
+                "measurement": "filesystem/usage_bytes_gauge",
+                "query": "SELECT last(\"value\") AS \"value\" FROM \"filesystem/usage_bytes_gauge\" WHERE \"container_name\" = 'machine' AND \"hostname\" =~ /$node/ AND $timeFilter GROUP BY time($interval)",
+                "refId": "B",
+                "tags": [
+                  {
+                    "key": "container_name",
+                    "value": "machine"
+                  },
+                  {
+                    "condition": "AND",
+                    "key": "hostname",
+                    "value": "/$node/"
+                  }
+                ]
               }
             ],
             "timeFrom": null,
@@ -1040,48 +1044,48 @@
         "title": "Individual Node Disk Usage"
       }
     ],
-    "nav": [
-      {
-        "collapse": false,
-        "enable": true,
-        "notice": false,
-        "now": true,
-        "refresh_intervals": [
-          "5s",
-          "10s",
-          "30s",
-          "1m",
-          "5m",
-          "15m",
-          "30m",
-          "1h",
-          "2h",
-          "1d"
-        ],
-        "status": "Stable",
-        "time_options": [
-          "5m",
-          "15m",
-          "1h",
-          "6h",
-          "12h",
-          "24h",
-          "2d",
-          "7d",
-          "30d"
-        ],
-        "type": "timepicker"
-      }
-    ],
     "time": {
       "from": "now-6h",
       "to": "now"
+    },
+    "timepicker": {
+      "collapse": false,
+      "enable": true,
+      "notice": false,
+      "now": true,
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "status": "Stable",
+      "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "30d"
+      ],
+      "type": "timepicker"
     },
     "templating": {
       "list": [
         {
           "allFormat": "glob",
           "current": {
+            "text": "All",
+            "value": "{}"
           },
           "datasource": null,
           "includeAll": true,
@@ -1090,8 +1094,13 @@
           "multiFormat": "glob",
           "name": "node",
           "options": [
+            {
+              "text": "All",
+              "value": "{}",
+              "selected": true
+            }
           ],
-          "query": "SHOW TAG VALUES FROM \"uptime_ms_cumulative\" WITH KEY = \"hostname\"\t",
+          "query": "SHOW TAG VALUES FROM \"uptime_ms_cumulative\" WITH KEY = \"hostname\"",
           "refresh": true,
           "refresh_on_load": true,
           "regex": "",
@@ -1103,8 +1112,9 @@
     "annotations": {
       "list": []
     },
-    "schemaVersion": 6,
-    "version": 33,
+    "schemaVersion": 7,
+    "version": 0,
     "links": []
-  }
+  },
+  "overwrite": false
 }

--- a/grafana/dashboards/containers.json
+++ b/grafana/dashboards/containers.json
@@ -315,7 +315,7 @@
       }
     ],
     "time": {
-      "from": "now-6h",
+      "from": "now-30m",
       "to": "now"
     },
     "timepicker": {
@@ -337,15 +337,14 @@
       ],
       "status": "Stable",
       "time_options": [
-        "5m",
         "15m",
         "1h",
+        "3h",
         "6h",
         "12h",
         "24h",
         "2d",
-        "7d",
-        "30d"
+        "7d"
       ],
       "type": "timepicker"
     },

--- a/grafana/dashboards/containers.json
+++ b/grafana/dashboards/containers.json
@@ -1,6 +1,6 @@
 {
-  "dashboard":
-  {
+  "dashboard": {
+    "id": null,
     "title": "Containers",
     "originalTitle": "Containers",
     "tags": [],
@@ -35,9 +35,8 @@
               "threshold2": null,
               "threshold2Color": "rgba(234, 112, 112, 0.22)"
             },
-            "hideTimeOverride": false,
             "id": 1,
-            "interval": "10s",
+            "interval": ">30s",
             "legend": {
               "avg": false,
               "current": true,
@@ -57,16 +56,9 @@
             "points": false,
             "renderer": "flot",
             "repeat": "container",
-            "scopedVars": {
-            },
-            "seriesOverrides": [
-              {},
-              {
-                "alias": "Used Memory",
-                "yaxis": 1
-              }
-            ],
-            "span": 12,
+            "scopedVars": {},
+            "seriesOverrides": [],
+            "span": 4,
             "stack": false,
             "steppedLine": false,
             "targets": [
@@ -79,25 +71,32 @@
                   }
                 ],
                 "fill": "null",
-                "groupByTags": [],
-                "hide": false,
+                "groupBy": [
+                  {
+                    "interval": "auto",
+                    "type": "time"
+                  }
+                ],
                 "measurement": "memory/limit_bytes_gauge",
-                "query": "SELECT last(value) FROM \"memory/limit_bytes_gauge\" WHERE \"container_name\" =~ /$container/ AND \"pod_name\" =~ /$pod/ AND \"pod_namespace\" =~ /$namespace/ AND $timeFilter GROUP BY time($interval) fill(null)",
-                "rawQuery": false,
+                "query": "SELECT last(\"value\") AS \"value\" FROM \"memory/limit_bytes_gauge\" WHERE \"container_name\" =~ /$container$/ AND \"pod_name\" =~ /$pod$/ AND \"pod_namespace\" =~ /$namespace$/ AND $timeFilter GROUP BY time($interval) fill(null)",
+                "refId": "A",
                 "tags": [
                   {
                     "key": "container_name",
-                    "value": "/$container/"
+                    "operator": "=~",
+                    "value": "/$container$/"
                   },
                   {
                     "condition": "AND",
                     "key": "pod_name",
-                    "value": "/$pod/"
+                    "operator": "=~",
+                    "value": "/$pod$/"
                   },
                   {
                     "condition": "AND",
                     "key": "pod_namespace",
-                    "value": "/$namespace/"
+                    "operator": "=~",
+                    "value": "/$namespace$/"
                   }
                 ]
               },
@@ -105,30 +104,37 @@
                 "alias": "Usage",
                 "fields": [
                   {
-                    "func": "last",
+                    "func": "max",
                     "name": "value"
                   }
                 ],
                 "fill": "null",
-                "groupByTags": [],
-                "hide": false,
+                "groupBy": [
+                  {
+                    "interval": "auto",
+                    "type": "time"
+                  }
+                ],
                 "measurement": "memory/usage_bytes_gauge",
-                "query": "SELECT last(value) FROM \"memory/usage_bytes_gauge\" WHERE \"container_name\" =~ /$container/ AND \"pod_name\" =~ /$pod/ AND \"pod_namespace\" =~ /$namespace/ AND $timeFilter GROUP BY time($interval) fill(null)",
-                "rawQuery": false,
+                "query": "SELECT max(\"value\") AS \"value\" FROM \"memory/usage_bytes_gauge\" WHERE \"container_name\" =~ /$container$/ AND \"pod_name\" =~ /$pod$/ AND \"pod_namespace\" =~ /$namespace$/ AND $timeFilter GROUP BY time($interval) fill(null)",
+                "refId": "B",
                 "tags": [
                   {
                     "key": "container_name",
-                    "value": "/$container/"
+                    "operator": "=~",
+                    "value": "/$container$/"
                   },
                   {
                     "condition": "AND",
                     "key": "pod_name",
-                    "value": "/$pod/"
+                    "operator": "=~",
+                    "value": "/$pod$/"
                   },
                   {
                     "condition": "AND",
                     "key": "pod_namespace",
-                    "value": "/$namespace/"
+                    "operator": "=~",
+                    "value": "/$namespace$/"
                   }
                 ]
               },
@@ -136,30 +142,37 @@
                 "alias": "Working Set",
                 "fields": [
                   {
-                    "func": "last",
+                    "func": "max",
                     "name": "value"
                   }
                 ],
                 "fill": "null",
-                "groupByTags": [],
-                "hide": false,
+                "groupBy": [
+                  {
+                    "interval": "auto",
+                    "type": "time"
+                  }
+                ],
                 "measurement": "memory/working_set_bytes_gauge",
-                "query": "SELECT last(value) FROM \"memory/working_set_bytes_gauge\" WHERE \"container_name\" =~ /$container/ AND \"pod_name\" =~ /$pod/ AND \"pod_namespace\" =~ /$namespace/ AND $timeFilter GROUP BY time($interval) fill(null)",
-                "rawQuery": false,
+                "query": "SELECT max(\"value\") AS \"value\" FROM \"memory/working_set_bytes_gauge\" WHERE \"container_name\" =~ /$container$/ AND \"pod_name\" =~ /$pod$/ AND \"pod_namespace\" =~ /$namespace$/ AND $timeFilter GROUP BY time($interval) fill(null)",
+                "refId": "C",
                 "tags": [
                   {
                     "key": "container_name",
-                    "value": "/$container/"
+                    "operator": "=~",
+                    "value": "/$container$/"
                   },
                   {
                     "condition": "AND",
                     "key": "pod_name",
-                    "value": "/$pod/"
+                    "operator": "=~",
+                    "value": "/$pod$/"
                   },
                   {
                     "condition": "AND",
                     "key": "pod_namespace",
-                    "value": "/$namespace/"
+                    "operator": "=~",
+                    "value": "/$namespace$/"
                   }
                 ]
               }
@@ -208,8 +221,7 @@
               "threshold2": null,
               "threshold2Color": "rgba(234, 112, 112, 0.22)"
             },
-            "hideTimeOverride": false,
-            "id": 14,
+            "id": 2,
             "interval": ">30s",
             "legend": {
               "avg": false,
@@ -230,16 +242,9 @@
             "points": false,
             "renderer": "flot",
             "repeat": "container",
-            "scopedVars": {
-            },
-            "seriesOverrides": [
-              {},
-              {
-                "alias": "Used Memory",
-                "yaxis": 1
-              }
-            ],
-            "span": 12,
+            "scopedVars": {},
+            "seriesOverrides": [],
+            "span": 4,
             "stack": false,
             "steppedLine": false,
             "targets": [
@@ -247,63 +252,46 @@
                 "alias": "Limit",
                 "fields": [
                   {
-                    "func": "mean",
+                    "func": "last",
                     "name": "value"
                   }
                 ],
                 "fill": "null",
-                "groupByTags": [],
-                "hide": false,
+                "groupBy": [
+                  {
+                    "interval": "auto",
+                    "type": "time"
+                  }
+                ],
                 "measurement": "cpu/limit_gauge",
-                "query": "SELECT mean(value) FROM \"cpu/limit_gauge\" WHERE \"container_name\" =~ /$container/ AND \"pod_name\" =~ /$pod/ AND \"pod_namespace\" =~ /$namespace/ AND $timeFilter GROUP BY time($interval) fill(null)",
-                "rawQuery": true,
+                "query": "SELECT last(\"value\") AS \"value\" FROM \"cpu/limit_gauge\" WHERE \"container_name\" =~ /$container$/ AND \"pod_name\" =~ /$pod$/ AND \"pod_namespace\" =~ /$namespace$/ AND $timeFilter GROUP BY time($interval) fill(null)",
+                "refId": "A",
                 "tags": [
                   {
                     "key": "container_name",
-                    "value": "/$container/"
+                    "operator": "=~",
+                    "value": "/$container$/"
                   },
                   {
                     "condition": "AND",
                     "key": "pod_name",
-                    "value": "/$pod/"
+                    "operator": "=~",
+                    "value": "/$pod$/"
                   },
                   {
                     "condition": "AND",
                     "key": "pod_namespace",
-                    "value": "/$namespace/"
+                    "operator": "=~",
+                    "value": "/$namespace$/"
                   }
                 ]
               },
               {
                 "alias": "Usage",
-                "fields": [
-                  {
-                    "func": "derivative",
-                    "name": "value"
-                  }
-                ],
-                "fill": "null",
-                "groupByTags": [],
-                "hide": false,
-                "measurement": "cpu/usage_ns_cumulative",
-                "query": "SELECT non_negative_derivative(mean(value), $interval)/10000000 FROM \"cpu/usage_ns_cumulative\" WHERE \"container_name\" =~ /$container/ AND \"pod_name\" =~ /$pod/ AND \"pod_namespace\" =~ /$namespace/ AND $timeFilter GROUP BY time($interval)",
+                "query": "SELECT non_negative_derivative(max(value),1u) FROM \"cpu/usage_ns_cumulative\" WHERE \"container_name\" =~ /$container$/ AND \"pod_name\" =~ /$pod$/ AND \"pod_namespace\" =~ /$namespace$/ AND $timeFilter GROUP BY time($interval)",
                 "rawQuery": true,
-                "tags": [
-                  {
-                    "key": "container_name",
-                    "value": "/$container/"
-                  },
-                  {
-                    "condition": "AND",
-                    "key": "pod_name",
-                    "value": "/$pod/"
-                  },
-                  {
-                    "condition": "AND",
-                    "key": "pod_namespace",
-                    "value": "/$namespace/"
-                  }
-                ]
+                "refId": "B",
+                "tags": []
               }
             ],
             "timeFrom": null,
@@ -326,65 +314,72 @@
         "title": "Container CPU"
       }
     ],
-    "nav": [
-      {
-        "collapse": false,
-        "enable": true,
-        "notice": false,
-        "now": true,
-        "refresh_intervals": [
-          "5s",
-          "10s",
-          "30s",
-          "1m",
-          "5m",
-          "15m",
-          "30m",
-          "1h",
-          "2h",
-          "1d"
-        ],
-        "status": "Stable",
-        "time_options": [
-          "5m",
-          "15m",
-          "1h",
-          "6h",
-          "12h",
-          "24h",
-          "2d",
-          "7d",
-          "30d"
-        ],
-        "type": "timepicker"
-      }
-    ],
     "time": {
       "from": "now-6h",
       "to": "now"
     },
+    "timepicker": {
+      "collapse": false,
+      "enable": true,
+      "notice": false,
+      "now": true,
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "status": "Stable",
+      "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "30d"
+      ],
+      "type": "timepicker"
+    },
     "templating": {
       "list": [
         {
-          "type": "query",
-          "refresh": true,
-          "refresh_on_load": true,
-          "datasource": null,
-          "refresh_on_load": false,
-          "name": "namespace",
-          "options": [
-          ],
-          "includeAll": true,
           "allFormat": "regex wildcard",
+          "current": {
+            "text": "All",
+            "value": ".*"
+          },
+          "datasource": null,
+          "includeAll": true,
           "multi": false,
           "multiFormat": "glob",
+          "name": "namespace",
+          "options": [
+            {
+              "text": "All",
+              "value": ".*",
+              "selected": true
+            }
+          ],
           "query": "SHOW TAG VALUES FROM \"uptime_ms_cumulative\" WITH KEY = \"pod_namespace\"",
-          "current": {
-          }
+          "refresh": true,
+          "refresh_on_load": false,
+          "regex": "",
+          "type": "query"
         },
         {
           "allFormat": "regex wildcard",
           "current": {
+            "text": "All",
+            "value": ".*"
           },
           "datasource": null,
           "includeAll": true,
@@ -392,15 +387,23 @@
           "multiFormat": "glob",
           "name": "pod",
           "options": [
+            {
+              "text": "All",
+              "value": ".*",
+              "selected": true
+            }
           ],
-          "query": "SHOW TAG VALUES FROM \"uptime_ms_cumulative\" WITH KEY = \"pod_name\" WHERE pod_namespace =~ /$namespace/ ",
+          "query": "SHOW TAG VALUES FROM \"uptime_ms_cumulative\" WITH KEY = \"pod_name\" WHERE pod_namespace =~ /$namespace$/",
           "refresh": true,
           "refresh_on_load": true,
+          "regex": "",
           "type": "query"
         },
         {
           "allFormat": "glob",
           "current": {
+            "text": "All",
+            "value": "{}"
           },
           "datasource": null,
           "includeAll": true,
@@ -408,10 +411,16 @@
           "multiFormat": "glob",
           "name": "container",
           "options": [
+            {
+              "text": "All",
+              "value": "{}",
+              "selected": true
+            }
           ],
-          "query": "SHOW TAG VALUES FROM \"uptime_ms_cumulative\" WITH KEY = \"container_name\" WHERE pod_name =~ /$pod/ and \"pod_namespace\" =~ /$namespace/",
+          "query": "SHOW TAG VALUES FROM \"uptime_ms_cumulative\" WITH KEY = \"container_name\" WHERE pod_name =~ /$pod$/ and \"pod_namespace\" =~ /$namespace$/",
           "refresh": true,
           "refresh_on_load": true,
+          "regex": "",
           "type": "query"
         }
       ]
@@ -419,8 +428,9 @@
     "annotations": {
       "list": []
     },
-    "schemaVersion": 6,
-    "version": 4,
+    "schemaVersion": 7,
+    "version": 0,
     "links": []
-  }
+  },
+  "overwrite": false
 }


### PR DESCRIPTION
This PR includes the following changes to the default Dashboards:

* Grafana v7 schema
* Accurate CPU metrics
* Group metrics by time >30s (better than fixed value, adapts to time range and pixel width of the graph)
* Fix container metrics aggregation ("app" and "app-slave" metrics used to be wrongly aggregated)
* Clean leftovers from old versions (mainly obsolete settings)