### PR TITLE
Revert "Temporary workaround for flaky metadata server on GCE"

### DIFF
--- a/Godeps/_workspace/src/google.golang.org/cloud/compute/metadata/README.md
+++ b/Godeps/_workspace/src/google.golang.org/cloud/compute/metadata/README.md
@@ -1,4 +1,0 @@
-This directory contains a workaround for
-https://github.com/GoogleCloudPlatform/gcloud-golang/issues/194.
-To prevent from accidental removing the fix the metadata.go file
-was renamed to metadata_custom.go.

--- a/Godeps/_workspace/src/google.golang.org/cloud/compute/metadata/metadata.go
+++ b/Godeps/_workspace/src/google.golang.org/cloud/compute/metadata/metadata.go
@@ -170,6 +170,7 @@ func OnGCE() bool {
 	if onGCE.set {
 		return onGCE.v
 	}
+	onGCE.set = true
 
 	// We use the DNS name of the metadata service here instead of the IP address
 	// because we expect that to fail faster in the not-on-GCE case.
@@ -177,7 +178,6 @@ func OnGCE() bool {
 	if err != nil {
 		return false
 	}
-	onGCE.set = true
 	onGCE.v = res.Header.Get("Metadata-Flavor") == "Google"
 	return onGCE.v
 }


### PR DESCRIPTION
Reverts kubernetes/heapster#1091

This is no longer needed once https://github.com/GoogleCloudPlatform/gcloud-golang/issues/194 is fixed.
