### PR TITLE
Skip pods that do not have any stats collected

### DIFF
--- a/metrics/processors/pod_aggregator.go
+++ b/metrics/processors/pod_aggregator.go
@@ -42,7 +42,7 @@ func (this *PodAggregator) Name() string {
 func (this *PodAggregator) Process(batch *core.DataBatch) (*core.DataBatch, error) {
 	result := core.DataBatch{
 		Timestamp:  batch.Timestamp,
-		MetricSets: make(map[string]*core.MetricSet),
+		MetricSets: make(map[string]*core.MetricSet, len(batch.MetricSets)),
 	}
 	for key, metricSet := range batch.MetricSets {
 		result.MetricSets[key] = metricSet


### PR DESCRIPTION
@mwringe As discussed in #911 this only adds pod info for pending & running pods. Pending pods need to be considered as they might be partially started, e.g. one container of a multi-container pod started. If there are no metrics collected for a pod then it is also dropped.

Thoughts @mwielgus?
