### PR TITLE
Fix of a spelling error of 'moment'

### DIFF
--- a/docs/source-configuration.md
+++ b/docs/source-configuration.md
@@ -1,7 +1,7 @@
 Configuring sources
 ===================
 
-Heapster can get data from multiple sources (although at this momeent we support only one kind - Kubernetes).
+Heapster can get data from multiple sources (although at this moment we support only one kind - Kubernetes).
 They are specified in the command line via the `--source` flag. The flag takes an argument of the form `PREFIX:CONFIG[?OPTIONS]`.
 Options (optional!) are specified as URL query parameters, separated by `&` as normal.
 This allows each source to have custom configuration passed to it without needing to


### PR DESCRIPTION
Fix of a spelling error of 'moment'
