### PR TITLE
Handle 'delta' metrics in the API conversion

### DIFF
--- a/metrics/api/v1/api.go
+++ b/metrics/api/v1/api.go
@@ -104,6 +104,8 @@ func convertMetricDescriptor(md core.MetricDescriptor) types.MetricDescriptor {
 		result.Type = "cumulative"
 	case core.MetricGauge:
 		result.Type = "gauge"
+	case core.MetricDelta:
+		result.Type = "delta"
 	}
 
 	switch md.ValueType {


### PR DESCRIPTION
Missed this in https://github.com/kubernetes/heapster/pull/927

/cc @vishh @mwielgus 
