### PR TITLE
GCM sink option to export only autoscalink metrics

### DIFF
--- a/common/flags/flags_test.go
+++ b/common/flags/flags_test.go
@@ -81,6 +81,16 @@ func TestUriSet(t *testing.T) {
 			},
 			false,
 		},
+		{
+			"gcm:?metrics=all",
+			Uri{
+				Key: "gcm",
+				Val: url.URL{
+					RawQuery: "metrics=all",
+				},
+			},
+			false,
+		},
 	}
 	for _, c := range tests {
 		var uri Uri


### PR DESCRIPTION
Google-influxdb k8s monitoring mode should export only autoscaling metrics.
