### PR TITLE
add prometheus for heapster

### DIFF
--- a/metrics/api/v1/model_handlers.go
+++ b/metrics/api/v1/model_handlers.go
@@ -193,21 +193,33 @@ func (a *Api) RegisterModel(container *restful.Container) {
 
 // availableMetrics returns a list of available cluster metric names.
 func (a *Api) availableClusterMetrics(request *restful.Request, response *restful.Response) {
+
+	//number of http model api requests add 1
+	core.ModelApiRequestCount.Inc()
 	a.processMetricNamesRequest(core.ClusterKey(), response)
 }
 
 // availableMetrics returns a list of available node metric names.
 func (a *Api) availableNodeMetrics(request *restful.Request, response *restful.Response) {
+
+	//number of http model api requests add 1
+	core.ModelApiRequestCount.Inc()
 	a.processMetricNamesRequest(core.NodeKey(request.PathParameter("node-name")), response)
 }
 
 // availableMetrics returns a list of available namespace metric names.
 func (a *Api) availableNamespaceMetrics(request *restful.Request, response *restful.Response) {
+
+	//number of http model api requests add 1
+	core.ModelApiRequestCount.Inc()
 	a.processMetricNamesRequest(core.NamespaceKey(request.PathParameter("namespace-name")), response)
 }
 
 // availableMetrics returns a list of available pod metric names.
 func (a *Api) availablePodMetrics(request *restful.Request, response *restful.Response) {
+
+	//number of http model api requests add 1
+	core.ModelApiRequestCount.Inc()
 	a.processMetricNamesRequest(
 		core.PodKey(request.PathParameter("namespace-name"),
 			request.PathParameter("pod-name")), response)
@@ -215,6 +227,9 @@ func (a *Api) availablePodMetrics(request *restful.Request, response *restful.Re
 
 // availableMetrics returns a list of available pod metric names.
 func (a *Api) availablePodContainerMetrics(request *restful.Request, response *restful.Response) {
+
+	//number of http model api requests add 1
+	core.ModelApiRequestCount.Inc()
 	a.processMetricNamesRequest(
 		core.PodContainerKey(request.PathParameter("namespace-name"),
 			request.PathParameter("pod-name"),
@@ -224,6 +239,9 @@ func (a *Api) availablePodContainerMetrics(request *restful.Request, response *r
 
 // availableMetrics returns a list of available pod metric names.
 func (a *Api) availableFreeContainerMetrics(request *restful.Request, response *restful.Response) {
+
+	//number of http model api requests add 1
+	core.ModelApiRequestCount.Inc()
 	a.processMetricNamesRequest(
 		core.NodeContainerKey(request.PathParameter("node-name"),
 			request.PathParameter("container-name"),
@@ -232,23 +250,35 @@ func (a *Api) availableFreeContainerMetrics(request *restful.Request, response *
 
 // clusterMetrics returns a metric timeseries for a metric of the Cluster entity.
 func (a *Api) clusterMetrics(request *restful.Request, response *restful.Response) {
+
+	//number of http model api requests add 1
+	core.ModelApiRequestCount.Inc()
 	a.processMetricRequest(core.ClusterKey(), request, response)
 }
 
 // nodeMetrics returns a metric timeseries for a metric of the Node entity.
 func (a *Api) nodeMetrics(request *restful.Request, response *restful.Response) {
+
+	//number of http model api requests add 1
+	core.ModelApiRequestCount.Inc()
 	a.processMetricRequest(core.NodeKey(request.PathParameter("node-name")),
 		request, response)
 }
 
 // namespaceMetrics returns a metric timeseries for a metric of the Namespace entity.
 func (a *Api) namespaceMetrics(request *restful.Request, response *restful.Response) {
+
+	//number of http model api requests add 1
+	core.ModelApiRequestCount.Inc()
 	a.processMetricRequest(core.NamespaceKey(request.PathParameter("namespace-name")),
 		request, response)
 }
 
 // podMetrics returns a metric timeseries for a metric of the Pod entity.
 func (a *Api) podMetrics(request *restful.Request, response *restful.Response) {
+
+	//number of http model api requests add 1
+	core.ModelApiRequestCount.Inc()
 	a.processMetricRequest(
 		core.PodKey(request.PathParameter("namespace-name"),
 			request.PathParameter("pod-name")),
@@ -256,6 +286,9 @@ func (a *Api) podMetrics(request *restful.Request, response *restful.Response) {
 }
 
 func (a *Api) podListMetrics(request *restful.Request, response *restful.Response) {
+
+	//number of http model api requests add 1
+	core.ModelApiRequestCount.Inc()
 	start, end, err := getStartEndTime(request)
 	if err != nil {
 		response.WriteError(http.StatusBadRequest, err)
@@ -284,6 +317,9 @@ func (a *Api) podListMetrics(request *restful.Request, response *restful.Respons
 // podContainerMetrics returns a metric timeseries for a metric of a Pod Container entity.
 // podContainerMetrics uses the namespace-name/pod-name/container-name path.
 func (a *Api) podContainerMetrics(request *restful.Request, response *restful.Response) {
+
+	//number of http model api requests add 1
+	core.ModelApiRequestCount.Inc()
 	a.processMetricRequest(
 		core.PodContainerKey(request.PathParameter("namespace-name"),
 			request.PathParameter("pod-name"),
@@ -295,6 +331,9 @@ func (a *Api) podContainerMetrics(request *restful.Request, response *restful.Re
 // freeContainerMetrics returns a metric timeseries for a metric of the Container entity.
 // freeContainerMetrics addresses only free containers, by using the node-name/container-name path.
 func (a *Api) freeContainerMetrics(request *restful.Request, response *restful.Response) {
+
+	//number of http model api requests add 1
+	core.ModelApiRequestCount.Inc()
 	a.processMetricRequest(
 		core.NodeContainerKey(request.PathParameter("node-name"),
 			request.PathParameter("container-name"),

--- a/metrics/core/prometheus_labels.go
+++ b/metrics/core/prometheus_labels.go
@@ -1,0 +1,115 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//define the summary and histogram label for prometheus
+package core
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const PrometheusPath = "/debug/prometheus"
+const normDomain float64 = 200
+const normMean float64 = 10
+
+var (
+
+	//time of the last metrics scrape
+	LastMetricsTimeStamp = prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Name: "timeStamp_of_last_metricsScrape",
+			Help: "TimeStamp of the last metrics scrape",
+		},
+		[]string{"timestamp"},
+	)
+
+	//histogram of Kubelet/source response times
+	SourceResponseTimesHistogram = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Name:    "kubelet_source_response_count",
+		Help:    "total times of Kubelet/Source response",
+		Buckets: prometheus.LinearBuckets(normMean-5*normDomain, 5*normDomain, 20),
+	})
+
+	//time spent in scrape (single run, not cumulative)
+	ScrapeDurations = prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Name: "scrape_durations_microseconds",
+			Help: "time spent in scrape",
+		},
+		[]string{"duration"},
+	)
+
+	//time spent in processors (single run, not cumulative)
+	ProcessorDurations = prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Name: "processor_durations_microseconds",
+			Help: "time spent in processor",
+		},
+		[]string{"duration", "processor"},
+	)
+
+	//time spent in exporting data to sinks (single run, not cumulative)
+	ExportingDurations = prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Name: "exporting_durations_microseconds",
+			Help: "time spent in exporting",
+		},
+		[]string{"duration"},
+	)
+
+	//number of scraped nodes
+	ScrapedNodesCount = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "scraped_nodes_count",
+			Help: "number of scraped nodes",
+		},
+	)
+
+	//number of scraped containers
+	ScrapedContainersCount = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "scraped_containers_count",
+			Help: "number of scraped containers",
+		},
+	)
+
+	//number of http model api requests
+	ModelApiRequestCount = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "model_api_request_count",
+			Help: "number of http model api requests",
+		},
+	)
+
+	//number of other http requests
+	OtherApiRequestCount = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "other_api_request_count",
+			Help: "number of other model api requests",
+		},
+	)
+
+	PrometheusHandler = prometheus.Handler()
+)
+
+func init() {
+	prometheus.MustRegister(LastMetricsTimeStamp)
+	prometheus.MustRegister(SourceResponseTimesHistogram)
+	prometheus.MustRegister(ProcessorDurations)
+	prometheus.MustRegister(ExportingDurations)
+	prometheus.MustRegister(ScrapedNodesCount)
+	prometheus.MustRegister(ScrapedContainersCount)
+	prometheus.MustRegister(ModelApiRequestCount)
+	prometheus.MustRegister(OtherApiRequestCount)
+}

--- a/metrics/handlers.go
+++ b/metrics/handlers.go
@@ -21,6 +21,7 @@ import (
 
 	restful "github.com/emicklei/go-restful"
 	"k8s.io/heapster/metrics/api/v1"
+	"k8s.io/heapster/metrics/core"
 	"k8s.io/heapster/metrics/sinks/metric"
 )
 
@@ -37,6 +38,9 @@ func setupHandlers(metricSink *metricsink.MetricSink) http.Handler {
 	a.Register(wsContainer)
 
 	handlePprofEndpoint := func(req *restful.Request, resp *restful.Response) {
+
+		//number of other http requests add 1
+		core.OtherApiRequestCount.Inc()
 		name := strings.TrimPrefix(req.Request.URL.Path, pprofBasePath)
 		switch name {
 		case "profile":

--- a/metrics/processors/namespace_aggregator.go
+++ b/metrics/processors/namespace_aggregator.go
@@ -16,6 +16,7 @@ package processors
 
 import (
 	"fmt"
+	"time"
 
 	"k8s.io/heapster/metrics/core"
 )
@@ -29,6 +30,8 @@ func (this *NamespaceAggregator) Process(batch *core.DataBatch) (*core.DataBatch
 		Timestamp:  batch.Timestamp,
 		MetricSets: make(map[string]*core.MetricSet),
 	}
+
+	startTime := time.Now()
 
 	for key, metricSet := range batch.MetricSets {
 		result.MetricSets[key] = metricSet
@@ -70,6 +73,10 @@ func (this *NamespaceAggregator) Process(batch *core.DataBatch) (*core.DataBatch
 			}
 		}
 	}
+	//export time spent in processors (single run, not cumulative) to prometheus
+	duration := fmt.Sprintf("%s", time.Now().Sub(startTime))
+	core.ProcessorDurations.WithLabelValues(duration, "namespace_aggregator")
+
 	return &result, nil
 }
 

--- a/metrics/processors/pod_aggregator.go
+++ b/metrics/processors/pod_aggregator.go
@@ -16,6 +16,7 @@ package processors
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/golang/glog"
 
@@ -41,7 +42,7 @@ func (this *PodAggregator) Process(batch *core.DataBatch) (*core.DataBatch, erro
 		Timestamp:  batch.Timestamp,
 		MetricSets: make(map[string]*core.MetricSet),
 	}
-
+	startTime := time.Now()
 	for key, metricSet := range batch.MetricSets {
 		result.MetricSets[key] = metricSet
 		if metricSetType, found := metricSet.Labels[core.LabelMetricSetType.Key]; found && metricSetType == core.MetricSetTypePodContainer {
@@ -83,6 +84,10 @@ func (this *PodAggregator) Process(batch *core.DataBatch) (*core.DataBatch, erro
 			}
 		}
 	}
+	//export time spent in processors (single run, not cumulative) to prometheus
+	duration := fmt.Sprintf("%s", time.Now().Sub(startTime))
+	core.ProcessorDurations.WithLabelValues(duration, "pod_aggregator")
+
 	return &result, nil
 }
 

--- a/metrics/sources/manager.go
+++ b/metrics/sources/manager.go
@@ -17,7 +17,10 @@ package sources
 import (
 	"time"
 
+	"fmt"
+
 	"github.com/golang/glog"
+	"k8s.io/heapster/metrics/core"
 	. "k8s.io/heapster/metrics/core"
 )
 
@@ -100,6 +103,10 @@ responseloop:
 			break responseloop
 		}
 	}
+	//export time spent in scrape (single run, not cumulative) to prometheus
+	duration := fmt.Sprintf("%s", time.Now().Sub(startTime))
+	core.ScrapeDurations.WithLabelValues(duration)
+
 	glog.Infof("ScrapeMetrics:  time: %s  size: %d", time.Now().Sub(startTime), len(response.MetricSets))
 	for i, value := range latencies {
 		glog.Infof("   scrape  bucket %d: %d", i, value)


### PR DESCRIPTION
@mwielgus 
**Add status information to Heapster**
including:
+ time of the last metrics scrape
+ histogram of Kubelet/source response times
+ number of scraped nodes and containers
+ time spent in scrape (single run, not cumulative)
+ time spent in processors (single run, not cumulative)
+ time spent in exporting data to sinks (single run, not cumulative)
+ number of http model api requests
+ number of other http requests
