### PR TITLE
Update events timestamp in store

### DIFF
--- a/sinks/cache/impl.go
+++ b/sinks/cache/impl.go
@@ -327,7 +327,7 @@ func (rc *realCache) StoreEvents(e []*Event) error {
 		}
 		rc.eventUIDs[e[idx].UID] = struct{}{}
 		if err := rc.events.Put(store.TimePoint{
-			Timestamp: time.Now(),
+			Timestamp: e[idx].LastUpdate,
 			Value:     e[idx],
 		}); err != nil {
 			return err

--- a/sinks/external.go
+++ b/sinks/external.go
@@ -116,7 +116,7 @@ func (esm *externalSinkManager) store() error {
 		glog.V(3).Infof("no timeseries data between %v and %v", esm.lastSync.nodeSync, zeroTime)
 		// Continue here to push events data.
 	}
-	events := esm.cache.GetEvents(esm.lastSync.eventsSync, zeroTime)
+	events := esm.cache.GetEvents(esm.lastSync.eventsSync.Add(time.Nanosecond), zeroTime)
 	var kEvents []kube_api.Event
 	for _, event := range events {
 		kEvents = append(kEvents, event.Raw)


### PR DESCRIPTION
Previously，`Put` events to store is by `time.Now()`, but `Get` events form store is by `LastUpdate`, it will cause sink events repeatedly.so this PR is to fix this.
