### PR TITLE
Don't fetch metrics from a node that we have not yet been able to reach. Fixes NPE

### DIFF
--- a/metrics/processors/node_aggregator.go
+++ b/metrics/processors/node_aggregator.go
@@ -42,8 +42,7 @@ func (this *NodeAggregator) Process(batch *core.DataBatch) (*core.DataBatch, err
 				node, found := batch.MetricSets[nodeKey]
 				if !found {
 					glog.Warningf("Failed to find node: %s", nodeKey)
-				}
-				if err := aggregate(metricSet, node, this.MetricsToAggregate); err != nil {
+				} else if err := aggregate(metricSet, node, this.MetricsToAggregate); err != nil {
 					return nil, err
 				}
 			} else {


### PR DESCRIPTION
This fixes a nil pointer exception which occurs when we try and fetch data from a node which could not be reached.
