### PR TITLE
Hawkular: Update to use the nodename when storing system level metrics

### DIFF
--- a/metrics/sinks/hawkular/client.go
+++ b/metrics/sinks/hawkular/client.go
@@ -107,7 +107,17 @@ func (self *hawkularSink) idName(ms *core.MetricSet, metricName string) string {
 	if ms.Labels[core.LabelPodId.Key] != "" {
 		n = append(n, ms.Labels[core.LabelPodId.Key])
 	} else {
-		n = append(n, ms.Labels[core.LabelHostID.Key])
+		if &self.labelNodeId != nil {
+			if v, found := ms.Labels[self.labelNodeId]; found {
+				n = append(n, v)
+			} else {
+				glog.V(4).Infof("The labelNodeId was set to %s but there is no label with this value."+
+					"Using the default 'nodename' label instead.", self.labelNodeId)
+				n = append(n, ms.Labels[core.LabelNodename.Key])
+			}
+		} else {
+			n = append(n, ms.Labels[core.LabelNodename.Key])
+		}
 	}
 	n = append(n, metricName)
 

--- a/metrics/sinks/hawkular/driver.go
+++ b/metrics/sinks/hawkular/driver.go
@@ -41,6 +41,8 @@ const (
 	batchSizeDefault   = 1000
 	concurrencyDefault = 5
 
+	nodeId string = "labelNodeId"
+
 	defaultServiceAccountFile = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 )
 
@@ -177,6 +179,9 @@ func (self *hawkularSink) DebugInfo() string {
 	if &self.labelTenant != nil {
 		info += fmt.Sprintf("Using label '%s' as tenant information\n", self.labelTenant)
 	}
+	if &self.labelNodeId != nil {
+		info += fmt.Sprintf("Using label '%s' as node identified in resourceid\n", self.labelNodeId)
+	}
 
 	// TODO Add here statistics from the Hawkular-Metrics client instance
 	return info
@@ -224,6 +229,10 @@ func (self *hawkularSink) init() error {
 
 	if v, found := opts["labelToTenant"]; found {
 		self.labelTenant = v[0]
+	}
+
+	if v, found := opts[nodeId]; found {
+		self.labelNodeId = v[0]
 	}
 
 	if v, found := opts["useServiceAccount"]; found {

--- a/metrics/sinks/hawkular/driver_test.go
+++ b/metrics/sinks/hawkular/driver_test.go
@@ -78,6 +78,7 @@ func TestMetricTransform(t *testing.T) {
 	l[core.LabelHostID.Key] = "localhost"
 	l[core.LabelContainerName.Key] = "docker"
 	l[core.LabelPodId.Key] = "aaaa-bbbb-cccc-dddd"
+	l[core.LabelNodename.Key] = "myNode"
 
 	metricName := "test/metric/1"
 	labeledMetricNameA := "test/labeledmetric/A"
@@ -131,21 +132,21 @@ func TestMetricTransform(t *testing.T) {
 	m, err = hSink.pointToMetricHeader(&metricSet, metricName, now)
 	assert.NoError(t, err)
 
-	assert.Equal(t, fmt.Sprintf("%s/%s/%s", metricSet.Labels[core.LabelContainerName.Key], metricSet.Labels[core.LabelHostID.Key], metricName), m.Id)
+	assert.Equal(t, fmt.Sprintf("%s/%s/%s", metricSet.Labels[core.LabelContainerName.Key], metricSet.Labels[core.LabelNodename.Key], metricName), m.Id)
 
 	//
 	m, err = hSink.pointToLabeledMetricHeader(&metricSet, metricSet.LabeledMetrics[0], now)
 	assert.NoError(t, err)
 
 	assert.Equal(t, fmt.Sprintf("%s/%s/%s/%s", metricSet.Labels[core.LabelContainerName.Key],
-		metricSet.Labels[core.LabelHostID.Key], labeledMetricNameA,
+		metricSet.Labels[core.LabelNodename.Key], labeledMetricNameA,
 		metricSet.LabeledMetrics[0].Labels[core.LabelResourceID.Key]), m.Id)
 
 	//
 	m, err = hSink.pointToLabeledMetricHeader(&metricSet, metricSet.LabeledMetrics[1], now)
 	assert.NoError(t, err)
 	assert.Equal(t, fmt.Sprintf("%s/%s/%s", metricSet.Labels[core.LabelContainerName.Key],
-		metricSet.Labels[core.LabelHostID.Key], labeledMetricNameB), m.Id)
+		metricSet.Labels[core.LabelNodename.Key], labeledMetricNameB), m.Id)
 }
 
 func TestRecentTest(t *testing.T) {

--- a/metrics/sinks/hawkular/types.go
+++ b/metrics/sinks/hawkular/types.go
@@ -54,6 +54,7 @@ type hawkularSink struct {
 	uri *url.URL
 
 	labelTenant string
+	labelNodeId string
 	modifiers   []metrics.Modifier
 	filters     []Filter
 


### PR DESCRIPTION
Update to use the node name when generating the id for non-container metrics instead of the deprecated externalID value (eg HostID).

Parameter can be used to get back the old behaviour if required
