### PR TITLE
Global concurrency limitation to Hawkular sink

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -122,8 +122,8 @@
 		},
 		{
 			"ImportPath": "github.com/hawkular/hawkular-client-go/metrics",
-			"Comment": "v0.5.1",
-			"Rev": "6a148493851c66d69b005283eb7932452c322b74"
+			"Comment": "v0.6.0",
+			"Rev": "50f4099dfd739f913ed7d8f33288aeeca338516a"
 		},
 		{
 			"ImportPath": "github.com/imdario/mergo",

--- a/Godeps/_workspace/src/github.com/hawkular/hawkular-client-go/metrics/client_test.go
+++ b/Godeps/_workspace/src/github.com/hawkular/hawkular-client-go/metrics/client_test.go
@@ -1,0 +1,275 @@
+package metrics
+
+import (
+	"crypto/rand"
+	"crypto/tls"
+	"fmt"
+	assert "github.com/stretchr/testify/require"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func integrationClient() (*Client, error) {
+	t, err := randomString()
+	if err != nil {
+		return nil, err
+	}
+	p := Parameters{Tenant: t, Url: "http://localhost:8080"}
+	// p := Parameters{Tenant: t, Host: "localhost:8180"}
+	// p := Parameters{Tenant: t, Url: "http://192.168.1.105:8080"}
+	// p := Parameters{Tenant: t, Host: "209.132.178.218:18080"}
+	return NewHawkularClient(p)
+}
+
+func randomString() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%X", b[:]), nil
+}
+
+func createError(err error) {
+}
+
+func TestTenantModifier(t *testing.T) {
+	c, err := integrationClient()
+	assert.Nil(t, err)
+
+	ot, _ := randomString()
+
+	// Create for another tenant
+	id := "test.metric.create.numeric.tenant.1"
+	md := MetricDefinition{Id: id, Type: Gauge}
+
+	ok, err := c.Create(md, Tenant(ot))
+	assert.Nil(t, err)
+	assert.True(t, ok, "MetricDefinition should have been created")
+
+	// Try to fetch from default tenant - should fail
+	mds, err := c.Definitions(Filters(TypeFilter(Gauge)))
+	assert.Nil(t, err)
+	assert.Nil(t, mds)
+
+	// Try to fetch from the given tenant - should succeed
+	mds, err = c.Definitions(Filters(TypeFilter(Gauge)), Tenant(ot))
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(mds))
+}
+
+func TestCreate(t *testing.T) {
+	c, err := integrationClient()
+	assert.Nil(t, err)
+
+	id := "test.metric.create.numeric.1"
+	md := MetricDefinition{Id: id, Type: Gauge}
+	ok, err := c.Create(md)
+	assert.Nil(t, err)
+	assert.True(t, ok, "MetricDefinition should have been created")
+
+	// Following would be nice:
+	// mdd, err := c.Definitions(Filters(Type(Gauge), Id(id)))
+
+	// mdd, err := c.Definition(Gauge, id)
+	// assert.Nil(t, err)
+	// assert.Equal(t, md.Id, mdd.Id)
+
+	// Try to recreate the same..
+	ok, err = c.Create(md)
+	assert.False(t, ok, "Should have received false when recreating them same metric")
+	assert.Nil(t, err)
+
+	// Use tags and dataRetention
+	tags := make(map[string]string)
+	tags["units"] = "bytes"
+	tags["env"] = "unittest"
+	md_tags := MetricDefinition{Id: "test.metric.create.numeric.2", Tags: tags, Type: Gauge}
+
+	ok, err = c.Create(md_tags)
+	assert.True(t, ok, "MetricDefinition should have been created")
+	assert.Nil(t, err)
+
+	md_reten := MetricDefinition{Id: "test/metric/create/availability/1", RetentionTime: 12, Type: Availability}
+	ok, err = c.Create(md_reten)
+	assert.Nil(t, err)
+	assert.True(t, ok, "MetricDefinition should have been created")
+
+	// Fetch all the previously created metrics and test equalities..
+	mdq, err := c.Definitions(Filters(TypeFilter(Gauge)))
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(mdq), "Size of the returned gauge metrics does not match 2")
+
+	mdm := make(map[string]MetricDefinition)
+	for _, v := range mdq {
+		mdm[v.Id] = *v
+	}
+
+	assert.Equal(t, md.Id, mdm[id].Id)
+	assert.True(t, reflect.DeepEqual(tags, mdm["test.metric.create.numeric.2"].Tags))
+
+	mda, err := c.Definitions(Filters(TypeFilter(Availability)))
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(mda))
+	assert.Equal(t, "test/metric/create/availability/1", mda[0].Id)
+	assert.Equal(t, 12, mda[0].RetentionTime)
+
+	if mda[0].Type != Availability {
+		assert.FailNow(t, "Type did not match Availability", int(mda[0].Type))
+	}
+}
+
+func TestTagsModification(t *testing.T) {
+	c, err := integrationClient()
+	assert.Nil(t, err)
+	id := "test/tags/modify/1"
+	// Create metric without tags
+	md := MetricDefinition{Id: id, Type: Gauge}
+	ok, err := c.Create(md)
+	assert.Nil(t, err)
+	assert.True(t, ok, "MetricDefinition should have been created")
+
+	// Add tags
+	tags := make(map[string]string)
+	tags["ab"] = "ac"
+	tags["host"] = "test"
+	err = c.UpdateTags(Gauge, id, tags)
+	assert.Nil(t, err)
+
+	// Fetch metric tags - check for equality
+	md_tags, err := c.Tags(Gauge, id)
+	assert.Nil(t, err)
+
+	assert.True(t, reflect.DeepEqual(tags, md_tags), "Tags did not match the updated ones")
+
+	// Delete some metric tags
+	err = c.DeleteTags(Gauge, id, tags)
+	assert.Nil(t, err)
+
+	// Fetch metric - check that tags were deleted
+	md_tags, err = c.Tags(Gauge, id)
+	assert.Nil(t, err)
+	assert.False(t, len(md_tags) > 0, "Received deleted tags")
+}
+
+func TestAddMixedMulti(t *testing.T) {
+
+	// Modify to send both Availability as well as Gauge metrics at the same time
+	c, err := integrationClient()
+	assert.NoError(t, err)
+
+	mone := Datapoint{Value: 1.45, Timestamp: UnixMilli(time.Now())}
+	hone := MetricHeader{
+		Id:   "test.multi.numeric.1",
+		Data: []Datapoint{mone},
+		Type: Gauge,
+	}
+
+	mtwo_1 := Datapoint{Value: 2, Timestamp: UnixMilli(time.Now())}
+
+	mtwo_2_t := UnixMilli(time.Now()) - 1e3
+
+	mtwo_2 := Datapoint{Value: float64(4.56), Timestamp: mtwo_2_t}
+	htwo := MetricHeader{
+		Id:   "test.multi.numeric.2",
+		Data: []Datapoint{mtwo_1, mtwo_2},
+		Type: Counter,
+	}
+
+	h := []MetricHeader{hone, htwo}
+
+	err = c.Write(h)
+	assert.NoError(t, err)
+
+	time.Sleep(1000 * time.Millisecond)
+
+	var checkDatapoints = func(id string, typ MetricType, expected int) []*Datapoint {
+		metric, err := c.ReadMetric(typ, id)
+		assert.NoError(t, err)
+		assert.Equal(t, expected, len(metric), "Amount of datapoints does not match expected value")
+		return metric
+	}
+
+	checkDatapoints(hone.Id, hone.Type, 1)
+	checkDatapoints(htwo.Id, htwo.Type, 2)
+}
+
+func TestCheckErrors(t *testing.T) {
+	c, err := integrationClient()
+	assert.Nil(t, err)
+
+	mH := MetricHeader{
+		Id:   "test.number.as.string",
+		Data: []Datapoint{Datapoint{Value: "notFloat"}},
+		Type: Gauge,
+	}
+
+	err = c.Write([]MetricHeader{mH})
+	assert.NotNil(t, err, "Invalid non-float value should not be accepted")
+	_, err = c.ReadMetric(mH.Type, mH.Id)
+	assert.Nil(t, err, "Querying empty metric should not generate an error")
+}
+
+func TestTokenAuthenticationWithSSL(t *testing.T) {
+	s := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Authorization", r.Header.Get("Authorization"))
+	}))
+	defer s.Close()
+
+	tenant, err := randomString()
+	assert.NoError(t, err)
+
+	tC := &tls.Config{InsecureSkipVerify: true}
+
+	p := Parameters{
+		Tenant:    tenant,
+		Url:       s.URL,
+		Token:     "62590bf9827213afadea8b5077a5bdc0",
+		TLSConfig: tC,
+	}
+
+	c, err := NewHawkularClient(p)
+	assert.NoError(t, err)
+
+	r, err := c.Send(c.Url("GET"))
+	assert.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf("Bearer %s", p.Token), r.Header.Get("X-Authorization"))
+}
+
+func TestBuckets(t *testing.T) {
+	c, err := integrationClient()
+	assert.NoError(t, err)
+
+	tags := make(map[string]string)
+	tags["units"] = "bytes"
+	tags["env"] = "unittest"
+	md_tags := MetricDefinition{Id: "test.buckets.1", Tags: tags, Type: Gauge}
+
+	ok, err := c.Create(md_tags)
+	assert.NoError(t, err)
+	assert.True(t, ok)
+
+	mone := Datapoint{Value: 1.45, Timestamp: UnixMilli(time.Now())}
+	hone := MetricHeader{
+		Id:   "test.buckets.1",
+		Data: []Datapoint{mone},
+		Type: Gauge,
+	}
+
+	err = c.Write([]MetricHeader{hone})
+	assert.NoError(t, err)
+
+	// TODO Muuta PercentilesFilter -> Percentiles (modifier)
+	bp, err := c.ReadBuckets(Gauge, Filters(TagsFilter(tags), BucketsFilter(1), PercentilesFilter([]float64{90.0, 99.0})))
+	assert.NoError(t, err)
+	assert.NotNil(t, bp)
+
+	assert.Equal(t, 1, len(bp))
+	assert.Equal(t, int64(1), bp[0].Samples)
+	assert.Equal(t, 2, len(bp[0].Percentiles))
+	assert.Equal(t, 1.45, bp[0].Percentiles[0].Value)
+	assert.Equal(t, 0.9, bp[0].Percentiles[0].Quantile)
+	assert.True(t, bp[0].Percentiles[1].Quantile >= 0.99) // Double arithmetic could cause this to be 0.9900000001 etc
+}

--- a/Godeps/_workspace/src/github.com/hawkular/hawkular-client-go/metrics/helpers.go
+++ b/Godeps/_workspace/src/github.com/hawkular/hawkular-client-go/metrics/helpers.go
@@ -1,3 +1,20 @@
+/*
+   Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+   and other contributors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 package metrics
 
 import (
@@ -7,6 +24,20 @@ import (
 	"time"
 )
 
+func (c *Client) sendRoutine() {
+	for {
+		select {
+		case pr, open := <-c.pool:
+			if !open {
+				return
+			}
+			resp, err := c.client.Do(pr.req)
+			pr.rChan <- &poolResponse{err, resp}
+		}
+	}
+}
+
+// ConvertToFloat64 Return float64 from most numeric types
 func ConvertToFloat64(v interface{}) (float64, error) {
 	switch i := v.(type) {
 	case float64:
@@ -44,7 +75,15 @@ func ConvertToFloat64(v interface{}) (float64, error) {
 	}
 }
 
-// Returns milliseconds since epoch
+// UnixMilli Returns milliseconds since epoch
 func UnixMilli(t time.Time) int64 {
 	return t.UnixNano() / 1e6
+}
+
+// Prepend Helper function to insert modifier in the beginning of slice
+func prepend(slice []Modifier, a ...Modifier) []Modifier {
+	p := make([]Modifier, 0, len(slice)+len(a))
+	p = append(p, a...)
+	p = append(p, slice...)
+	return p
 }

--- a/Godeps/_workspace/src/github.com/hawkular/hawkular-client-go/metrics/types.go
+++ b/Godeps/_workspace/src/github.com/hawkular/hawkular-client-go/metrics/types.go
@@ -1,9 +1,77 @@
+/*
+   Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+   and other contributors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 package metrics
 
 import (
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/url"
 )
+
+// HawkularClientError Extracted error information from Hawkular-Metrics server
+type HawkularClientError struct {
+	msg  string
+	Code int
+}
+
+// Parameters Initialization parameters to the client
+type Parameters struct {
+	Tenant      string // Technically optional, but requires setting Tenant() option everytime
+	Url         string
+	TLSConfig   *tls.Config
+	Token       string
+	Concurrency int
+}
+
+// Client HawkularClient's data structure
+type Client struct {
+	Tenant string
+	url    *url.URL
+	client *http.Client
+	Token  string
+	pool   chan (*poolRequest)
+}
+
+type poolRequest struct {
+	req   *http.Request
+	rChan chan (*poolResponse)
+}
+
+type poolResponse struct {
+	err  error
+	resp *http.Response
+}
+
+// HawkularClient HawkularClient base type to define available functions..
+type HawkularClient interface {
+	Send(*http.Request) (*http.Response, error)
+}
+
+// Modifier Modifiers base type
+type Modifier func(*http.Request) error
+
+// Filter Filter type for querying
+type Filter func(r *http.Request)
+
+// Endpoint Endpoint type to define request URL
+type Endpoint func(u *url.URL)
 
 // MetricType restrictions
 type MetricType int
@@ -29,29 +97,30 @@ var shortForm = []string{
 	"metrics",
 }
 
-func (self MetricType) validate() error {
-	if int(self) > len(longForm) && int(self) > len(shortForm) {
-		return fmt.Errorf("Given MetricType value %d is not valid", self)
+func (mt MetricType) validate() error {
+	if int(mt) > len(longForm) && int(mt) > len(shortForm) {
+		return fmt.Errorf("Given MetricType value %d is not valid", mt)
 	}
 	return nil
 }
 
-func (self MetricType) String() string {
-	if err := self.validate(); err != nil {
+// String Get string representation of type
+func (mt MetricType) String() string {
+	if err := mt.validate(); err != nil {
 		return "unknown"
 	}
-	return longForm[self]
+	return longForm[mt]
 }
 
-func (self MetricType) shortForm() string {
-	if err := self.validate(); err != nil {
+func (mt MetricType) shortForm() string {
+	if err := mt.validate(); err != nil {
 		return "unknown"
 	}
-	return shortForm[self]
+	return shortForm[mt]
 }
 
-// Custom unmarshaller
-func (self *MetricType) UnmarshalJSON(b []byte) error {
+// UnmarshalJSON Custom unmarshaller for MetricType
+func (mt *MetricType) UnmarshalJSON(b []byte) error {
 	var f interface{}
 	err := json.Unmarshal(b, &f)
 	if err != nil {
@@ -61,7 +130,7 @@ func (self *MetricType) UnmarshalJSON(b []byte) error {
 	if str, ok := f.(string); ok {
 		for i, v := range shortForm {
 			if str == v {
-				*self = MetricType(i)
+				*mt = MetricType(i)
 				break
 			}
 		}
@@ -70,13 +139,9 @@ func (self *MetricType) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-func (self MetricType) MarshalJSON() ([]byte, error) {
-	return json.Marshal(self.String())
-}
-
-type SortKey struct {
-	Tenant string
-	Type   MetricType
+// MarshalJSON Custom marshaller for MetricType
+func (mt MetricType) MarshalJSON() ([]byte, error) {
+	return json.Marshal(mt.String())
 }
 
 // Hawkular-Metrics external structs
@@ -89,14 +154,14 @@ type MetricHeader struct {
 	Data   []Datapoint `json:"data"`
 }
 
-// Value should be convertible to float64 for numeric values
-// Timestamp is milliseconds since epoch
+// Datapoint Value should be convertible to float64 for numeric values, Timestamp is milliseconds since epoch
 type Datapoint struct {
 	Timestamp int64             `json:"timestamp"`
 	Value     interface{}       `json:"value"`
 	Tags      map[string]string `json:"tags,omitempty"`
 }
 
+// HawkularError Return payload from Hawkular-Metrics if processing failed
 type HawkularError struct {
 	ErrorMsg string `json:"errorMsg"`
 }
@@ -107,4 +172,46 @@ type MetricDefinition struct {
 	Id            string            `json:"id"`
 	Tags          map[string]string `json:"tags,omitempty"`
 	RetentionTime int               `json:"dataRetention,omitempty"`
+}
+
+// TODO Fix the Start & End to return a time.Time
+
+// Bucketpoint Return structure for bucketed data
+type Bucketpoint struct {
+	Start       int64        `json:"start"`
+	End         int64        `json:"end"`
+	Min         float64      `json:"min"`
+	Max         float64      `json:"max"`
+	Avg         float64      `json:"avg"`
+	Median      float64      `json:"median"`
+	Empty       bool         `json:"empty"`
+	Samples     int64        `json:"samples"`
+	Percentiles []Percentile `json:"percentiles"`
+}
+
+// Percentile Hawkular-Metrics calculated percentiles representation
+type Percentile struct {
+	Quantile float64 `json:"quantile"`
+	Value    float64 `json:"value"`
+}
+
+// Order Basetype for selecting the sorting of datapoints
+type Order int
+
+const (
+	// ASC Ascending
+	ASC = iota
+	// DESC Descending
+	DESC
+)
+
+// String Get string representation of type
+func (o Order) String() string {
+	switch o {
+	case ASC:
+		return "ASC"
+	case DESC:
+		return "DESC"
+	}
+	return ""
 }

--- a/metrics/sinks/hawkular/driver.go
+++ b/metrics/sinks/hawkular/driver.go
@@ -195,11 +195,11 @@ func (h *hawkularSink) init() error {
 	h.modifiers = make([]metrics.Modifier, 0)
 	h.filters = make([]Filter, 0)
 	h.batchSize = batchSizeDefault
-	h.concurrencyLimit = concurrencyDefault
 
 	p := metrics.Parameters{
-		Tenant: "heapster",
-		Url:    h.uri.String(),
+		Tenant:      "heapster",
+		Url:         h.uri.String(),
+		Concurrency: concurrencyDefault,
 	}
 
 	opts := h.uri.Query()
@@ -301,7 +301,7 @@ func (h *hawkularSink) init() error {
 		if err != nil || cs < 0 {
 			return fmt.Errorf("Supplied concurrency value of %s is invalid", v[0])
 		}
-		h.concurrencyLimit = cs
+		p.Concurrency = cs
 	}
 
 	if v, found := opts["batchSize"]; found {

--- a/metrics/sinks/hawkular/driver_test.go
+++ b/metrics/sinks/hawkular/driver_test.go
@@ -623,6 +623,7 @@ func TestBatchingTimeseries(t *testing.T) {
 		for _, v := range mH {
 			ids = append(ids, v.Id)
 		}
+
 		calls++
 	}))
 	defer s.Close()

--- a/metrics/sinks/hawkular/types.go
+++ b/metrics/sinks/hawkular/types.go
@@ -58,8 +58,7 @@ type hawkularSink struct {
 	modifiers   []metrics.Modifier
 	filters     []Filter
 
-	batchSize        int
-	concurrencyLimit int
+	batchSize int
 }
 
 func heapsterTypeToHawkularType(t core.MetricType) metrics.MetricType {


### PR DESCRIPTION
This PR is based on the PR #1118 

Updates the Hawkular-Metrics Golang client to version 0.6.0, which provides a global concurrency restriction to all the commands sent to the Hawkular-Metrics server.

Removes the sink's concurrency handling and uses the client's one. This causes the metric registration part to be concurrency limited also (preventing flooding of the server if Hawkular is deployed to existing installation).

Only commit e0e7883 is relevant (rest I guess disappear if #1118 is merged)
