### PR TITLE
Remove duplicate namespace in podname.

### DIFF
--- a/model/getters.go
+++ b/model/getters.go
@@ -307,12 +307,7 @@ func (rc *realModel) GetNodePods(hostname string) []EntityListEntry {
 	}
 
 	for podname, val := range noderef.Pods {
-		// Set the Pod name as <namespace> / <podname>
-		namespace, err := rc.findPodNamespace(val)
-		if err != nil {
-			break
-		}
-		newEntity := makeEntityListEntry(namespace+"/"+podname, val.Metrics)
+		newEntity := makeEntityListEntry(podname, val.Metrics)
 		if newEntity.Name == "" {
 			continue
 		}


### PR DESCRIPTION
The `podname` in the for loop is already `<namespace> / <podname>`. 
See https://github.com/kubernetes/heapster/blob/master/model/impl.go#L181

So this `GetNodePods` will return duplicate namespace in podname.