### PR TITLE
DO NOT MERGE - summary API correctness testing

### DIFF
--- a/deploy/kube-config/standalone-test/heapster-controller.yaml
+++ b/deploy/kube-config/standalone-test/heapster-controller.yaml
@@ -21,7 +21,7 @@ spec:
         imagePullPolicy: Always
         command:
         - /heapster
-        - --source=kubernetes:https://kubernetes.default
+        - --source=kubernetes.compare:https://kubernetes.default
         - --sink=log
         volumeMounts:
         - name: ssl-certs

--- a/metrics/sources/factory.go
+++ b/metrics/sources/factory.go
@@ -17,6 +17,8 @@ package sources
 import (
 	"fmt"
 
+	"github.com/golang/glog"
+
 	"k8s.io/heapster/common/flags"
 	"k8s.io/heapster/metrics/core"
 	"k8s.io/heapster/metrics/sources/kubelet"
@@ -33,6 +35,10 @@ func (this *SourceFactory) Build(uri flags.Uri) (core.MetricsSourceProvider, err
 		return provider, err
 	case "kubernetes.summary_api":
 		provider, err := summary.NewSummaryProvider(&uri.Val)
+		return provider, err
+	case "kubernetes.compare":
+		glog.Warningf("Running in test-only comparison mode")
+		provider, err := summary.NewCompareProvider(&uri.Val)
 		return provider, err
 	default:
 		return nil, fmt.Errorf("Source not recognized: %s", uri.Key)

--- a/metrics/sources/summary/compare.go
+++ b/metrics/sources/summary/compare.go
@@ -1,0 +1,204 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package summary
+
+import (
+	"fmt"
+	"net/url"
+	"regexp"
+	"time"
+
+	"github.com/golang/glog"
+	. "k8s.io/heapster/metrics/core"
+)
+
+var (
+	// Ignore these metrics.
+	ignoreMetrics = map[string]bool{
+		MetricUptime.Name: true, // Checked via creation time
+	}
+
+	// Ignore these metrics on pod metric sets.
+	ignorePodMetrics = map[string]bool{
+		// The following are set from the POD infra container using the old kubelet metrics,
+		// but not set for pods using the summary_api.
+		"cpu/usage":                true,
+		"memory/working_set":       true,
+		"memory/usage":             true,
+		"memory/page_faults":       true,
+		"memory/major_page_faults": true,
+	}
+
+	// Ignore these labels.
+	ignoreLabels = map[string]bool{
+		LabelContainerBaseImage.Key: true, // Set in pod_based_enricher.go
+	}
+)
+
+type CompareSource struct {
+	summary *summaryMetricsSource
+	kubelet MetricsSource
+}
+
+func NewCompareSource(summary *summaryMetricsSource) MetricsSource {
+	return &CompareSource{
+		summary: summary,
+		kubelet: summary.fallback,
+	}
+}
+
+func (this *CompareSource) Name() string   { return this.String() }
+func (this *CompareSource) String() string { return "__compare__:" + this.summary.String() }
+
+func (this *CompareSource) ScrapeMetrics(start, end time.Time) *DataBatch {
+	var (
+		summaryMetrics *DataBatch
+		kubeletMetrics *DataBatch
+	)
+	summaryMetrics = this.summary.ScrapeMetrics(start, end)
+	kubeletMetrics = this.kubelet.ScrapeMetrics(start, summaryMetrics.Timestamp)
+
+	if this.summary.useFallback {
+		this.errorf("summary used fallback")
+		return nil
+	}
+
+	this.validateMetrics(summaryMetrics, kubeletMetrics)
+	return summaryMetrics
+}
+
+var (
+	podKeyRe = regexp.MustCompile("namespace:[^:/]+/pod:[^:/]+")
+)
+
+func (this *CompareSource) validateMetrics(summary, kubelet *DataBatch) {
+	if summary == nil {
+		this.errorf("summary metrics is nil")
+		return
+	}
+	if kubelet == nil {
+		this.errorf("kubelet metrics is nil")
+		return
+	}
+	valid := true
+	if !fuzzyTimeEqual(summary.Timestamp, kubelet.Timestamp, 5*time.Second) {
+		valid = this.mismatch("timestamp", summary.Timestamp, kubelet.Timestamp)
+	}
+
+	for name, kubeletSet := range kubelet.MetricSets {
+		summarySet, found := summary.MetricSets[name]
+		if !found {
+			valid = this.errorf("Summary missing metric set %q", name)
+			continue
+		}
+		if !fuzzyTimeEqual(summarySet.CreateTime, kubeletSet.CreateTime, time.Second) {
+			valid = this.mismatch("creation time", summarySet.CreateTime, kubeletSet.CreateTime)
+			continue
+		}
+		if !fuzzyTimeEqual(summarySet.ScrapeTime, kubeletSet.ScrapeTime, time.Second) {
+			valid = this.mismatch("scrape time", summarySet.ScrapeTime, kubeletSet.ScrapeTime)
+			continue
+		}
+
+		isPod := podKeyRe.MatchString(name)
+		for metric, kubeVal := range kubeletSet.MetricValues {
+			if isPod && ignorePodMetrics[metric] {
+				continue
+			}
+			sumVal, found := summarySet.MetricValues[metric]
+			if !found {
+				valid = this.errorf("summary set %q missing metric %q", name, metric)
+				continue
+			}
+			var mismatch bool
+			switch metric {
+			case MetricUptime.Name:
+				// Uptime depends on exact scrape time, so perform a fuzzy comparison.
+				diff := sumVal.IntValue - kubeVal.IntValue
+				const epsilon = int64(time.Second / time.Millisecond)
+				mismatch = diff < -epsilon || epsilon < diff
+			default:
+				mismatch = sumVal != kubeVal
+			}
+			if mismatch {
+				valid = this.mismatch(name+" metric "+metric, sumVal, kubeVal)
+			}
+		}
+
+		for label, kv := range kubeletSet.Labels {
+			if ignoreLabels[label] {
+				continue
+			}
+			sv, found := summarySet.Labels[label]
+			if !found {
+				valid = this.errorf("summary set %q missing label %q", name, label)
+			}
+			if kv != sv {
+				valid = this.mismatch(name+" label "+label, sv, kv)
+			}
+		}
+
+		// TODO: validate labeled metrics.
+	}
+
+	if valid {
+		glog.Infof("!!!! metric set valid!")
+	} else {
+		glog.Fatalf("!!!! metric set invalid")
+	}
+}
+
+func (this *CompareSource) errorf(format string, args ...interface{}) bool {
+	const tag = ">>> "
+	fmt.Printf(tag+format+"\n", args...)
+	//	glog.Errorf(tag+format, args...)
+	return false
+}
+
+func (this *CompareSource) mismatch(label string, summary, kubelet interface{}) bool {
+	return this.errorf(label+" mismatch: summary = %v kubelet = %v", summary, kubelet)
+}
+
+func fuzzyTimeEqual(a, b time.Time, epsilon time.Duration) bool {
+	diff := a.Sub(b)
+	return -epsilon <= diff && diff <= epsilon
+}
+
+type CompareProvider struct {
+	summary *summaryProvider
+}
+
+func NewCompareProvider(uri *url.URL) (MetricsSourceProvider, error) {
+	summary, err := NewSummaryProvider(uri)
+	if err != nil {
+		return nil, err
+	}
+	return &CompareProvider{
+		summary: summary.(*summaryProvider),
+	}, nil
+}
+
+func (this *CompareProvider) GetMetricsSources() []MetricsSource {
+	summarySources := this.summary.GetMetricsSources()
+	sources := make([]MetricsSource, len(summarySources))
+	for i, source := range summarySources {
+		summary := source.(*summaryMetricsSource)
+		if summary.useFallback {
+			glog.Errorf("**** New source %q using fallback!!!!", sources[i].Name())
+		}
+		sources[i] = NewCompareSource(summary)
+	}
+	return sources
+}

--- a/metrics/sources/summary/summary.go
+++ b/metrics/sources/summary/summary.go
@@ -76,7 +76,7 @@ func NewSummaryMetricsSource(node NodeInfo, client *kubelet.KubeletClient, fallb
 	return &summaryMetricsSource{
 		node:          node,
 		kubeletClient: client,
-		useFallback:   summarySupported(node.KubeletVersion),
+		useFallback:   !summarySupported(node.KubeletVersion),
 		fallback:      fallback,
 	}
 }

--- a/metrics/sources/summary/summary_test.go
+++ b/metrics/sources/summary/summary_test.go
@@ -409,19 +409,22 @@ func TestFallback(t *testing.T) {
 
 func TestSummarySupported(t *testing.T) {
 	tests := []struct {
-		version         string
-		expectSupported bool
+		version        string
+		expectFallback bool
 	}{
-		{"v1.2.0-alpha.8", true},
-		{"v1.2.0", true},
-		{"v1.2.0-alpha.6", false},
-		{"v1.3.0-alpha.1", true},
-		{"v1.1.8", false},
-		{"v1.0.6", false},
-		{"v-invalid", false},
+		{"v1.2.0-alpha.8", false},
+		{"v1.2.0", false},
+		{"v1.2.0-alpha.6", true},
+		{"v1.3.0-alpha.1", false},
+		{"v1.1.8", true},
+		{"v1.0.6", true},
+		{"v-invalid", true},
 	}
 
 	for _, test := range tests {
-		assert.Equal(t, test.expectSupported, summarySupported(test.version), test.version)
+		node := nodeInfo
+		node.KubeletVersion = test.version
+		source := NewSummaryMetricsSource(node, nil, nil).(*summaryMetricsSource)
+		assert.Equal(t, test.expectFallback, source.useFallback, test.version)
 	}
 }


### PR DESCRIPTION
Add test-only `CompareSource` which performs a side-by-side comparison of the metrics gathered from the `kubernetes.summary_api` source and the `kubernetes` source. See [Heapster Summary Testing](https://docs.google.com/document/d/1ZUYslYiSBjI6V7rhCRxyh4lH-CdMjX45F_0DZ65ZaxA/edit#heading=h.dulh3aqcsdfv) for more details (sorry that the link is google-only, LMK if you'd like access).

### Results

First, a few special cases:

- times (uptime, scrape time, create time) use a fuzzy comparison since the calculation is based on the exact scrape / parse time.
- pod cpu & memory metrics (`cpu/usage, memory/{working_set, usage, page_faults, major_page_faults}`) are ignored, since these metrics measured the pod infra container usage, which is not surfaced in the summary API.
- label `container_base_image` - Filled in by the pod enricher from the k8s API, and hence ignored here.
- labeled metrics - Handled differently by the summary API. These metrics will need to be validated through other means.

Aside from these exceptions, the only remaining discrepancy is in networking:
```
I0301 23:08:05.000222       1 manager.go:79] Scraping metrics start: 2016-03-01 23:07:30 +0000 UTC, end: 2016-03-01 23:08:00 +0000 UTC
node:e2e-test-stclair-minion-gilj metric network/tx mismatch: summary = {902197626 0 0 0} kubelet = {699783929 0 0 0}
node:e2e-test-stclair-minion-gilj metric network/rx mismatch: summary = {2916806622 0 0 0} kubelet = {2695792187 0 0 0}
namespace:kube-system/pod:kube-proxy-e2e-test-stclair-minion-gilj metric network/rx mismatch: summary = {2916841897 0 0 0} kubelet = {2695826628 0 0 0}
namespace:kube-system/pod:kube-proxy-e2e-test-stclair-minion-gilj metric network/tx mismatch: summary = {902226555 0 0 0} kubelet = {699792580 0 0 0}
```
This is due to the summary API reporting the sum over all interfaces, while the kubelet source just reports the stats from eth0. From offline discussions, we probably want to change the summary API to use that same behavior.