### PR TITLE
add prometheus for event/eventers

### DIFF
--- a/events/manager/manager.go
+++ b/events/manager/manager.go
@@ -26,8 +26,8 @@ var (
 	// Last time of eventer housekeep since unix epoch in seconds
 	lastHousekeepTimestamp = prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Namespace: "heapster",
-			Subsystem: "eventer",
+			Namespace: "eventer",
+			Subsystem: "manager",
 			Name:      "last_time_seconds",
 			Help:      "Last time of eventer housekeep since unix epoch in seconds.",
 		})

--- a/events/manager/manager.go
+++ b/events/manager/manager.go
@@ -17,10 +17,25 @@ package manager
 import (
 	"time"
 
-	"k8s.io/heapster/events/core"
-
 	"github.com/golang/glog"
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/heapster/events/core"
 )
+
+var (
+	// Last time of eventer housekeep since unix epoch in seconds
+	lastHousekeepTimestamp = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "heapster",
+			Subsystem: "eventer",
+			Name:      "last_time_seconds",
+			Help:      "Last time of eventer housekeep since unix epoch in seconds.",
+		})
+)
+
+func init() {
+	prometheus.MustRegister(lastHousekeepTimestamp)
+}
 
 type Manager interface {
 	Start()
@@ -72,6 +87,8 @@ func (rm *realManager) Housekeep() {
 }
 
 func (rm *realManager) housekeep() {
+	defer lastHousekeepTimestamp.Set(float64(time.Now().Unix()))
+
 	// No parallelism. Assumes that the events are pushed to Heapster. Add paralellism
 	// when this stops to be true.
 	events := rm.source.GetNewEvents()

--- a/events/sinks/manager.go
+++ b/events/sinks/manager.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/heapster/events/core"
 )
 
@@ -26,6 +27,23 @@ const (
 	DefaultSinkExportEventsTimeout = 20 * time.Second
 	DefaultSinkStopTimeout         = 60 * time.Second
 )
+
+var (
+	// Time spent exporting events to sink in microseconds.
+	exporterDuration = prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Namespace: "heapster",
+			Subsystem: "exporter",
+			Name:      "duration_microseconds",
+			Help:      "Time spent exporting events to sink in microseconds.",
+		},
+		[]string{"exporter"},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(exporterDuration)
+}
 
 type sinkHolder struct {
 	sink              core.EventSink
@@ -56,7 +74,7 @@ func NewEventSinkManager(sinks []core.EventSink, exportEventsTimeout, stopTimeou
 			for {
 				select {
 				case data := <-sh.eventBatchChannel:
-					sh.sink.ExportEvents(data)
+					export(sh.sink, data)
 				case isStop := <-sh.stopChannel:
 					glog.V(2).Infof("Stop received: %s", sh.sink.Name())
 					if isStop {
@@ -115,4 +133,12 @@ func (this *sinkManager) Stop() {
 			return
 		}(sh)
 	}
+}
+
+func export(s core.EventSink, data *core.EventBatch) {
+	startTime := time.Now()
+	defer exporterDuration.
+		WithLabelValues(s.Name()).
+		Observe(float64(time.Since(startTime)) / float64(time.Microsecond))
+	s.ExportEvents(data)
 }

--- a/events/sinks/manager.go
+++ b/events/sinks/manager.go
@@ -32,7 +32,7 @@ var (
 	// Time spent exporting events to sink in microseconds.
 	exporterDuration = prometheus.NewSummaryVec(
 		prometheus.SummaryOpts{
-			Namespace: "heapster",
+			Namespace: "eventer",
 			Subsystem: "exporter",
 			Name:      "duration_microseconds",
 			Help:      "Time spent exporting events to sink in microseconds.",

--- a/events/sources/kubernetes/kubernetes_source.go
+++ b/events/sources/kubernetes/kubernetes_source.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+	"github.com/prometheus/client_golang/prometheus"
 
 	kubeconfig "k8s.io/heapster/common/kubernetes"
 	"k8s.io/heapster/events/core"
@@ -36,6 +37,37 @@ const (
 	LocalEventsBufferSize = 100000
 )
 
+var (
+	// Last time of event since unix epoch in seconds
+	lastEventTimestamp = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "heapster",
+			Subsystem: "events",
+			Name:      "last_time_seconds",
+			Help:      "Last time of event since unix epoch in seconds.",
+		})
+	totalEventsNum = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "heapster",
+			Subsystem: "events",
+			Name:      "events_total_number",
+			Help:      "The total number of events.",
+		})
+	scrapEventsDuration = prometheus.NewSummary(
+		prometheus.SummaryOpts{
+			Namespace: "heapster",
+			Subsystem: "events",
+			Name:      "duration_microseconds",
+			Help:      "Time spent scraping events in microseconds.",
+		})
+)
+
+func init() {
+	prometheus.MustRegister(lastEventTimestamp)
+	prometheus.MustRegister(totalEventsNum)
+	prometheus.MustRegister(scrapEventsDuration)
+}
+
 // Implements core.EventSource interface.
 type KubernetesEventSource struct {
 	// Large local buffer, periodically read.
@@ -48,6 +80,9 @@ type KubernetesEventSource struct {
 }
 
 func (this *KubernetesEventSource) GetNewEvents() *core.EventBatch {
+	startTime := time.Now()
+	defer lastEventTimestamp.Set(float64(time.Now().Unix()))
+	defer scrapEventsDuration.Observe(float64(time.Since(startTime)) / float64(time.Microsecond))
 	result := core.EventBatch{
 		Timestamp: time.Now(),
 		Events:    []*kubeapi.Event{},
@@ -62,6 +97,8 @@ event_loop:
 			break event_loop
 		}
 	}
+
+	totalEventsNum.Add(float64(len(result)))
 	return &result
 }
 

--- a/events/sources/kubernetes/kubernetes_source.go
+++ b/events/sources/kubernetes/kubernetes_source.go
@@ -98,7 +98,7 @@ event_loop:
 		}
 	}
 
-	totalEventsNum.Add(float64(len(result)))
+	totalEventsNum.Add(float64(len(result.Events)))
 	return &result
 }
 

--- a/events/sources/kubernetes/kubernetes_source.go
+++ b/events/sources/kubernetes/kubernetes_source.go
@@ -41,22 +41,22 @@ var (
 	// Last time of event since unix epoch in seconds
 	lastEventTimestamp = prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Namespace: "heapster",
-			Subsystem: "events",
+			Namespace: "eventer",
+			Subsystem: "scraper",
 			Name:      "last_time_seconds",
 			Help:      "Last time of event since unix epoch in seconds.",
 		})
 	totalEventsNum = prometheus.NewCounter(
 		prometheus.CounterOpts{
-			Namespace: "heapster",
-			Subsystem: "events",
+			Namespace: "eventer",
+			Subsystem: "scraper",
 			Name:      "events_total_number",
 			Help:      "The total number of events.",
 		})
 	scrapEventsDuration = prometheus.NewSummary(
 		prometheus.SummaryOpts{
-			Namespace: "heapster",
-			Subsystem: "events",
+			Namespace: "eventer",
+			Subsystem: "scraper",
 			Name:      "duration_microseconds",
 			Help:      "Time spent scraping events in microseconds.",
 		})


### PR DESCRIPTION
add prometheus for event/eventers
- last event timestamp
- last housekeep timestamp
- total number of events
- time spent for scraping events
- time spent for writing events (total and on per sink basis)
