### PR TITLE
Introduce Oldtimer (with InfluxDB sink support)

### DIFF
--- a/metrics/api/v1/api.go
+++ b/metrics/api/v1/api.go
@@ -27,12 +27,13 @@ import (
 type Api struct {
 	runningInKubernetes bool
 	metricSink          *metricsink.MetricSink
+	historicalSource    core.HistoricalSource
 	gkeMetrics          map[string]core.MetricDescriptor
 	gkeLabels           map[string]core.LabelDescriptor
 }
 
 // Create a new Api to serve from the specified cache.
-func NewApi(runningInKubernetes bool, metricSink *metricsink.MetricSink) *Api {
+func NewApi(runningInKubernetes bool, metricSink *metricsink.MetricSink, historicalSource core.HistoricalSource) *Api {
 	gkeMetrics := make(map[string]core.MetricDescriptor)
 	gkeLabels := make(map[string]core.LabelDescriptor)
 	for _, val := range core.StandardMetrics {
@@ -57,6 +58,7 @@ func NewApi(runningInKubernetes bool, metricSink *metricsink.MetricSink) *Api {
 	return &Api{
 		runningInKubernetes: runningInKubernetes,
 		metricSink:          metricSink,
+		historicalSource:    historicalSource,
 		gkeMetrics:          gkeMetrics,
 		gkeLabels:           gkeLabels,
 	}
@@ -87,6 +89,10 @@ func (a *Api) Register(container *restful.Container) {
 
 	if a.metricSink != nil {
 		a.RegisterModel(container)
+	}
+
+	if a.historicalSource != nil {
+		a.RegisterHistorical(container)
 	}
 }
 

--- a/metrics/api/v1/api_test.go
+++ b/metrics/api/v1/api_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestApiFactory(t *testing.T) {
 	metricSink := metricsink.MetricSink{}
-	api := NewApi(false, &metricSink)
+	api := NewApi(false, &metricSink, nil)
 	as := assert.New(t)
 	for _, metric := range core.StandardMetrics {
 		val, exists := api.gkeMetrics[metric.Name]
@@ -56,7 +56,7 @@ func TestApiFactory(t *testing.T) {
 }
 
 func TestFuzzInput(t *testing.T) {
-	api := NewApi(false, nil)
+	api := NewApi(false, nil, nil)
 	data := []*core.DataBatch{}
 	fuzz.New().NilChance(0).Fuzz(&data)
 	_ = api.processMetricsRequest(data)
@@ -103,7 +103,7 @@ func generateMetricSet(objectType string, labels []core.LabelDescriptor) *core.M
 }
 
 func TestRealInput(t *testing.T) {
-	api := NewApi(false, nil)
+	api := NewApi(false, nil, nil)
 	dataBatch := []*core.DataBatch{
 		{
 			Timestamp:  time.Now(),

--- a/metrics/api/v1/historical_handlers.go
+++ b/metrics/api/v1/historical_handlers.go
@@ -1,0 +1,790 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	restful "github.com/emicklei/go-restful"
+
+	"k8s.io/heapster/metrics/api/v1/types"
+	"k8s.io/heapster/metrics/core"
+	"k8s.io/heapster/metrics/util/metrics"
+)
+
+// HistoricalApi wraps the standard API to overload the fetchers to use the
+// one of the persistent storage sinks instead of the in-memory metrics sink
+type HistoricalApi struct {
+	*Api
+}
+
+// metricsAggregationFetcher represents the capability to fetch aggregations for metrics
+type metricsAggregationFetcher interface {
+	clusterAggregations(request *restful.Request, response *restful.Response)
+	nodeAggregations(request *restful.Request, response *restful.Response)
+	namespaceAggregations(request *restful.Request, response *restful.Response)
+	podAggregations(request *restful.Request, response *restful.Response)
+	podContainerAggregations(request *restful.Request, response *restful.Response)
+	freeContainerAggregations(request *restful.Request, response *restful.Response)
+	podListAggregations(request *restful.Request, response *restful.Response)
+
+	isRunningInKubernetes() bool
+}
+
+// addAggregationRoutes adds routes to a webservice which point to a metricsAggregationFetcher's methods
+func addAggregationRoutes(a metricsAggregationFetcher, ws *restful.WebService) {
+	// The /metrics-aggregated/{aggregations}/{metric-name} endpoint exposes some aggregations for the Cluster entity of the historical API.
+	ws.Route(ws.GET("/metrics-aggregated/{aggregations}/{metric-name:*}").
+		To(metrics.InstrumentRouteFunc("clusterMetrics", a.clusterAggregations)).
+		Doc("Export some cluster-level metric aggregations").
+		Operation("clusterAggregations").
+		Param(ws.PathParameter("aggregations", "A comma-separated list of requested aggregations").DataType("string")).
+		Param(ws.PathParameter("metric-name", "The name of the requested metric").DataType("string")).
+		Param(ws.QueryParameter("start", "Start time for requested metric").DataType("string")).
+		Param(ws.QueryParameter("end", "End time for requested metric").DataType("string")).
+		Writes(types.MetricAggregationResult{}))
+
+	// The /nodes/{node-name}/metrics-aggregated/{aggregations}/{metric-name} endpoint exposes some aggregations for a Node entity of the historical API.
+	// The {node-name} parameter is the hostname of a specific node.
+	ws.Route(ws.GET("/nodes/{node-name}/metrics-aggregated/{aggregations}/{metric-name:*}").
+		To(metrics.InstrumentRouteFunc("nodeMetrics", a.nodeAggregations)).
+		Doc("Export a node-level metric").
+		Operation("nodeAggregations").
+		Param(ws.PathParameter("node-name", "The name of the node to lookup").DataType("string")).
+		Param(ws.PathParameter("aggregations", "A comma-separated list of requested aggregations").DataType("string")).
+		Param(ws.PathParameter("metric-name", "The name of the requested metric").DataType("string")).
+		Param(ws.QueryParameter("start", "Start time for requested metric").DataType("string")).
+		Param(ws.QueryParameter("end", "End time for requested metric").DataType("string")).
+		Writes(types.MetricAggregationResult{}))
+
+	if a.isRunningInKubernetes() {
+		// The /namespaces/{namespace-name}/metrics-aggregated/{aggregations}/{metric-name} endpoint exposes some aggregations
+		// for a Namespace entity of the historical API.
+		ws.Route(ws.GET("/namespaces/{namespace-name}/metrics-aggregated/{aggregations}/{metric-name:*}").
+			To(metrics.InstrumentRouteFunc("namespaceMetrics", a.namespaceAggregations)).
+			Doc("Export some namespace-level metric aggregations").
+			Operation("namespaceAggregations").
+			Param(ws.PathParameter("namespace-name", "The name of the namespace to lookup").DataType("string")).
+			Param(ws.PathParameter("aggregations", "A comma-separated list of requested aggregations").DataType("string")).
+			Param(ws.PathParameter("metric-name", "The name of the requested metric").DataType("string")).
+			Param(ws.QueryParameter("start", "Start time for requested metrics").DataType("string")).
+			Param(ws.QueryParameter("end", "End time for requested metric").DataType("string")).
+			Writes(types.MetricAggregationResult{}))
+
+		// The /namespaces/{namespace-name}/pods/{pod-name}/metrics-aggregated/{aggregations}/{metric-name} endpoint exposes
+		// some aggregations for a Pod entity of the historical API.
+		ws.Route(ws.GET("/namespaces/{namespace-name}/pods/{pod-name}/metrics-aggregated/{aggregations}/{metric-name:*}").
+			To(metrics.InstrumentRouteFunc("podMetrics", a.podAggregations)).
+			Doc("Export some pod-level metric aggregations").
+			Operation("podAggregations").
+			Param(ws.PathParameter("namespace-name", "The name of the namespace to lookup").DataType("string")).
+			Param(ws.PathParameter("pod-name", "The name of the pod to lookup").DataType("string")).
+			Param(ws.PathParameter("aggregations", "A comma-separated list of requested aggregations").DataType("string")).
+			Param(ws.PathParameter("metric-name", "The name of the requested metric").DataType("string")).
+			Param(ws.QueryParameter("start", "Start time for requested metrics").DataType("string")).
+			Param(ws.QueryParameter("end", "End time for requested metric").DataType("string")).
+			Writes(types.MetricAggregationResult{}))
+
+		// The /namespaces/{namespace-name}/pods/{pod-name}/containers/{container-name}/metrics-aggregated/{aggregations}/{metric-name} endpoint exposes
+		// some aggregations for a Container entity of the historical API.
+		ws.Route(ws.GET("/namespaces/{namespace-name}/pods/{pod-name}/containers/{container-name}/metrics-aggregated/{aggregations}/{metric-name:*}").
+			To(metrics.InstrumentRouteFunc("podContainerMetrics", a.podContainerAggregations)).
+			Doc("Export some aggregations for a Pod Container").
+			Operation("podContainerAggregations").
+			Param(ws.PathParameter("namespace-name", "The name of the namespace to use").DataType("string")).
+			Param(ws.PathParameter("pod-name", "The name of the pod to use").DataType("string")).
+			Param(ws.PathParameter("container-name", "The name of the namespace to use").DataType("string")).
+			Param(ws.PathParameter("aggregations", "A comma-separated list of requested aggregations").DataType("string")).
+			Param(ws.PathParameter("metric-name", "The name of the requested metric").DataType("string")).
+			Param(ws.QueryParameter("start", "Start time for requested metrics").DataType("string")).
+			Param(ws.QueryParameter("end", "End time for requested metric").DataType("string")).
+			Writes(types.MetricAggregationResult{}))
+
+		// The /pod-id/{pod-id}/metrics-aggregated/{aggregations}/{metric-name} endpoint exposes
+		// some aggregations for a Pod entity of the historical API.
+		ws.Route(ws.GET("/pod-id/{pod-id}/metrics-aggregated/{aggregations}/{metric-name:*}").
+			To(metrics.InstrumentRouteFunc("podMetrics", a.podAggregations)).
+			Doc("Export some pod-level metric aggregations").
+			Operation("podAggregations").
+			Param(ws.PathParameter("pod-id", "The UID of the pod to lookup").DataType("string")).
+			Param(ws.PathParameter("aggregations", "A comma-separated list of requested aggregations").DataType("string")).
+			Param(ws.PathParameter("metric-name", "The name of the requested metric").DataType("string")).
+			Param(ws.QueryParameter("start", "Start time for requested metrics").DataType("string")).
+			Param(ws.QueryParameter("end", "End time for requested metric").DataType("string")).
+			Writes(types.MetricAggregationResult{}))
+
+		// The /pod-id/{pod-id}/containers/{container-name}/metrics-aggregated/{aggregations}/{metric-name} endpoint exposes
+		// some aggregations for a Container entity of the historical API.
+		ws.Route(ws.GET("/pod-id/{pod-id}/containers/{container-name}/metrics-aggregated/{aggregations}/{metric-name:*}").
+			To(metrics.InstrumentRouteFunc("podContainerMetrics", a.podContainerAggregations)).
+			Doc("Export some aggregations for a Pod Container").
+			Operation("podContainerAggregations").
+			Param(ws.PathParameter("pod-id", "The name of the pod to use").DataType("string")).
+			Param(ws.PathParameter("container-name", "The name of the namespace to use").DataType("string")).
+			Param(ws.PathParameter("aggregations", "A comma-separated list of requested aggregations").DataType("string")).
+			Param(ws.PathParameter("metric-name", "The name of the requested metric").DataType("string")).
+			Param(ws.QueryParameter("start", "Start time for requested metrics").DataType("string")).
+			Param(ws.QueryParameter("end", "End time for requested metric").DataType("string")).
+			Writes(types.MetricAggregationResult{}))
+	}
+
+	// The /nodes/{node-name}/freecontainers/{container-name}/metrics-aggregated/{aggregations}/{metric-name} endpoint exposes
+	// some aggregations for a free Container entity of the historical API.
+	ws.Route(ws.GET("/nodes/{node-name}/freecontainers/{container-name}/metrics-aggregated/{aggregations}/{metric-name:*}").
+		To(metrics.InstrumentRouteFunc("freeContainerMetrics", a.freeContainerAggregations)).
+		Doc("Export a contsome iner-level metric aggregations for a free container").
+		Operation("freeContainerAggregations").
+		Param(ws.PathParameter("node-name", "The name of the node to use").DataType("string")).
+		Param(ws.PathParameter("container-name", "The name of the container to use").DataType("string")).
+		Param(ws.PathParameter("aggregations", "A comma-separated list of requested aggregations").DataType("string")).
+		Param(ws.PathParameter("metric-name", "The name of the requested metric").DataType("string")).
+		Param(ws.QueryParameter("start", "Start time for requested metrics").DataType("string")).
+		Param(ws.QueryParameter("end", "End time for requested metric").DataType("string")).
+		Writes(types.MetricAggregationResult{}))
+
+	if a.isRunningInKubernetes() {
+		// The /namespaces/{namespace-name}/pod-list/{pod-list}/metrics-aggregated/{aggregations}/{metric-name} endpoint exposes
+		// metrics for a list of pods of the historical API.
+		ws.Route(ws.GET("/namespaces/{namespace-name}/pod-list/{pod-list}/metrics-aggregated/{aggregations}/{metric-name:*}").
+			To(metrics.InstrumentRouteFunc("podListAggregations", a.podListAggregations)).
+			Doc("Export some aggregations for all pods from the given list").
+			Operation("podListAggregations").
+			Param(ws.PathParameter("namespace-name", "The name of the namespace to lookup").DataType("string")).
+			Param(ws.PathParameter("pod-list", "Comma separated list of pod names to lookup").DataType("string")).
+			Param(ws.PathParameter("aggregations", "A comma-separated list of requested aggregations").DataType("string")).
+			Param(ws.PathParameter("metric-name", "The name of the requested metric").DataType("string")).
+			Param(ws.QueryParameter("start", "Start time for requested metrics").DataType("string")).
+			Param(ws.QueryParameter("end", "End time for requested metric").DataType("string")).
+			Writes(types.MetricAggregationResultList{}))
+
+		// The /pod-id-list/{pod-id-list}/metrics-aggregated/{aggregations}/{metric-name} endpoint exposes
+		// metrics for a list of pod ids of the historical API.
+		ws.Route(ws.GET("/pod-id-list/{pod-id-list}/metrics-aggregated/{aggregations}/{metric-name:*}").
+			To(metrics.InstrumentRouteFunc("podListAggregations", a.podListAggregations)).
+			Doc("Export an aggregation for all pods from the given list").
+			Operation("podListAggregations").
+			Param(ws.PathParameter("pod-id-list", "Comma separated list of pod UIDs to lookup").DataType("string")).
+			Param(ws.PathParameter("aggregations", "A comma-separated list of requested aggregations").DataType("string")).
+			Param(ws.PathParameter("metric-name", "The name of the requested metric").DataType("string")).
+			Param(ws.QueryParameter("start", "Start time for requested metrics").DataType("string")).
+			Param(ws.QueryParameter("end", "End time for requested metric").DataType("string")).
+			Writes(types.MetricAggregationResultList{}))
+	}
+}
+
+// RegisterHistorical registers the Historical API endpoints.  It will register the same endpoints
+// as those in the model API, plus endpoints for aggregation retrieval, and endpoints to retrieve pod
+// metrics by using the pod id.
+func (normalApi *Api) RegisterHistorical(container *restful.Container) {
+	ws := new(restful.WebService)
+	ws.Path("/api/v1/historical").
+		Doc("Root endpoint of the historical access API").
+		Consumes("*/*").
+		Produces(restful.MIME_JSON)
+
+	a := &HistoricalApi{normalApi}
+	addClusterMetricsRoutes(a, ws)
+	addAggregationRoutes(a, ws)
+
+	// register the endpoint for fetching raw metrics based on pod id
+	if a.isRunningInKubernetes() {
+		// The /pod-id/{pod-id}/metrics-aggregated/{aggregations}/{metric-name} endpoint exposes
+		// some aggregations for a Pod entity of the historical API.
+		ws.Route(ws.GET("/pod-id/{pod-id}/metrics/{metric-name:*}").
+			To(metrics.InstrumentRouteFunc("podMetrics", a.podMetrics)).
+			Doc("Export some pod-level metric aggregations").
+			Operation("podAggregations").
+			Param(ws.PathParameter("pod-id", "The UID of the pod to lookup").DataType("string")).
+			Param(ws.PathParameter("metric-name", "The name of the requested metric").DataType("string")).
+			Param(ws.QueryParameter("start", "Start time for requested metrics").DataType("string")).
+			Param(ws.QueryParameter("end", "End time for requested metric").DataType("string")).
+			Writes(types.MetricResult{}))
+
+		// The /pod-id/{pod-id}/containers/{container-name}/metrics-aggregated/{aggregations}/{metric-name} endpoint exposes
+		// some aggregations for a Container entity of the historical API.
+		ws.Route(ws.GET("/pod-id/{pod-id}/containers/{container-name}/metrics/{metric-name:*}").
+			To(metrics.InstrumentRouteFunc("podContainerMetrics", a.podContainerMetrics)).
+			Doc("Export some aggregations for a Pod Container").
+			Operation("podContainerAggregations").
+			Param(ws.PathParameter("pod-id", "The uid of the pod to use").DataType("string")).
+			Param(ws.PathParameter("container-name", "The name of the namespace to use").DataType("string")).
+			Param(ws.PathParameter("metric-name", "The name of the requested metric").DataType("string")).
+			Param(ws.QueryParameter("start", "Start time for requested metrics").DataType("string")).
+			Param(ws.QueryParameter("end", "End time for requested metric").DataType("string")).
+			Writes(types.MetricResult{}))
+
+		// The /pod-id-list/{pod-id-list}/metrics-aggregated/{aggregations}/{metric-name} endpoint exposes
+		// metrics for a list of pod ids of the historical API.
+		ws.Route(ws.GET("/pod-id-list/{pod-id-list}/metrics/{metric-name:*}").
+			To(metrics.InstrumentRouteFunc("podListAggregations", a.podListMetrics)).
+			Doc("Export an aggregation for all pods from the given list").
+			Operation("podListAggregations").
+			Param(ws.PathParameter("pod-id-list", "Comma separated list of pod UIDs to lookup").DataType("string")).
+			Param(ws.PathParameter("metric-name", "The name of the requested metric").DataType("string")).
+			Param(ws.QueryParameter("start", "Start time for requested metrics").DataType("string")).
+			Param(ws.QueryParameter("end", "End time for requested metric").DataType("string")).
+			Writes(types.MetricResultList{}))
+	}
+
+	container.Add(ws)
+}
+
+// availableClusterMetrics returns a list of available cluster metric names.
+func (a *HistoricalApi) availableClusterMetrics(request *restful.Request, response *restful.Response) {
+	key := core.HistoricalKey{ObjectType: core.MetricSetTypeCluster}
+	a.processMetricNamesRequest(key, response)
+}
+
+// availableNodeMetrics returns a list of available node metric names.
+func (a *HistoricalApi) availableNodeMetrics(request *restful.Request, response *restful.Response) {
+	key := core.HistoricalKey{
+		ObjectType: core.MetricSetTypeNode,
+		NodeName:   request.PathParameter("node-name"),
+	}
+	a.processMetricNamesRequest(key, response)
+}
+
+// availableNamespaceMetrics returns a list of available namespace metric names.
+func (a *HistoricalApi) availableNamespaceMetrics(request *restful.Request, response *restful.Response) {
+	key := core.HistoricalKey{
+		ObjectType:    core.MetricSetTypeNamespace,
+		NamespaceName: request.PathParameter("namespace-name"),
+	}
+	a.processMetricNamesRequest(key, response)
+}
+
+// availablePodMetrics returns a list of available pod metric names.
+func (a *HistoricalApi) availablePodMetrics(request *restful.Request, response *restful.Response) {
+	key := core.HistoricalKey{
+		ObjectType:    core.MetricSetTypePod,
+		NamespaceName: request.PathParameter("namespace-name"),
+		PodName:       request.PathParameter("pod-name"),
+	}
+	a.processMetricNamesRequest(key, response)
+}
+
+// availablePodContainerMetrics returns a list of available pod container metric names.
+func (a *HistoricalApi) availablePodContainerMetrics(request *restful.Request, response *restful.Response) {
+	key := core.HistoricalKey{
+		ObjectType:    core.MetricSetTypePodContainer,
+		NamespaceName: request.PathParameter("namespace-name"),
+		PodName:       request.PathParameter("pod-name"),
+		ContainerName: request.PathParameter("container-name"),
+	}
+	a.processMetricNamesRequest(key, response)
+}
+
+// availableFreeContainerMetrics returns a list of available pod metric names.
+func (a *HistoricalApi) availableFreeContainerMetrics(request *restful.Request, response *restful.Response) {
+	key := core.HistoricalKey{
+		ObjectType:    core.MetricSetTypeSystemContainer,
+		NodeName:      request.PathParameter("node-name"),
+		ContainerName: request.PathParameter("container-name"),
+	}
+	a.processMetricNamesRequest(key, response)
+}
+
+// nodeList lists all nodes for which we have metrics
+func (a *HistoricalApi) nodeList(request *restful.Request, response *restful.Response) {
+	if resp, err := a.historicalSource.GetNodes(); err != nil {
+		response.WriteError(http.StatusInternalServerError, err)
+	} else {
+		response.WriteEntity(resp)
+	}
+}
+
+// namespaceList lists all namespaces for which we have metrics
+func (a *HistoricalApi) namespaceList(request *restful.Request, response *restful.Response) {
+	if resp, err := a.historicalSource.GetNamespaces(); err != nil {
+		response.WriteError(http.StatusInternalServerError, err)
+	} else {
+		response.WriteEntity(resp)
+	}
+}
+
+// namespacePodList lists all pods for which we have metrics in a particular namespace
+func (a *HistoricalApi) namespacePodList(request *restful.Request, response *restful.Response) {
+	if resp, err := a.historicalSource.GetPodsFromNamespace(request.PathParameter("namespace-name")); err != nil {
+		response.WriteError(http.StatusInternalServerError, err)
+	} else {
+		response.WriteEntity(resp)
+	}
+}
+
+// nodeSystemContainerList lists all system containers on a node for which we have metrics
+func (a *HistoricalApi) nodeSystemContainerList(request *restful.Request, response *restful.Response) {
+	if resp, err := a.historicalSource.GetSystemContainersFromNode(request.PathParameter("node-name")); err != nil {
+		response.WriteError(http.StatusInternalServerError, err)
+	} else {
+		response.WriteEntity(resp)
+	}
+}
+
+// clusterMetrics returns a metric timeseries for a metric of the Cluster entity.
+func (a *HistoricalApi) clusterMetrics(request *restful.Request, response *restful.Response) {
+	key := core.HistoricalKey{ObjectType: core.MetricSetTypeCluster}
+	a.processMetricRequest(key, request, response)
+}
+
+// nodeMetrics returns a metric timeseries for a metric of the Node entity.
+func (a *HistoricalApi) nodeMetrics(request *restful.Request, response *restful.Response) {
+	key := core.HistoricalKey{
+		ObjectType: core.MetricSetTypeNode,
+		NodeName:   request.PathParameter("node-name"),
+	}
+	a.processMetricRequest(key, request, response)
+}
+
+// namespaceMetrics returns a metric timeseries for a metric of the Namespace entity.
+func (a *HistoricalApi) namespaceMetrics(request *restful.Request, response *restful.Response) {
+	key := core.HistoricalKey{
+		ObjectType:    core.MetricSetTypeNamespace,
+		NamespaceName: request.PathParameter("namespace-name"),
+	}
+	a.processMetricRequest(key, request, response)
+}
+
+// podMetrics returns a metric timeseries for a metric of the Pod entity.
+func (a *HistoricalApi) podMetrics(request *restful.Request, response *restful.Response) {
+	var key core.HistoricalKey
+	if request.PathParameter("pod-id") != "" {
+		key = core.HistoricalKey{
+			ObjectType: core.MetricSetTypePod,
+			PodId:      request.PathParameter("pod-id"),
+		}
+	} else {
+		key = core.HistoricalKey{
+			ObjectType:    core.MetricSetTypePod,
+			NamespaceName: request.PathParameter("namespace-name"),
+			PodName:       request.PathParameter("pod-name"),
+		}
+	}
+	a.processMetricRequest(key, request, response)
+}
+
+// freeContainerMetrics returns a metric timeseries for a metric of the Container entity.
+// freeContainerMetrics addresses only free containers.
+func (a *HistoricalApi) freeContainerMetrics(request *restful.Request, response *restful.Response) {
+	key := core.HistoricalKey{
+		ObjectType:    core.MetricSetTypeSystemContainer,
+		NodeName:      request.PathParameter("node-name"),
+		ContainerName: request.PathParameter("container-name"),
+	}
+	a.processMetricRequest(key, request, response)
+}
+
+// podListMetrics returns a list of metric timeseries for each for the listed nodes
+func (a *HistoricalApi) podListMetrics(request *restful.Request, response *restful.Response) {
+	start, end, err := getStartEndTimeHistorical(request)
+	if err != nil {
+		response.WriteError(http.StatusBadRequest, err)
+		return
+	}
+
+	keys := []core.HistoricalKey{}
+	if request.PathParameter("pod-id-list") != "" {
+		for _, podId := range strings.Split(request.PathParameter("pod-id-list"), ",") {
+			key := core.HistoricalKey{
+				ObjectType: core.MetricSetTypePod,
+				PodId:      podId,
+			}
+			keys = append(keys, key)
+		}
+	} else {
+		for _, podName := range strings.Split(request.PathParameter("pod-list"), ",") {
+			key := core.HistoricalKey{
+				ObjectType:    core.MetricSetTypePod,
+				NamespaceName: request.PathParameter("namespace-name"),
+				PodName:       podName,
+			}
+			keys = append(keys, key)
+		}
+	}
+	metricName := request.PathParameter("metric-name")
+	convertedMetricName := convertMetricName(metricName)
+	metrics, err := a.historicalSource.GetMetric(convertedMetricName, keys, start, end)
+	if err != nil {
+		response.WriteError(http.StatusInternalServerError, err)
+		return
+	}
+
+	result := types.MetricResultList{
+		Items: make([]types.MetricResult, 0, len(keys)),
+	}
+	for _, key := range keys {
+		result.Items = append(result.Items, exportTimestampedMetricValue(metrics[key]))
+	}
+	response.PrettyPrint(false)
+	response.WriteEntity(result)
+}
+
+// podContainerMetrics returns a metric timeseries for a metric of a Pod Container entity.
+func (a *HistoricalApi) podContainerMetrics(request *restful.Request, response *restful.Response) {
+	var key core.HistoricalKey
+	if request.PathParameter("pod-id") != "" {
+		key = core.HistoricalKey{
+			ObjectType:    core.MetricSetTypePodContainer,
+			PodId:         request.PathParameter("pod-id"),
+			ContainerName: request.PathParameter("container-name"),
+		}
+	} else {
+		key = core.HistoricalKey{
+			ObjectType:    core.MetricSetTypePodContainer,
+			NamespaceName: request.PathParameter("namespace-name"),
+			PodName:       request.PathParameter("pod-name"),
+			ContainerName: request.PathParameter("container-name"),
+		}
+	}
+	a.processMetricRequest(key, request, response)
+}
+
+// clusterAggregations returns a metric timeseries for a metric of the Cluster entity.
+func (a *HistoricalApi) clusterAggregations(request *restful.Request, response *restful.Response) {
+	key := core.HistoricalKey{ObjectType: core.MetricSetTypeCluster}
+	a.processAggregationRequest(key, request, response)
+}
+
+// nodeAggregations returns a metric timeseries for a metric of the Node entity.
+func (a *HistoricalApi) nodeAggregations(request *restful.Request, response *restful.Response) {
+	key := core.HistoricalKey{
+		ObjectType: core.MetricSetTypeNode,
+		NodeName:   request.PathParameter("node-name"),
+	}
+	a.processAggregationRequest(key, request, response)
+}
+
+// namespaceAggregations returns a metric timeseries for a metric of the Namespace entity.
+func (a *HistoricalApi) namespaceAggregations(request *restful.Request, response *restful.Response) {
+	key := core.HistoricalKey{
+		ObjectType:    core.MetricSetTypeNamespace,
+		NamespaceName: request.PathParameter("namespace-name"),
+	}
+	a.processAggregationRequest(key, request, response)
+}
+
+// podAggregations returns a metric timeseries for a metric of the Pod entity.
+func (a *HistoricalApi) podAggregations(request *restful.Request, response *restful.Response) {
+	var key core.HistoricalKey
+	if request.PathParameter("pod-id") != "" {
+		key = core.HistoricalKey{
+			ObjectType: core.MetricSetTypePod,
+			PodId:      request.PathParameter("pod-id"),
+		}
+	} else {
+		key = core.HistoricalKey{
+			ObjectType:    core.MetricSetTypePod,
+			NamespaceName: request.PathParameter("namespace-name"),
+			PodName:       request.PathParameter("pod-name"),
+		}
+	}
+	a.processAggregationRequest(key, request, response)
+}
+
+// podContainerAggregations returns a metric timeseries for a metric of a Pod Container entity.
+func (a *HistoricalApi) podContainerAggregations(request *restful.Request, response *restful.Response) {
+	var key core.HistoricalKey
+	if request.PathParameter("pod-id") != "" {
+		key = core.HistoricalKey{
+			ObjectType:    core.MetricSetTypePodContainer,
+			PodId:         request.PathParameter("pod-id"),
+			ContainerName: request.PathParameter("container-name"),
+		}
+	} else {
+		key = core.HistoricalKey{
+			ObjectType:    core.MetricSetTypePodContainer,
+			NamespaceName: request.PathParameter("namespace-name"),
+			PodName:       request.PathParameter("pod-name"),
+			ContainerName: request.PathParameter("container-name"),
+		}
+	}
+	a.processAggregationRequest(key, request, response)
+}
+
+// freeContainerAggregations returns a metric timeseries for a metric of the Container entity.
+// freeContainerAggregations addresses only free containers.
+func (a *HistoricalApi) freeContainerAggregations(request *restful.Request, response *restful.Response) {
+	key := core.HistoricalKey{
+		ObjectType:    core.MetricSetTypeSystemContainer,
+		NodeName:      request.PathParameter("node-name"),
+		ContainerName: request.PathParameter("container-name"),
+	}
+	a.processAggregationRequest(key, request, response)
+}
+
+// podListAggregations returns a list of metric timeseries for the specified pods.
+func (a *HistoricalApi) podListAggregations(request *restful.Request, response *restful.Response) {
+	start, end, err := getStartEndTimeHistorical(request)
+	if err != nil {
+		response.WriteError(http.StatusBadRequest, err)
+		return
+	}
+	bucketSize, err := getBucketSize(request)
+	if err != nil {
+		response.WriteError(http.StatusBadRequest, err)
+		return
+	}
+	aggregations, err := getAggregations(request)
+	if err != nil {
+		response.WriteError(http.StatusBadRequest, err)
+	}
+	keys := []core.HistoricalKey{}
+	if request.PathParameter("pod-id-list") != "" {
+		for _, podId := range strings.Split(request.PathParameter("pod-id-list"), ",") {
+			key := core.HistoricalKey{
+				ObjectType: core.MetricSetTypePod,
+				PodId:      podId,
+			}
+			keys = append(keys, key)
+		}
+	} else {
+		for _, podName := range strings.Split(request.PathParameter("pod-list"), ",") {
+			key := core.HistoricalKey{
+				ObjectType:    core.MetricSetTypePod,
+				NamespaceName: request.PathParameter("namespace-name"),
+				PodName:       podName,
+			}
+			keys = append(keys, key)
+		}
+	}
+	metricName := request.PathParameter("metric-name")
+	convertedMetricName := convertMetricName(metricName)
+	metrics, err := a.historicalSource.GetAggregation(convertedMetricName, aggregations, keys, start, end, bucketSize)
+	if err != nil {
+		response.WriteError(http.StatusInternalServerError, err)
+	}
+
+	result := types.MetricAggregationResultList{
+		Items: make([]types.MetricAggregationResult, 0, len(keys)),
+	}
+	for _, key := range keys {
+		result.Items = append(result.Items, exportTimestampedAggregationValue(metrics[key]))
+	}
+	response.PrettyPrint(false)
+	response.WriteEntity(result)
+}
+
+// processMetricRequest retrieves a metric for the object at the requested key.
+func (a *HistoricalApi) processMetricRequest(key core.HistoricalKey, request *restful.Request, response *restful.Response) {
+	start, end, err := getStartEndTimeHistorical(request)
+	if err != nil {
+		response.WriteError(http.StatusBadRequest, err)
+		return
+	}
+	metricName := request.PathParameter("metric-name")
+	convertedMetricName := convertMetricName(metricName)
+	metrics, err := a.historicalSource.GetMetric(convertedMetricName, []core.HistoricalKey{key}, start, end)
+	if err != nil {
+		response.WriteError(http.StatusInternalServerError, err)
+		return
+	}
+
+	converted := exportTimestampedMetricValue(metrics[key])
+	response.WriteEntity(converted)
+}
+
+// processMetricNamesRequest retrieves the available metrics for the object at the specified key.
+func (a *HistoricalApi) processMetricNamesRequest(key core.HistoricalKey, response *restful.Response) {
+	if resp, err := a.historicalSource.GetMetricNames(key); err != nil {
+		response.WriteError(http.StatusInternalServerError, err)
+	} else {
+		response.WriteEntity(resp)
+	}
+}
+
+// processAggregationRequest retrieves one or more aggregations (across time) of a metric for the object specified at the given key.
+func (a *HistoricalApi) processAggregationRequest(key core.HistoricalKey, request *restful.Request, response *restful.Response) {
+	start, end, err := getStartEndTimeHistorical(request)
+	if err != nil {
+		response.WriteError(http.StatusBadRequest, err)
+		return
+	}
+	bucketSize, err := getBucketSize(request)
+	if err != nil {
+		response.WriteError(http.StatusBadRequest, err)
+		return
+	}
+	aggregations, err := getAggregations(request)
+	if err != nil {
+		response.WriteError(http.StatusBadRequest, err)
+	}
+
+	metricName := request.PathParameter("metric-name")
+	convertedMetricName := convertMetricName(metricName)
+	metrics, err := a.historicalSource.GetAggregation(convertedMetricName, aggregations, []core.HistoricalKey{key}, start, end, bucketSize)
+	if err != nil {
+		response.WriteError(http.StatusInternalServerError, err)
+		return
+	}
+
+	converted := exportTimestampedAggregationValue(metrics[key])
+	response.WriteEntity(converted)
+}
+
+// getBucketSize parses the bucket size specifier into a
+func getBucketSize(request *restful.Request) (time.Duration, error) {
+	rawSize := request.QueryParameter("bucket")
+	if rawSize == "" {
+		return 0, nil
+	}
+
+	if len(rawSize) < 2 {
+		return 0, fmt.Errorf("unable to parse bucket size: %q is too short to be a duration", rawSize)
+	}
+	var multiplier time.Duration
+	var num string
+
+	switch rawSize[len(rawSize)-1] {
+	case 's':
+		// could be s or ms
+		if len(rawSize) < 3 || rawSize[len(rawSize)-2] != 'm' {
+			multiplier = time.Second
+			num = rawSize[:len(rawSize)-1]
+		} else {
+			multiplier = time.Millisecond
+			num = rawSize[:len(rawSize)-2]
+		}
+	case 'h':
+		multiplier = time.Hour
+		num = rawSize[:len(rawSize)-1]
+	case 'd':
+		multiplier = 24 * time.Hour
+		num = rawSize[:len(rawSize)-1]
+	case 'm':
+		multiplier = time.Minute
+		num = rawSize[:len(rawSize)-1]
+	default:
+		return 0, fmt.Errorf("unable to parse bucket size: %q has no known duration suffix", rawSize)
+	}
+
+	parsedNum, err := strconv.ParseUint(num, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+
+	return time.Duration(parsedNum) * multiplier, nil
+}
+
+// getAggregations extracts and validates the list of requested aggregations
+func getAggregations(request *restful.Request) ([]core.AggregationType, error) {
+	aggregationsRaw := strings.Split(request.PathParameter("aggregations"), ",")
+	if len(aggregationsRaw) == 0 {
+		return nil, fmt.Errorf("No aggregations specified")
+	}
+
+	aggregations := make([]core.AggregationType, len(aggregationsRaw))
+
+	for ind, aggNameRaw := range aggregationsRaw {
+		aggName := core.AggregationType(aggNameRaw)
+		if _, ok := core.AllAggregations[aggName]; !ok {
+			return nil, fmt.Errorf("Unknown aggregation %q", aggName)
+		}
+		aggregations[ind] = aggName
+	}
+
+	return aggregations, nil
+}
+
+// exportMetricValue converts a core.MetricValue into an API MetricValue
+func exportMetricValue(value *core.MetricValue) *types.MetricValue {
+	if value == nil {
+		return nil
+	}
+
+	if value.ValueType == core.ValueInt64 {
+		return &types.MetricValue{
+			IntValue: &value.IntValue,
+		}
+	} else {
+		floatVal := float64(value.FloatValue)
+		return &types.MetricValue{
+			FloatValue: &floatVal,
+		}
+	}
+}
+
+// extractMetricValue checks to see if the given metric was present in the results, and if so,
+// returns it in API form
+func extractMetricValue(aggregations *core.AggregationValue, aggName core.AggregationType) *types.MetricValue {
+	if inputVal, ok := aggregations.Aggregations[aggName]; ok {
+		return exportMetricValue(&inputVal)
+	} else {
+		return nil
+	}
+}
+
+// exportTimestampedAggregationValue converts a core.TimestampedAggregationValue into an API MetricAggregationResult
+func exportTimestampedAggregationValue(values []core.TimestampedAggregationValue) types.MetricAggregationResult {
+	result := types.MetricAggregationResult{
+		Buckets:    make([]types.MetricAggregationBucket, 0, len(values)),
+		BucketSize: 0,
+	}
+	for _, value := range values {
+		// just use the largest bucket size, since all bucket sizes should be uniform
+		// (except for the last one, which may be smaller)
+		if result.BucketSize < value.BucketSize {
+			result.BucketSize = value.BucketSize
+		}
+
+		bucket := types.MetricAggregationBucket{
+			Timestamp: value.Timestamp,
+
+			Count: value.Count,
+
+			Average: extractMetricValue(&value.AggregationValue, core.AggregationTypeAverage),
+			Maximum: extractMetricValue(&value.AggregationValue, core.AggregationTypeMaximum),
+			Minimum: extractMetricValue(&value.AggregationValue, core.AggregationTypeMinimum),
+			Median:  extractMetricValue(&value.AggregationValue, core.AggregationTypeMedian),
+
+			Percentiles: make(map[string]types.MetricValue, 3),
+		}
+
+		if val, ok := value.Aggregations[core.AggregationTypePercentile50]; ok {
+			bucket.Percentiles["50"] = *exportMetricValue(&val)
+		}
+		if val, ok := value.Aggregations[core.AggregationTypePercentile95]; ok {
+			bucket.Percentiles["95"] = *exportMetricValue(&val)
+		}
+		if val, ok := value.Aggregations[core.AggregationTypePercentile99]; ok {
+			bucket.Percentiles["99"] = *exportMetricValue(&val)
+		}
+
+		result.Buckets = append(result.Buckets, bucket)
+	}
+	return result
+}
+
+// getStartEndTimeHistorical fetches the start and end times of the request.  Unlike
+// getStartEndTime, this function returns an error if the start time is not passed
+// (or is zero, since many things in go use time.Time{} as an empty value) --
+// different sinks have different defaults, and certain sinks have issues if an actual
+// time of zero (i.e. the epoch) is used (because that would be too many data points
+// to consider in certain cases).  Require applications to pass an explicit end time
+// that they can deal with.
+func getStartEndTimeHistorical(request *restful.Request) (time.Time, time.Time, error) {
+	start, end, err := getStartEndTime(request)
+	if err != nil {
+		return start, end, err
+	}
+
+	if start.IsZero() {
+		return start, end, fmt.Errorf("no start time (or a start time of zero) provided")
+	}
+
+	return start, end, err
+}

--- a/metrics/api/v1/historical_handlers_test.go
+++ b/metrics/api/v1/historical_handlers_test.go
@@ -1,0 +1,1358 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	restful "github.com/emicklei/go-restful"
+	"k8s.io/heapster/metrics/api/v1/types"
+	"k8s.io/heapster/metrics/core"
+)
+
+type metricReq struct {
+	name  string
+	keys  []core.HistoricalKey
+	start time.Time
+	end   time.Time
+
+	aggregations []core.AggregationType
+	bucketSize   time.Duration
+}
+
+type fakeHistoricalSource struct {
+	metricNames map[core.HistoricalKey][]string
+
+	nodes             []string
+	namespaces        []string
+	podsForNamespace  map[string][]string
+	containersForNode map[string][]string
+
+	metricRequests      []metricReq
+	aggregationRequests []metricReq
+
+	nowTime time.Time
+}
+
+func (src *fakeHistoricalSource) GetMetric(metricName string, metricKeys []core.HistoricalKey, start, end time.Time) (map[core.HistoricalKey][]core.TimestampedMetricValue, error) {
+	if metricName == "invalid" {
+		return nil, fmt.Errorf("fake error fetching metrics")
+	}
+
+	src.metricRequests = append(src.metricRequests, metricReq{
+		name:  metricName,
+		keys:  metricKeys,
+		start: start,
+		end:   end,
+	})
+
+	res := make(map[core.HistoricalKey][]core.TimestampedMetricValue, len(metricKeys))
+
+	for _, key := range metricKeys {
+		res[key] = []core.TimestampedMetricValue{
+			{
+				Timestamp: src.nowTime.Add(-10 * time.Second),
+				MetricValue: core.MetricValue{
+					ValueType:  core.ValueFloat,
+					FloatValue: 33,
+				},
+			},
+		}
+	}
+
+	return res, nil
+}
+
+func (src *fakeHistoricalSource) GetAggregation(metricName string, aggregations []core.AggregationType, metricKeys []core.HistoricalKey, start, end time.Time, bucketSize time.Duration) (map[core.HistoricalKey][]core.TimestampedAggregationValue, error) {
+	if metricName == "invalid" {
+		return nil, fmt.Errorf("fake error fetching metrics")
+	}
+
+	src.metricRequests = append(src.aggregationRequests, metricReq{
+		name:  metricName,
+		keys:  metricKeys,
+		start: start,
+		end:   end,
+
+		aggregations: aggregations,
+		bucketSize:   bucketSize,
+	})
+
+	res := make(map[core.HistoricalKey][]core.TimestampedAggregationValue, len(metricKeys))
+
+	for _, key := range metricKeys {
+		countVal := uint64(10)
+		res[key] = []core.TimestampedAggregationValue{
+			{
+				Timestamp:  src.nowTime.Add(-10 * time.Second),
+				BucketSize: 10 * time.Second,
+				AggregationValue: core.AggregationValue{
+					Count: &countVal,
+				},
+			},
+		}
+	}
+
+	return res, nil
+}
+
+func (src *fakeHistoricalSource) GetMetricNames(metricKey core.HistoricalKey) ([]string, error) {
+	if names, ok := src.metricNames[metricKey]; ok {
+		return names, nil
+	}
+
+	return nil, fmt.Errorf("no such object %q", metricKey.String())
+}
+
+func (src *fakeHistoricalSource) GetNodes() ([]string, error) {
+	return src.nodes, nil
+}
+
+func (src *fakeHistoricalSource) GetNamespaces() ([]string, error) {
+	return src.namespaces, nil
+}
+
+func (src *fakeHistoricalSource) GetPodsFromNamespace(namespace string) ([]string, error) {
+	if pods, ok := src.podsForNamespace[namespace]; ok {
+		return pods, nil
+	}
+
+	return nil, fmt.Errorf("no such namespace %q", namespace)
+}
+
+func (src *fakeHistoricalSource) GetSystemContainersFromNode(node string) ([]string, error) {
+	if conts, ok := src.containersForNode[node]; ok {
+		return conts, nil
+	}
+
+	return nil, fmt.Errorf("no such node %q", node)
+}
+
+func prepApi() (*HistoricalApi, *fakeHistoricalSource) {
+	histSrc := &fakeHistoricalSource{
+		metricNames: make(map[core.HistoricalKey][]string),
+	}
+
+	api := &HistoricalApi{
+		Api: &Api{
+			historicalSource: histSrc,
+		},
+	}
+
+	return api, histSrc
+}
+
+type fakeRespRecorder struct {
+	headers http.Header
+	status  int
+	data    *bytes.Buffer
+}
+
+func (r *fakeRespRecorder) Header() http.Header {
+	return r.headers
+}
+
+func (r *fakeRespRecorder) WriteHeader(status int) {
+	r.status = status
+}
+
+func (r *fakeRespRecorder) Write(content []byte) (int, error) {
+	return r.data.Write(content)
+}
+
+func TestAvailableMetrics(t *testing.T) {
+	api, src := prepApi()
+
+	src.metricNames = map[core.HistoricalKey][]string{
+		core.HistoricalKey{
+			ObjectType: core.MetricSetTypeCluster,
+		}: {"cm1", "cm2"},
+
+		core.HistoricalKey{
+			ObjectType: core.MetricSetTypeNode,
+			NodeName:   "somenode1",
+		}: {"nm1", "nm2"},
+
+		core.HistoricalKey{
+			ObjectType:    core.MetricSetTypeNamespace,
+			NamespaceName: "somens1",
+		}: {"nsm1", "nsm2"},
+
+		core.HistoricalKey{
+			ObjectType:    core.MetricSetTypePod,
+			NamespaceName: "somens1",
+			PodName:       "somepod1",
+		}: {"pm1", "pm2"},
+
+		core.HistoricalKey{
+			ObjectType:    core.MetricSetTypePodContainer,
+			NamespaceName: "somens1",
+			PodName:       "somepod1",
+			ContainerName: "somecont1",
+		}: {"pcm1", "pcm2"},
+
+		core.HistoricalKey{
+			ObjectType:    core.MetricSetTypeSystemContainer,
+			NodeName:      "somenode1",
+			ContainerName: "somecont1",
+		}: {"ncm1", "ncm2"},
+	}
+
+	tests := []struct {
+		name          string
+		fun           func(request *restful.Request, response *restful.Response)
+		pathParams    map[string]string
+		expectedNames []string
+	}{
+		{
+			name:          "cluster metrics",
+			fun:           api.availableClusterMetrics,
+			pathParams:    map[string]string{},
+			expectedNames: []string{"cm1", "cm2"},
+		},
+		{
+			name:          "node metrics",
+			fun:           api.availableNodeMetrics,
+			pathParams:    map[string]string{"node-name": "somenode1"},
+			expectedNames: []string{"nm1", "nm2"},
+		},
+		{
+			name:          "namespace metrics",
+			fun:           api.availableNamespaceMetrics,
+			pathParams:    map[string]string{"namespace-name": "somens1"},
+			expectedNames: []string{"nsm1", "nsm2"},
+		},
+		{
+			name: "pod metrics",
+			fun:  api.availablePodMetrics,
+			pathParams: map[string]string{
+				"namespace-name": "somens1",
+				"pod-name":       "somepod1",
+			},
+			expectedNames: []string{"pm1", "pm2"},
+		},
+		{
+			name: "pod container metrics",
+			fun:  api.availablePodContainerMetrics,
+			pathParams: map[string]string{
+				"namespace-name": "somens1",
+				"pod-name":       "somepod1",
+				"container-name": "somecont1",
+			},
+			expectedNames: []string{"pcm1", "pcm2"},
+		},
+		{
+			name: "free container metrics",
+			fun:  api.availableFreeContainerMetrics,
+			pathParams: map[string]string{
+				"node-name":      "somenode1",
+				"container-name": "somecont1",
+			},
+			expectedNames: []string{"ncm1", "ncm2"},
+		},
+	}
+
+	assert := assert.New(t)
+	restful.DefaultResponseMimeType = restful.MIME_JSON
+
+	for _, test := range tests {
+		req := restful.NewRequest(&http.Request{})
+		pathParams := req.PathParameters()
+		for k, v := range test.pathParams {
+			pathParams[k] = v
+		}
+		recorder := &fakeRespRecorder{
+			data:    new(bytes.Buffer),
+			headers: make(http.Header),
+		}
+		resp := restful.NewResponse(recorder)
+
+		test.fun(req, resp)
+
+		actualNames := []string{}
+		if err := json.Unmarshal(recorder.data.Bytes(), &actualNames); err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		assert.Equal(http.StatusOK, recorder.status, "status should have been OK (200)")
+		assert.Equal(test.expectedNames, actualNames, "should have gotten expected JSON")
+	}
+
+	for _, test := range tests {
+		if len(test.pathParams) == 0 {
+			// don't test tests with no parameters for invalid parameters
+			continue
+		}
+		req := restful.NewRequest(&http.Request{})
+		pathParams := req.PathParameters()
+		for k := range test.pathParams {
+			pathParams[k] = "some-other-value"
+		}
+		recorder := &fakeRespRecorder{
+			data:    new(bytes.Buffer),
+			headers: make(http.Header),
+		}
+		resp := restful.NewResponse(recorder)
+
+		test.fun(req, resp)
+
+		assert.Equal(http.StatusInternalServerError, recorder.status, "status should have been InternalServerError (500)")
+	}
+}
+
+func TestListObjects(t *testing.T) {
+	api, src := prepApi()
+
+	src.nodes = []string{"node1", "node2"}
+	src.namespaces = []string{"ns1", "ns2"}
+	src.podsForNamespace = map[string][]string{
+		"ns1": {"pod1", "pod2"},
+	}
+	src.containersForNode = map[string][]string{
+		"node1": {"x/y/z", "a/b/c"},
+	}
+
+	tests := []struct {
+		name          string
+		fun           func(request *restful.Request, response *restful.Response)
+		pathParams    map[string]string
+		expectedNames []string
+	}{
+		{
+			name:          "nodes",
+			fun:           api.nodeList,
+			expectedNames: []string{"node1", "node2"},
+		},
+		{
+			name:          "namespaces",
+			fun:           api.namespaceList,
+			expectedNames: []string{"ns1", "ns2"},
+		},
+		{
+			name:          "pods in namespace",
+			fun:           api.namespacePodList,
+			pathParams:    map[string]string{"namespace-name": "ns1"},
+			expectedNames: []string{"pod1", "pod2"},
+		},
+		{
+			name: "free containers on node",
+			fun:  api.nodeSystemContainerList,
+			pathParams: map[string]string{
+				"node-name": "node1",
+			},
+			expectedNames: []string{"x/y/z", "a/b/c"},
+		},
+	}
+
+	assert := assert.New(t)
+	restful.DefaultResponseMimeType = restful.MIME_JSON
+
+	for _, test := range tests {
+		req := restful.NewRequest(&http.Request{})
+		pathParams := req.PathParameters()
+		for k, v := range test.pathParams {
+			pathParams[k] = v
+		}
+		recorder := &fakeRespRecorder{
+			data:    new(bytes.Buffer),
+			headers: make(http.Header),
+		}
+		resp := restful.NewResponse(recorder)
+
+		test.fun(req, resp)
+
+		actualNames := []string{}
+		if err := json.Unmarshal(recorder.data.Bytes(), &actualNames); err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		assert.Equal(http.StatusOK, recorder.status, "status should have been OK (200)")
+		assert.Equal(test.expectedNames, actualNames, "should have gotten expected JSON")
+	}
+
+	for _, test := range tests {
+		if len(test.pathParams) == 0 {
+			// don't test tests with no parameters for invalid parameters
+			continue
+		}
+		req := restful.NewRequest(&http.Request{})
+		pathParams := req.PathParameters()
+		for k := range test.pathParams {
+			pathParams[k] = "some-other-value"
+		}
+		recorder := &fakeRespRecorder{
+			data:    new(bytes.Buffer),
+			headers: make(http.Header),
+		}
+		resp := restful.NewResponse(recorder)
+
+		test.fun(req, resp)
+
+		assert.Equal(http.StatusInternalServerError, recorder.status, "status should have been InternalServerError (500)")
+	}
+}
+
+func TestFetchMetrics(t *testing.T) {
+	api, src := prepApi()
+	nowTime := time.Now().UTC().Truncate(time.Second)
+	src.nowTime = nowTime
+	nowFunc = func() time.Time { return nowTime }
+
+	tests := []struct {
+		test              string
+		start             string
+		end               string
+		fun               func(*restful.Request, *restful.Response)
+		pathParams        map[string]string
+		expectedMetricReq metricReq
+		expectedStatus    int
+	}{
+		{
+			test: "cluster metrics",
+			fun:  api.clusterMetrics,
+			pathParams: map[string]string{
+				"metric-name": "some-metric",
+			},
+			start: nowTime.Add(-10 * time.Second).Format(time.RFC3339),
+			expectedMetricReq: metricReq{
+				name:  "some-metric",
+				start: nowTime.Add(-10 * time.Second),
+				keys: []core.HistoricalKey{
+					{ObjectType: core.MetricSetTypeCluster},
+				},
+			},
+		},
+		{
+			test: "node metrics",
+			fun:  api.nodeMetrics,
+			pathParams: map[string]string{
+				"metric-name": "some-metric",
+				"node-name":   "node1",
+			},
+			start: nowTime.Add(-10 * time.Second).Format(time.RFC3339),
+			expectedMetricReq: metricReq{
+				name:  "some-metric",
+				start: nowTime.Add(-10 * time.Second),
+				keys: []core.HistoricalKey{
+					{ObjectType: core.MetricSetTypeNode, NodeName: "node1"},
+				},
+			},
+		},
+		{
+			test: "namespace metrics",
+			fun:  api.namespaceMetrics,
+			pathParams: map[string]string{
+				"metric-name":    "some-metric",
+				"namespace-name": "ns1",
+			},
+			start: nowTime.Add(-10 * time.Second).Format(time.RFC3339),
+			expectedMetricReq: metricReq{
+				name:  "some-metric",
+				start: nowTime.Add(-10 * time.Second),
+				keys: []core.HistoricalKey{
+					{ObjectType: core.MetricSetTypeNamespace, NamespaceName: "ns1"},
+				},
+			},
+		},
+		{
+			test: "pod name metrics",
+			fun:  api.podMetrics,
+			pathParams: map[string]string{
+				"metric-name":    "some-metric",
+				"namespace-name": "ns1",
+				"pod-name":       "pod1",
+			},
+			start: nowTime.Add(-10 * time.Second).Format(time.RFC3339),
+			expectedMetricReq: metricReq{
+				name:  "some-metric",
+				start: nowTime.Add(-10 * time.Second),
+				keys: []core.HistoricalKey{
+					{ObjectType: core.MetricSetTypePod, NamespaceName: "ns1", PodName: "pod1"},
+				},
+			},
+		},
+		{
+			test: "pod id metrics",
+			fun:  api.podMetrics,
+			pathParams: map[string]string{
+				"metric-name": "some-metric",
+				"pod-id":      "pod-1-id",
+			},
+			start: nowTime.Add(-10 * time.Second).Format(time.RFC3339),
+			expectedMetricReq: metricReq{
+				name:  "some-metric",
+				start: nowTime.Add(-10 * time.Second),
+				keys: []core.HistoricalKey{
+					{ObjectType: core.MetricSetTypePod, PodId: "pod-1-id"},
+				},
+			},
+		},
+		{
+			test: "pod name container metrics",
+			fun:  api.podContainerMetrics,
+			pathParams: map[string]string{
+				"metric-name":    "some-metric",
+				"namespace-name": "ns1",
+				"pod-name":       "pod1",
+				"container-name": "cont1",
+			},
+			start: nowTime.Add(-10 * time.Second).Format(time.RFC3339),
+			expectedMetricReq: metricReq{
+				name:  "some-metric",
+				start: nowTime.Add(-10 * time.Second),
+				keys: []core.HistoricalKey{
+					{ObjectType: core.MetricSetTypePodContainer, NamespaceName: "ns1", PodName: "pod1", ContainerName: "cont1"},
+				},
+			},
+		},
+		{
+			test: "pod id container metrics",
+			fun:  api.podContainerMetrics,
+			pathParams: map[string]string{
+				"metric-name":    "some-metric",
+				"pod-id":         "pod-1-id",
+				"container-name": "cont1",
+			},
+			start: nowTime.Add(-10 * time.Second).Format(time.RFC3339),
+			expectedMetricReq: metricReq{
+				name:  "some-metric",
+				start: nowTime.Add(-10 * time.Second),
+				keys: []core.HistoricalKey{
+					{ObjectType: core.MetricSetTypePodContainer, PodId: "pod-1-id", ContainerName: "cont1"},
+				},
+			},
+		},
+		{
+			test: "system container metrics",
+			fun:  api.freeContainerMetrics,
+			pathParams: map[string]string{
+				"metric-name":    "some-metric",
+				"node-name":      "node1",
+				"container-name": "cont1",
+			},
+			start: nowTime.Add(-10 * time.Second).Format(time.RFC3339),
+			expectedMetricReq: metricReq{
+				name:  "some-metric",
+				start: nowTime.Add(-10 * time.Second),
+				keys: []core.HistoricalKey{
+					{ObjectType: core.MetricSetTypeSystemContainer, NodeName: "node1", ContainerName: "cont1"},
+				},
+			},
+		},
+		{
+			test: "query with end",
+			fun:  api.clusterMetrics,
+			pathParams: map[string]string{
+				"metric-name": "some-metric",
+			},
+			start: nowTime.Add(-10 * time.Second).Format(time.RFC3339),
+			end:   nowTime.Format(time.RFC3339),
+			expectedMetricReq: metricReq{
+				name: "some-metric",
+				keys: []core.HistoricalKey{
+					{ObjectType: core.MetricSetTypeCluster},
+				},
+				start: nowTime.Add(-10 * time.Second),
+				end:   nowTime,
+			},
+		},
+		{
+			test:           "query with bad start",
+			fun:            api.clusterMetrics,
+			start:          "afdsfd",
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			test:           "query with no start",
+			fun:            api.clusterMetrics,
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			test:  "query with error while fetching metrics",
+			fun:   api.clusterMetrics,
+			start: nowTime.Add(-10 * time.Second).Format(time.RFC3339),
+			pathParams: map[string]string{
+				"metric-name": "invalid",
+			},
+			expectedStatus: http.StatusInternalServerError,
+		},
+	}
+
+	assert := assert.New(t)
+	restful.DefaultResponseMimeType = restful.MIME_JSON
+
+	// doesn't particularly correspond to the query -- we're just using it to
+	// test conversion between internal types
+	expectedNormalVals := types.MetricResult{
+		LatestTimestamp: nowTime.Add(-10 * time.Second),
+		Metrics: []types.MetricPoint{
+			{
+				Timestamp: nowTime.Add(-10 * time.Second),
+				Value:     33,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		queryParams := make(url.Values)
+		queryParams.Add("start", test.start)
+		queryParams.Add("end", test.end)
+		u := &url.URL{RawQuery: queryParams.Encode()}
+		req := restful.NewRequest(&http.Request{URL: u})
+		pathParams := req.PathParameters()
+		for k, v := range test.pathParams {
+			pathParams[k] = v
+		}
+		recorder := &fakeRespRecorder{
+			data:    new(bytes.Buffer),
+			headers: make(http.Header),
+		}
+		resp := restful.NewResponse(recorder)
+
+		test.fun(req, resp)
+
+		if test.expectedStatus != 0 {
+			assert.Equal(test.expectedStatus, recorder.status, "for test %q: status should have been an error status", test.test)
+		} else {
+			if !assert.Equal(http.StatusOK, recorder.status, "for test %q: status should have been OK (200)", test.test) {
+				continue
+			}
+
+			actualReq := src.metricRequests[len(src.metricRequests)-1]
+			if test.expectedMetricReq.end.IsZero() {
+				test.expectedMetricReq.end = nowTime
+			}
+			assert.Equal(test.expectedMetricReq, actualReq, "for test %q: expected a different metric request to have been placed", test.test)
+
+			actualVals := types.MetricResult{}
+			if err := json.Unmarshal(recorder.data.Bytes(), &actualVals); err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			assert.Equal(expectedNormalVals, actualVals, "for test %q: should have gotten expected JSON", test.test)
+		}
+	}
+
+	listTests := []struct {
+		test              string
+		start             string
+		end               string
+		fun               func(*restful.Request, *restful.Response)
+		pathParams        map[string]string
+		expectedMetricReq metricReq
+		expectedStatus    int
+	}{
+		{
+			test:  "pod list by ids",
+			fun:   api.podListMetrics,
+			start: nowTime.Add(-10 * time.Second).Format(time.RFC3339),
+			pathParams: map[string]string{
+				"metric-name": "some-metric",
+				"pod-id-list": "pod-id-1,pod-id-2,pod-id-3",
+			},
+			expectedMetricReq: metricReq{
+				name: "some-metric",
+				keys: []core.HistoricalKey{
+					{ObjectType: core.MetricSetTypePod, PodId: "pod-id-1"},
+					{ObjectType: core.MetricSetTypePod, PodId: "pod-id-2"},
+					{ObjectType: core.MetricSetTypePod, PodId: "pod-id-3"},
+				},
+				start: nowTime.Add(-10 * time.Second),
+			},
+		},
+		{
+			test:  "pod list by names",
+			fun:   api.podListMetrics,
+			start: nowTime.Add(-10 * time.Second).Format(time.RFC3339),
+			pathParams: map[string]string{
+				"metric-name":    "some-metric",
+				"namespace-name": "ns1",
+				"pod-list":       "pod1,pod2,pod3",
+			},
+			expectedMetricReq: metricReq{
+				name: "some-metric",
+				keys: []core.HistoricalKey{
+					{ObjectType: core.MetricSetTypePod, NamespaceName: "ns1", PodName: "pod1"},
+					{ObjectType: core.MetricSetTypePod, NamespaceName: "ns1", PodName: "pod2"},
+					{ObjectType: core.MetricSetTypePod, NamespaceName: "ns1", PodName: "pod3"},
+				},
+				start: nowTime.Add(-10 * time.Second),
+			},
+		},
+		{
+			test:           "pod list with bad start time",
+			fun:            api.podListMetrics,
+			start:          "afdsfd",
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			test:  "pod list with error fetching metrics",
+			fun:   api.podListMetrics,
+			start: nowTime.Add(-10 * time.Second).Format(time.RFC3339),
+			pathParams: map[string]string{
+				"metric-name": "invalid",
+			},
+			expectedStatus: http.StatusInternalServerError,
+		},
+		{
+			test:           "pod list with no start",
+			fun:            api.podListMetrics,
+			expectedStatus: http.StatusBadRequest,
+		},
+	}
+
+	expectedListVals := types.MetricResultList{
+		Items: []types.MetricResult{
+			expectedNormalVals,
+			expectedNormalVals,
+			expectedNormalVals,
+		},
+	}
+
+	for _, test := range listTests {
+		queryParams := make(url.Values)
+		queryParams.Add("start", test.start)
+		queryParams.Add("end", test.end)
+		u := &url.URL{RawQuery: queryParams.Encode()}
+		req := restful.NewRequest(&http.Request{URL: u})
+		pathParams := req.PathParameters()
+		for k, v := range test.pathParams {
+			pathParams[k] = v
+		}
+		recorder := &fakeRespRecorder{
+			data:    new(bytes.Buffer),
+			headers: make(http.Header),
+		}
+		resp := restful.NewResponse(recorder)
+
+		test.fun(req, resp)
+
+		if test.expectedStatus != 0 {
+			assert.Equal(test.expectedStatus, recorder.status, "for test %q: status should have been an error status", test.test)
+		} else {
+			if !assert.Equal(http.StatusOK, recorder.status, "for test %q: status should have been OK (200)", test.test) {
+				continue
+			}
+
+			actualReq := src.metricRequests[len(src.metricRequests)-1]
+			if test.expectedMetricReq.end.IsZero() {
+				test.expectedMetricReq.end = nowTime
+			}
+
+			assert.Equal(test.expectedMetricReq, actualReq, "for test %q: expected a different metric request to have been placed", test.test)
+
+			actualVals := types.MetricResultList{}
+			if err := json.Unmarshal(recorder.data.Bytes(), &actualVals); err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			assert.Equal(expectedListVals, actualVals, "for test %q: should have gotten expected JSON", test.test)
+		}
+	}
+}
+
+func TestFetchAggregations(t *testing.T) {
+	api, src := prepApi()
+	nowTime := time.Now().UTC().Truncate(time.Second)
+	src.nowTime = nowTime
+	nowFunc = func() time.Time { return nowTime }
+
+	tests := []struct {
+		test              string
+		bucketSize        string
+		start             string
+		end               string
+		fun               func(*restful.Request, *restful.Response)
+		pathParams        map[string]string
+		expectedMetricReq metricReq
+		expectedStatus    int
+	}{
+		{
+			test:  "cluster aggregations",
+			fun:   api.clusterAggregations,
+			start: nowTime.Add(-10 * time.Second).Format(time.RFC3339),
+			pathParams: map[string]string{
+				"metric-name":  "some-metric",
+				"aggregations": "count,average",
+			},
+			expectedMetricReq: metricReq{
+				name:  "some-metric",
+				start: nowTime.Add(-10 * time.Second),
+				keys: []core.HistoricalKey{
+					{ObjectType: core.MetricSetTypeCluster},
+				},
+			},
+		},
+		{
+			test:  "node aggregations",
+			fun:   api.nodeAggregations,
+			start: nowTime.Add(-10 * time.Second).Format(time.RFC3339),
+			pathParams: map[string]string{
+				"metric-name":  "some-metric",
+				"node-name":    "node1",
+				"aggregations": "count,average",
+			},
+			expectedMetricReq: metricReq{
+				name:  "some-metric",
+				start: nowTime.Add(-10 * time.Second),
+				keys: []core.HistoricalKey{
+					{ObjectType: core.MetricSetTypeNode, NodeName: "node1"},
+				},
+			},
+		},
+		{
+			test:  "namespace aggregations",
+			fun:   api.namespaceAggregations,
+			start: nowTime.Add(-10 * time.Second).Format(time.RFC3339),
+			pathParams: map[string]string{
+				"metric-name":    "some-metric",
+				"namespace-name": "ns1",
+				"aggregations":   "count,average",
+			},
+			expectedMetricReq: metricReq{
+				name:  "some-metric",
+				start: nowTime.Add(-10 * time.Second),
+				keys: []core.HistoricalKey{
+					{ObjectType: core.MetricSetTypeNamespace, NamespaceName: "ns1"},
+				},
+			},
+		},
+		{
+			test:  "pod name aggregations",
+			fun:   api.podAggregations,
+			start: nowTime.Add(-10 * time.Second).Format(time.RFC3339),
+			pathParams: map[string]string{
+				"metric-name":    "some-metric",
+				"namespace-name": "ns1",
+				"pod-name":       "pod1",
+				"aggregations":   "count,average",
+			},
+			expectedMetricReq: metricReq{
+				name:  "some-metric",
+				start: nowTime.Add(-10 * time.Second),
+				keys: []core.HistoricalKey{
+					{ObjectType: core.MetricSetTypePod, NamespaceName: "ns1", PodName: "pod1"},
+				},
+			},
+		},
+		{
+			test:  "pod id aggregations",
+			fun:   api.podAggregations,
+			start: nowTime.Add(-10 * time.Second).Format(time.RFC3339),
+			pathParams: map[string]string{
+				"metric-name":  "some-metric",
+				"pod-id":       "pod-1-id",
+				"aggregations": "count,average",
+			},
+			expectedMetricReq: metricReq{
+				name:  "some-metric",
+				start: nowTime.Add(-10 * time.Second),
+				keys: []core.HistoricalKey{
+					{ObjectType: core.MetricSetTypePod, PodId: "pod-1-id"},
+				},
+			},
+		},
+		{
+			test:  "pod name container aggregations",
+			fun:   api.podContainerAggregations,
+			start: nowTime.Add(-10 * time.Second).Format(time.RFC3339),
+			pathParams: map[string]string{
+				"metric-name":    "some-metric",
+				"namespace-name": "ns1",
+				"pod-name":       "pod1",
+				"container-name": "cont1",
+				"aggregations":   "count,average",
+			},
+			expectedMetricReq: metricReq{
+				name:  "some-metric",
+				start: nowTime.Add(-10 * time.Second),
+				keys: []core.HistoricalKey{
+					{ObjectType: core.MetricSetTypePodContainer, NamespaceName: "ns1", PodName: "pod1", ContainerName: "cont1"},
+				},
+			},
+		},
+		{
+			test:  "pod id container aggregations",
+			fun:   api.podContainerAggregations,
+			start: nowTime.Add(-10 * time.Second).Format(time.RFC3339),
+			pathParams: map[string]string{
+				"metric-name":    "some-metric",
+				"pod-id":         "pod-1-id",
+				"container-name": "cont1",
+				"aggregations":   "count,average",
+			},
+			expectedMetricReq: metricReq{
+				name:  "some-metric",
+				start: nowTime.Add(-10 * time.Second),
+				keys: []core.HistoricalKey{
+					{ObjectType: core.MetricSetTypePodContainer, PodId: "pod-1-id", ContainerName: "cont1"},
+				},
+			},
+		},
+		{
+			test:  "system container aggregations",
+			fun:   api.freeContainerAggregations,
+			start: nowTime.Add(-10 * time.Second).Format(time.RFC3339),
+			pathParams: map[string]string{
+				"metric-name":    "some-metric",
+				"node-name":      "node1",
+				"container-name": "cont1",
+				"aggregations":   "count,average",
+			},
+			expectedMetricReq: metricReq{
+				name:  "some-metric",
+				start: nowTime.Add(-10 * time.Second),
+				keys: []core.HistoricalKey{
+					{ObjectType: core.MetricSetTypeSystemContainer, NodeName: "node1", ContainerName: "cont1"},
+				},
+			},
+		},
+		{
+			test: "aggregations with end and bucket",
+			fun:  api.clusterAggregations,
+			pathParams: map[string]string{
+				"metric-name":  "some-metric",
+				"aggregations": "count,average",
+			},
+			start:      nowTime.Add(-10 * time.Second).Format(time.RFC3339),
+			end:        nowTime.Format(time.RFC3339),
+			bucketSize: "20s",
+			expectedMetricReq: metricReq{
+				name: "some-metric",
+				keys: []core.HistoricalKey{
+					{ObjectType: core.MetricSetTypeCluster},
+				},
+				start:      nowTime.Add(-10 * time.Second),
+				end:        nowTime,
+				bucketSize: 20 * time.Second,
+			},
+		},
+		{
+			test:           "aggregations with bad start time",
+			fun:            api.clusterAggregations,
+			start:          "afdsfd",
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			test:  "aggregations with fetch error",
+			fun:   api.clusterAggregations,
+			start: nowTime.Add(-10 * time.Second).Format(time.RFC3339),
+			pathParams: map[string]string{
+				"metric-name":  "invalid",
+				"aggregations": "count,average",
+			},
+			expectedStatus: http.StatusInternalServerError,
+		},
+		{
+			test:           "aggregations with no start time",
+			fun:            api.clusterAggregations,
+			expectedStatus: http.StatusBadRequest,
+		},
+	}
+
+	assert := assert.New(t)
+	restful.DefaultResponseMimeType = restful.MIME_JSON
+
+	// doesn't particularly correspond to the query -- we're just using it to
+	// test conversion between internal types
+	countVal := uint64(10)
+	expectedNormalVals := types.MetricAggregationResult{
+		BucketSize: 10 * time.Second,
+		Buckets: []types.MetricAggregationBucket{
+			{
+				Timestamp: src.nowTime.Add(-10 * time.Second),
+				Count:     &countVal,
+			},
+		},
+	}
+
+	aggList := []core.AggregationType{
+		core.AggregationTypeCount,
+		core.AggregationTypeAverage,
+	}
+
+	for _, test := range tests {
+		queryParams := make(url.Values)
+		queryParams.Add("start", test.start)
+		queryParams.Add("end", test.end)
+		queryParams.Add("bucket", test.bucketSize)
+		u := &url.URL{RawQuery: queryParams.Encode()}
+		req := restful.NewRequest(&http.Request{URL: u})
+		pathParams := req.PathParameters()
+		for k, v := range test.pathParams {
+			pathParams[k] = v
+		}
+		recorder := &fakeRespRecorder{
+			data:    new(bytes.Buffer),
+			headers: make(http.Header),
+		}
+		resp := restful.NewResponse(recorder)
+
+		test.fun(req, resp)
+
+		if test.expectedStatus != 0 {
+			assert.Equal(test.expectedStatus, recorder.status, "for test %q: status should have been an error status", test.test)
+		} else {
+			if !assert.Equal(http.StatusOK, recorder.status, "for test %q: status should have been OK (200)", test.test) {
+				continue
+			}
+
+			actualReq := src.metricRequests[len(src.metricRequests)-1]
+			if test.expectedMetricReq.end.IsZero() {
+				test.expectedMetricReq.end = nowTime
+			}
+
+			test.expectedMetricReq.aggregations = aggList
+			assert.Equal(test.expectedMetricReq, actualReq, "for test %q: expected a different metric request to have been placed", test.test)
+
+			actualVals := types.MetricAggregationResult{}
+			if err := json.Unmarshal(recorder.data.Bytes(), &actualVals); err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			assert.Equal(expectedNormalVals, actualVals, "for test %q: should have gotten expected JSON", test.test)
+		}
+	}
+
+	listTests := []struct {
+		test              string
+		start             string
+		end               string
+		fun               func(*restful.Request, *restful.Response)
+		pathParams        map[string]string
+		expectedMetricReq metricReq
+		expectedStatus    int
+	}{
+		{
+			test:  "pod id list aggregations",
+			fun:   api.podListAggregations,
+			start: nowTime.Add(-10 * time.Second).Format(time.RFC3339),
+			pathParams: map[string]string{
+				"metric-name":  "some-metric",
+				"pod-id-list":  "pod-id-1,pod-id-2,pod-id-3",
+				"aggregations": "count,average",
+			},
+			expectedMetricReq: metricReq{
+				name: "some-metric",
+				keys: []core.HistoricalKey{
+					{ObjectType: core.MetricSetTypePod, PodId: "pod-id-1"},
+					{ObjectType: core.MetricSetTypePod, PodId: "pod-id-2"},
+					{ObjectType: core.MetricSetTypePod, PodId: "pod-id-3"},
+				},
+				start: nowTime.Add(-10 * time.Second),
+			},
+		},
+		{
+			test:  "pod name list aggregations",
+			fun:   api.podListAggregations,
+			start: nowTime.Add(-10 * time.Second).Format(time.RFC3339),
+			pathParams: map[string]string{
+				"metric-name":    "some-metric",
+				"namespace-name": "ns1",
+				"pod-list":       "pod1,pod2,pod3",
+				"aggregations":   "count,average",
+			},
+			expectedMetricReq: metricReq{
+				name: "some-metric",
+				keys: []core.HistoricalKey{
+					{ObjectType: core.MetricSetTypePod, NamespaceName: "ns1", PodName: "pod1"},
+					{ObjectType: core.MetricSetTypePod, NamespaceName: "ns1", PodName: "pod2"},
+					{ObjectType: core.MetricSetTypePod, NamespaceName: "ns1", PodName: "pod3"},
+				},
+				start: nowTime.Add(-10 * time.Second),
+			},
+		},
+		{
+			test:           "pod list aggregations with bad start time",
+			fun:            api.podListAggregations,
+			start:          "afdsfd",
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			test:  "pod list aggregations with fetch error",
+			fun:   api.podListAggregations,
+			start: nowTime.Add(-10 * time.Second).Format(time.RFC3339),
+			pathParams: map[string]string{
+				"metric-name":  "invalid",
+				"aggregations": "count,average",
+			},
+			expectedStatus: http.StatusInternalServerError,
+		},
+		{
+			test:           "pod list aggregations with no start time",
+			fun:            api.podListAggregations,
+			expectedStatus: http.StatusBadRequest,
+		},
+	}
+
+	expectedListVals := types.MetricAggregationResultList{
+		Items: []types.MetricAggregationResult{
+			expectedNormalVals,
+			expectedNormalVals,
+			expectedNormalVals,
+		},
+	}
+
+	for _, test := range listTests {
+		queryParams := make(url.Values)
+		queryParams.Add("start", test.start)
+		queryParams.Add("end", test.end)
+		u := &url.URL{RawQuery: queryParams.Encode()}
+		req := restful.NewRequest(&http.Request{URL: u})
+		pathParams := req.PathParameters()
+		for k, v := range test.pathParams {
+			pathParams[k] = v
+		}
+		recorder := &fakeRespRecorder{
+			data:    new(bytes.Buffer),
+			headers: make(http.Header),
+		}
+		resp := restful.NewResponse(recorder)
+
+		test.fun(req, resp)
+
+		if test.expectedStatus != 0 {
+			assert.Equal(test.expectedStatus, recorder.status, "for test %q: status should have been an error status", test.test)
+		} else {
+			if !assert.Equal(http.StatusOK, recorder.status, "for test %q: status should have been OK (200)", test.test) {
+				continue
+			}
+
+			actualReq := src.metricRequests[len(src.metricRequests)-1]
+			if test.expectedMetricReq.end.IsZero() {
+				test.expectedMetricReq.end = nowTime
+			}
+			test.expectedMetricReq.aggregations = aggList
+			assert.Equal(test.expectedMetricReq, actualReq, "for test %q: expected a different metric request to have been placed", test.test)
+
+			actualVals := types.MetricAggregationResultList{}
+			if err := json.Unmarshal(recorder.data.Bytes(), &actualVals); err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			assert.Equal(expectedListVals, actualVals, "for test %q: should have gotten expected JSON", test.test)
+		}
+	}
+}
+
+func TestGetBucketSize(t *testing.T) {
+	tests := []struct {
+		sizeParam        string
+		expectedDuration time.Duration
+		expectedError    bool
+	}{
+		{
+			// empty duration
+			sizeParam:        "",
+			expectedDuration: 0,
+		},
+		{
+			// no units
+			sizeParam:     "1",
+			expectedError: true,
+		},
+		{
+			// unknown unit
+			sizeParam:     "1g",
+			expectedError: true,
+		},
+		{
+			// invalid unit (looks like ms)
+			sizeParam:     "10gs",
+			expectedError: true,
+		},
+		{
+			// NaN
+			sizeParam:     "abch",
+			expectedError: true,
+		},
+		{
+			sizeParam:        "5ms",
+			expectedDuration: 5 * time.Millisecond,
+		},
+		{
+			sizeParam:        "10s",
+			expectedDuration: 10 * time.Second,
+		},
+		{
+			sizeParam:        "15m",
+			expectedDuration: 15 * time.Minute,
+		},
+		{
+			sizeParam:        "20h",
+			expectedDuration: 20 * time.Hour,
+		},
+		{
+			sizeParam:        "25d",
+			expectedDuration: 600 * time.Hour,
+		},
+	}
+
+	assert := assert.New(t)
+	for _, test := range tests {
+		u, err := url.Parse(fmt.Sprintf("/foo?bucket=%s", test.sizeParam))
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		req := restful.NewRequest(&http.Request{URL: u})
+		res, err := getBucketSize(req)
+		if test.expectedError {
+			assert.Error(err, fmt.Sprintf("%q should have been an invalid value", test.sizeParam))
+		} else if assert.NoError(err, fmt.Sprintf("%q should have been a valid value", test.sizeParam)) {
+			assert.Equal(test.expectedDuration, res, fmt.Sprintf("%q should have given the correct duration", test.sizeParam))
+		}
+	}
+}
+
+func TestGetAggregations(t *testing.T) {
+	assert := assert.New(t)
+
+	validAggregations := "average,max"
+	invalidAggregations := "max,non-existant"
+
+	req := restful.NewRequest(&http.Request{})
+	pathParams := req.PathParameters()
+	pathParams["aggregations"] = validAggregations
+
+	validRes, validErr := getAggregations(req)
+	if assert.NoError(validErr, "expected valid list to not produce an error") {
+		assert.Equal([]core.AggregationType{core.AggregationTypeAverage, core.AggregationTypeMaximum}, validRes, "expected valid list to be properly split and converted to AggregationType values")
+	}
+
+	pathParams["aggregations"] = invalidAggregations
+	_, invalidErr := getAggregations(req)
+	assert.Error(invalidErr, "expected list with unknown aggregations to produce an error")
+}
+
+func TestExportMetricValue(t *testing.T) {
+	assert := assert.New(t)
+
+	assert.Nil(exportMetricValue(nil), "a nil input value should yield a nil output value")
+
+	intVal := &core.MetricValue{
+		IntValue:  33,
+		ValueType: core.ValueInt64,
+	}
+	outputIntVal := exportMetricValue(intVal)
+	if assert.NotNil(outputIntVal, "a non-nil input should yield a non-nil output") && assert.NotNil(outputIntVal.IntValue, "an int-valued input should yield an output with the IntValue set") {
+		assert.Equal(intVal.IntValue, *outputIntVal.IntValue, "the input int value should be the same as the output int value")
+	}
+
+	floatVal := &core.MetricValue{
+		FloatValue: 66.0,
+		ValueType:  core.ValueFloat,
+	}
+	outputFloatVal := exportMetricValue(floatVal)
+	if assert.NotNil(outputFloatVal, "a non-nil input should yield a non-nil output") && assert.NotNil(outputFloatVal.FloatValue, "an float-valued input should yield an output with the FloatValue set") {
+		assert.Equal(float64(floatVal.FloatValue), *outputFloatVal.FloatValue, "the input float value should be the same as the output float value (as a float64)")
+	}
+}
+
+func TestExtractMetricValue(t *testing.T) {
+	assert := assert.New(t)
+
+	aggregationVal := &core.AggregationValue{
+		Aggregations: map[core.AggregationType]core.MetricValue{
+			core.AggregationTypeAverage: {
+				FloatValue: 66.0,
+				ValueType:  core.ValueFloat,
+			},
+		},
+	}
+
+	avgRes := extractMetricValue(aggregationVal, core.AggregationTypeAverage)
+	if assert.NotNil(avgRes, "a present aggregation should yield a non-nil output") && assert.NotNil(avgRes.FloatValue, "the output float value should be set when the input aggregation value is of the float type") {
+		assert.Equal(66.0, *avgRes.FloatValue, "the output float value should be the same as the aggregation's float value")
+	}
+
+	maxRes := extractMetricValue(aggregationVal, core.AggregationTypeMaximum)
+	assert.Nil(maxRes, "a non-present aggregation should yield a nil output")
+}
+
+func TestExportTimestampedAggregationValue(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+	nowTime := time.Now().UTC()
+
+	count10 := uint64(10)
+	count11 := uint64(11)
+	values := []core.TimestampedAggregationValue{
+		{
+			Timestamp:  nowTime.Add(-20 * time.Second),
+			BucketSize: 10 * time.Second,
+			AggregationValue: core.AggregationValue{
+				Count: &count10,
+				Aggregations: map[core.AggregationType]core.MetricValue{
+					core.AggregationTypeAverage: {
+						FloatValue: 66.0,
+						ValueType:  core.ValueFloat,
+					},
+					core.AggregationTypePercentile50: {
+						IntValue:  44,
+						ValueType: core.ValueInt64,
+					},
+				},
+			},
+		},
+		{
+			Timestamp:  nowTime.Add(-10 * time.Second),
+			BucketSize: 10 * time.Second,
+			AggregationValue: core.AggregationValue{
+				Count: &count11,
+				Aggregations: map[core.AggregationType]core.MetricValue{
+					core.AggregationTypeAverage: {
+						FloatValue: 88.0,
+						ValueType:  core.ValueFloat,
+					},
+					core.AggregationTypePercentile50: {
+						IntValue:  55,
+						ValueType: core.ValueInt64,
+					},
+				},
+			},
+		},
+	}
+
+	res := exportTimestampedAggregationValue(values)
+
+	assert.Equal(10*time.Second, res.BucketSize, "the output bucket size should be 10s")
+	require.Equal(len(values), len(res.Buckets), "there should be an output bucket for every input value")
+
+	for i, bucket := range res.Buckets {
+		inputVal := values[i]
+
+		assert.Equal(inputVal.Count, bucket.Count, "the output bucket should have the same sample count as the input value")
+
+		if assert.NotNil(bucket.Average, "the output bucket should have the average set") {
+			metricVal := inputVal.Aggregations[core.AggregationTypeAverage]
+			assert.Equal(exportMetricValue(&metricVal), bucket.Average, "the output bucket should have an average value equal to that of the input value")
+		}
+
+		percVal, ok := bucket.Percentiles["50"]
+		if assert.True(ok, "the output bucket should have the 50th percentile set") {
+			metricVal := inputVal.Aggregations[core.AggregationTypePercentile50]
+			assert.Equal(exportMetricValue(&metricVal), &percVal, "the output bucket should have a 50th-percentile value equal to that of the input value")
+		}
+	}
+}

--- a/metrics/api/v1/types/historical_types.go
+++ b/metrics/api/v1/types/historical_types.go
@@ -1,0 +1,49 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"time"
+)
+
+// MetricValue is either a floating point value or an unsigned integer value
+type MetricValue struct {
+	IntValue   *int64   `json:"intValue,omitempty"`
+	FloatValue *float64 `json:"floatValue,omitempty"`
+}
+
+// MetricAggregationBucket holds information about various aggregations across a single bucket of time
+type MetricAggregationBucket struct {
+	Timestamp time.Time `json:"timestamp"`
+	Count     *uint64   `json:"count,omitempty"`
+
+	Average *MetricValue `json:"average,omitempty"`
+	Maximum *MetricValue `json:"maximum,omitempty"`
+	Minimum *MetricValue `json:"minimum,omitempty"`
+	Median  *MetricValue `json:"median,omitempty"`
+
+	Percentiles map[string]MetricValue `json:"percentiles,omitempty"`
+}
+
+// MetricAggregationResult holds a series of MetricAggregationBuckets of a particular size
+type MetricAggregationResult struct {
+	Buckets    []MetricAggregationBucket `json:"buckets"`
+	BucketSize time.Duration             `json:"bucketSize"`
+}
+
+// MetricAggregationResultList is a list of MetricAggregationResults, each for a different object
+type MetricAggregationResultList struct {
+	Items []MetricAggregationResult `json:"items"`
+}

--- a/metrics/core/historical_types.go
+++ b/metrics/core/historical_types.go
@@ -1,0 +1,164 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package core
+
+import (
+	"fmt"
+	"time"
+)
+
+type AggregationType string
+
+var (
+	AggregationTypeAverage      AggregationType = "average"
+	AggregationTypeMaximum      AggregationType = "max"
+	AggregationTypeMinimum      AggregationType = "min"
+	AggregationTypeMedian       AggregationType = "median"
+	AggregationTypeCount        AggregationType = "count"
+	AggregationTypePercentile50 AggregationType = "50-perc"
+	AggregationTypePercentile95 AggregationType = "95-perc"
+	AggregationTypePercentile99 AggregationType = "99-perc"
+)
+
+// MultiTypedAggregations is the list of aggregations that can be either float or int
+var MultiTypedAggregations = []AggregationType{
+	AggregationTypeAverage,
+	AggregationTypeMaximum,
+	AggregationTypeMinimum,
+	AggregationTypeMedian,
+	AggregationTypePercentile50,
+	AggregationTypePercentile95,
+	AggregationTypePercentile99,
+}
+
+// AllAggregations is the set of all supported aggregations
+var AllAggregations = map[AggregationType]bool{
+	AggregationTypeAverage:      true,
+	AggregationTypeMaximum:      true,
+	AggregationTypeMinimum:      true,
+	AggregationTypeMedian:       true,
+	AggregationTypePercentile50: true,
+	AggregationTypePercentile95: true,
+	AggregationTypePercentile99: true,
+	AggregationTypeCount:        true,
+}
+
+// TimestampedMetricValue is a metric value with an associated timestamp
+type TimestampedMetricValue struct {
+	MetricValue
+	Timestamp time.Time
+}
+
+// AggregationValue is a description of aggregated MetricValues over time
+type AggregationValue struct {
+	Count *uint64
+
+	Aggregations map[AggregationType]MetricValue
+}
+
+// TimestampedAggregationValue is an aggregation value with an associated timestamp
+// and bucket size
+type TimestampedAggregationValue struct {
+	// Timestamp is the start time of the bucket
+	Timestamp time.Time
+
+	// BucketSize is the duration of the bucket
+	BucketSize time.Duration
+
+	AggregationValue
+}
+
+// HistoricalKey is an identifier pointing to a particular object.
+// Is is composed of an object type (pod, namespace, container, etc) as well
+// as a series of fields which identify that object.
+type HistoricalKey struct {
+	// ObjectType specifies which type of object this is for (pod, namespace, etc)
+	// It should be one of the MetricSetType* labels.
+	ObjectType string
+
+	// NodeName is used for node and system-container metrics
+	NodeName string
+	// NamespaceName is used for namespace, pod, and pod-container metrics
+	NamespaceName string
+	// PodName is used for pod and pod-container metrics
+	PodName string
+	// ContainerName is used for system-container and pod-container metrics
+	ContainerName string
+	// PodId may be used in place of the combination of PodName and NamespaceName for pod and pod-container metrics
+	PodId string
+}
+
+func (key *HistoricalKey) String() string {
+	prefix := fmt.Sprintf("(%s)", key.ObjectType)
+
+	var path string = "[unknown type]"
+	switch key.ObjectType {
+	case MetricSetTypeSystemContainer:
+		path = fmt.Sprintf("node:%s/container:%s", key.NodeName, key.ContainerName)
+	case MetricSetTypePodContainer:
+		if key.PodId != "" {
+			path = fmt.Sprintf("poduid:%s/container:%s", key.PodId, key.ContainerName)
+		} else {
+			path = fmt.Sprintf("ns:%s/pod:%s/container:%s", key.NamespaceName, key.PodName, key.ContainerName)
+		}
+	case MetricSetTypePod:
+		if key.PodId != "" {
+			path = fmt.Sprintf("poduid:%s", key.PodId)
+		} else {
+			path = fmt.Sprintf("ns:%s/pod:%s", key.NamespaceName, key.PodName)
+		}
+	case MetricSetTypeNamespace:
+		path = fmt.Sprintf("ns:%s", key.NamespaceName)
+	case MetricSetTypeNode:
+		path = fmt.Sprintf("node:%s", key.NodeName)
+	case MetricSetTypeCluster:
+		path = "[cluster]"
+	}
+
+	return prefix + path
+}
+
+// HistoricalSource allows for retrieval of historical metrics and aggregations from sinks
+type HistoricalSource interface {
+	// GetMetric retrieves the given metric for one or more objects (specified by metricKeys) of
+	// the same type, within the given time interval.  A start time of zero indicates no starting bound,
+	// while an end time of zero indicates no ending bound.
+	GetMetric(metricName string, metricKeys []HistoricalKey, start, end time.Time) (map[HistoricalKey][]TimestampedMetricValue, error)
+
+	// GetAggregation fetches the given aggregations for one or more objects (specified by metricKeys) of
+	// the same type, within the given time interval, calculated over a series of buckets.  The start time,
+	// end time, and bucket size may be zero.  A start time of zero indicates no starting bound, while and
+	// end time of zero indicates no ending bound (effectively meaning up to the latest metrics, but not metrics
+	// from the future).  A bucket size of zero indicates that only a single bucket spanning the entire specified
+	// time range should be returned.
+	GetAggregation(metricName string, aggregations []AggregationType, metricKeys []HistoricalKey, start, end time.Time, bucketSize time.Duration) (map[HistoricalKey][]TimestampedAggregationValue, error)
+
+	// GetMetricNames retrieves the available metric names for the given object
+	GetMetricNames(metricKey HistoricalKey) ([]string, error)
+
+	// GetNodes retrieves the list of nodes in the cluster
+	GetNodes() ([]string, error)
+	// GetNamespaces retrieves the list of namespaces in the cluster
+	GetNamespaces() ([]string, error)
+	// GetPodsFromNamespace retrieves the list of pods in a given namespace
+	GetPodsFromNamespace(namespace string) ([]string, error)
+	// GetSystemContainersFromNode retrieves the list of free containers for a given node
+	GetSystemContainersFromNode(node string) ([]string, error)
+}
+
+// AsHistoricalSource represents sinks which support a historical access interface
+type AsHistoricalSource interface {
+	// Historical returns the historical data access interface for this sink
+	Historical() HistoricalSource
+}

--- a/metrics/handlers.go
+++ b/metrics/handlers.go
@@ -22,6 +22,7 @@ import (
 	restful "github.com/emicklei/go-restful"
 	"k8s.io/heapster/metrics/api/v1"
 	metricsApi "k8s.io/heapster/metrics/apis/metrics"
+	"k8s.io/heapster/metrics/core"
 	"k8s.io/heapster/metrics/sinks/metric"
 	"k8s.io/heapster/metrics/util/metrics"
 
@@ -30,7 +31,7 @@ import (
 
 const pprofBasePath = "/debug/pprof/"
 
-func setupHandlers(metricSink *metricsink.MetricSink, podLister *cache.StoreToPodLister) http.Handler {
+func setupHandlers(metricSink *metricsink.MetricSink, podLister *cache.StoreToPodLister, historicalSource core.HistoricalSource) http.Handler {
 
 	runningInKubernetes := true
 
@@ -38,7 +39,7 @@ func setupHandlers(metricSink *metricsink.MetricSink, podLister *cache.StoreToPo
 	wsContainer := restful.NewContainer()
 	wsContainer.EnableContentEncoding(true)
 	wsContainer.Router(restful.CurlyRouter{})
-	a := v1.NewApi(runningInKubernetes, metricSink)
+	a := v1.NewApi(runningInKubernetes, metricSink, historicalSource)
 	a.Register(wsContainer)
 	// Metrics API
 	m := metricsApi.NewApi(metricSink, podLister)

--- a/metrics/sinks/influxdb/influxdb_historical.go
+++ b/metrics/sinks/influxdb/influxdb_historical.go
@@ -1,0 +1,571 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package influxdb
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"k8s.io/heapster/metrics/core"
+
+	"github.com/golang/glog"
+	influxdb "github.com/influxdata/influxdb/client"
+	influx_models "github.com/influxdata/influxdb/models"
+)
+
+// Historical indicates that this sink supports being used as a HistoricalSource
+func (sink *influxdbSink) Historical() core.HistoricalSource {
+	return sink
+}
+
+// implementation of HistoricalSource for influxdbSink
+
+// Kube pod and namespace names are limitted to [a-zA-Z0-9-.], while docker also allows
+// underscores, so only allow these those characters.  When Influx actually supports bound
+// paramaters, this will be less necessary.
+var nameAllowedChars = regexp.MustCompile("^[a-zA-Z0-9_.-]+$")
+
+// metric names are restricted to prevent injection attacks
+var metricAllowedChars = regexp.MustCompile("^[a-zA-Z0-9_./:-]+$")
+
+// checkSanitizedKey errors out if invalid characters are found in the key, since InfluxDB does not widely
+// support bound parameters yet (see https://github.com/influxdata/influxdb/pull/6634) and we need to
+// sanitize our inputs.
+func (sink *influxdbSink) checkSanitizedKey(key *core.HistoricalKey) error {
+	if key.NodeName != "" && !nameAllowedChars.MatchString(key.NodeName) {
+		return fmt.Errorf("Invalid node name %q", key.NodeName)
+	}
+
+	if key.NamespaceName != "" && !nameAllowedChars.MatchString(key.NamespaceName) {
+		return fmt.Errorf("Invalid namespace name %q", key.NamespaceName)
+	}
+
+	if key.PodName != "" && !nameAllowedChars.MatchString(key.PodName) {
+		return fmt.Errorf("Invalid pod name %q", key.PodName)
+	}
+
+	// NB: this prevents access to some of the free containers with slashes in their name
+	// (e.g. system.slice/foo.bar), but the Heapster API seems to choke on the slashes anyway
+	if key.ContainerName != "" && !nameAllowedChars.MatchString(key.ContainerName) {
+		return fmt.Errorf("Invalid container name %q", key.ContainerName)
+	}
+
+	if key.PodId != "" && !nameAllowedChars.MatchString(key.PodId) {
+		return fmt.Errorf("Invalid pod id %q", key.PodId)
+	}
+
+	return nil
+}
+
+// checkSanitizedMetricName errors out if invalid characters are found in the metric name, since InfluxDB
+// does not widely support bound parameters yet, and we need to sanitize our inputs.
+func (sink *influxdbSink) checkSanitizedMetricName(name string) error {
+	if !metricAllowedChars.MatchString(name) {
+		return fmt.Errorf("Invalid metric name %q", name)
+	}
+
+	return nil
+}
+
+// aggregationFunc converts an aggregation name into the equivalent call to an InfluxQL
+// aggregation function
+func (sink *influxdbSink) aggregationFunc(aggregationName core.AggregationType, fieldName string) string {
+	switch aggregationName {
+	case core.AggregationTypeAverage:
+		return fmt.Sprintf("MEAN(%q)", fieldName)
+	case core.AggregationTypeMaximum:
+		return fmt.Sprintf("MAX(%q)", fieldName)
+	case core.AggregationTypeMinimum:
+		return fmt.Sprintf("MIN(%q)", fieldName)
+	case core.AggregationTypeMedian:
+		return fmt.Sprintf("MEDIAN(%q)", fieldName)
+	case core.AggregationTypeCount:
+		return fmt.Sprintf("COUNT(%q)", fieldName)
+	case core.AggregationTypePercentile50:
+		return fmt.Sprintf("PERCENTILE(%q, 50)", fieldName)
+	case core.AggregationTypePercentile95:
+		return fmt.Sprintf("PERCENTILE(%q, 95)", fieldName)
+	case core.AggregationTypePercentile99:
+		return fmt.Sprintf("PERCENTILE(%q, 99)", fieldName)
+	}
+
+	// This should have been checked by the API level, so something's seriously wrong here
+	panic(fmt.Sprintf("Unknown aggregation type %q", aggregationName))
+}
+
+// keyToSelector converts a HistoricalKey to a InfluxQL predicate
+func (sink *influxdbSink) keyToSelector(key core.HistoricalKey) string {
+	typeSel := fmt.Sprintf("type = '%s'", key.ObjectType)
+	switch key.ObjectType {
+	case core.MetricSetTypeNode:
+		return fmt.Sprintf("%s AND %s = '%s'", typeSel, core.LabelNodename.Key, key.NodeName)
+	case core.MetricSetTypeSystemContainer:
+		return fmt.Sprintf("%s AND %s = '%s' AND %s = '%s'", typeSel, core.LabelContainerName.Key, key.ContainerName, core.LabelNodename.Key, key.NodeName)
+	case core.MetricSetTypeCluster:
+		return typeSel
+	case core.MetricSetTypeNamespace:
+		return fmt.Sprintf("%s AND %s = '%s'", typeSel, core.LabelNamespaceName.Key, key.NamespaceName)
+	case core.MetricSetTypePod:
+		if key.PodId != "" {
+			return fmt.Sprintf("%s AND %s = '%s'", typeSel, core.LabelPodId.Key, key.PodId)
+		} else {
+			return fmt.Sprintf("%s AND %s = '%s' AND %s = '%s'", typeSel, core.LabelNamespaceName.Key, key.NamespaceName, core.LabelPodName.Key, key.PodName)
+		}
+	case core.MetricSetTypePodContainer:
+		if key.PodId != "" {
+			return fmt.Sprintf("%s AND %s = '%s' AND %s = '%s'", typeSel, core.LabelPodId.Key, key.PodId, core.LabelContainerName.Key, key.ContainerName)
+		} else {
+			return fmt.Sprintf("%s AND %s = '%s' AND %s = '%s' AND %s = '%s'", typeSel, core.LabelNamespaceName.Key, key.NamespaceName, core.LabelPodName.Key, key.PodName, core.LabelContainerName.Key, key.ContainerName)
+		}
+	}
+
+	// These are assigned by the API, so it shouldn't be possible to reach this unless things are really broken
+	panic(fmt.Sprintf("Unknown metric type %q", key.ObjectType))
+}
+
+// metricToSeriesAndField retrieves the appropriate field name and series name for a given metric
+// (this varies depending on whether or not WithFields is enabled)
+func (sink *influxdbSink) metricToSeriesAndField(metricName string) (string, string) {
+	if sink.c.WithFields {
+		seriesName := strings.SplitN(metricName, "/", 2)
+		if len(seriesName) > 1 {
+			return seriesName[0], seriesName[1]
+		} else {
+			return seriesName[0], "value"
+		}
+	} else {
+		return metricName, "value"
+	}
+}
+
+// composeRawQuery creates the InfluxQL query to fetch the given metric values
+func (sink *influxdbSink) composeRawQuery(metricName string, metricKeys []core.HistoricalKey, start, end time.Time) string {
+	seriesName, fieldName := sink.metricToSeriesAndField(metricName)
+
+	queries := make([]string, len(metricKeys))
+	for i, key := range metricKeys {
+		pred := sink.keyToSelector(key)
+		if !start.IsZero() {
+			pred += fmt.Sprintf(" AND time > '%s'", start.Format(time.RFC3339))
+		}
+		if !end.IsZero() {
+			pred += fmt.Sprintf(" AND time < '%s'", end.Format(time.RFC3339))
+		}
+		queries[i] = fmt.Sprintf("SELECT time, %q FROM %q WHERE %s", fieldName, seriesName, pred)
+	}
+
+	return strings.Join(queries, "; ")
+}
+
+// parseRawQueryRow parses a set of timestamped metric values from unstructured JSON output into the
+// appropriate Heapster form
+func (sink *influxdbSink) parseRawQueryRow(rawRow influx_models.Row) ([]core.TimestampedMetricValue, error) {
+	vals := make([]core.TimestampedMetricValue, len(rawRow.Values))
+	wasInt := make(map[string]bool, 1)
+	for i, rawVal := range rawRow.Values {
+		val := core.TimestampedMetricValue{}
+
+		if ts, err := time.Parse(time.RFC3339, rawVal[0].(string)); err != nil {
+			return nil, fmt.Errorf("Unable to parse timestamp %q in series %q", rawVal[0].(string), rawRow.Name)
+		} else {
+			val.Timestamp = ts
+		}
+
+		if err := tryParseMetricValue("value", rawVal, &val.MetricValue, 1, wasInt); err != nil {
+			glog.Errorf("Unable to parse field \"value\" in series %q: %v", rawRow.Name, err)
+			return nil, fmt.Errorf("Unable to parse values in series %q", rawRow.Name)
+		}
+
+		vals[i] = val
+	}
+
+	if wasInt["value"] {
+		for i := range vals {
+			vals[i].MetricValue.ValueType = core.ValueInt64
+		}
+	} else {
+		for i := range vals {
+			vals[i].MetricValue.ValueType = core.ValueFloat
+		}
+	}
+
+	return vals, nil
+}
+
+// GetMetric retrieves the given metric for one or more objects (specified by metricKeys) of
+// the same type, within the given time interval
+func (sink *influxdbSink) GetMetric(metricName string, metricKeys []core.HistoricalKey, start, end time.Time) (map[core.HistoricalKey][]core.TimestampedMetricValue, error) {
+	for _, key := range metricKeys {
+		if err := sink.checkSanitizedKey(&key); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := sink.checkSanitizedMetricName(metricName); err != nil {
+		return nil, err
+	}
+
+	query := sink.composeRawQuery(metricName, metricKeys, start, end)
+
+	sink.RLock()
+	defer sink.RUnlock()
+
+	resp, err := sink.runQuery(query)
+	if err != nil {
+		return nil, err
+	}
+
+	res := make(map[core.HistoricalKey][]core.TimestampedMetricValue, len(metricKeys))
+	for i, key := range metricKeys {
+		if len(resp[i].Series) < 1 {
+			return nil, fmt.Errorf("No results for metric %q describing %q", metricName, key.String())
+		}
+
+		vals, err := sink.parseRawQueryRow(resp[i].Series[0])
+		if err != nil {
+			return nil, err
+		}
+		res[key] = vals
+	}
+
+	return res, nil
+}
+
+// composeRawQuery creates the InfluxQL query to fetch the given aggregation values
+func (sink *influxdbSink) composeAggregateQuery(metricName string, aggregations []core.AggregationType, metricKeys []core.HistoricalKey, start, end time.Time, bucketSize time.Duration) string {
+	seriesName, fieldName := sink.metricToSeriesAndField(metricName)
+
+	var bucketSizeNanoSeconds int64 = 0
+	if bucketSize != 0 {
+		bucketSizeNanoSeconds = int64(bucketSize.Nanoseconds() / int64(time.Microsecond/time.Nanosecond))
+	}
+
+	queries := make([]string, len(metricKeys))
+	for i, key := range metricKeys {
+		pred := sink.keyToSelector(key)
+		if !start.IsZero() {
+			pred += fmt.Sprintf(" AND time > '%s'", start.Format(time.RFC3339))
+		}
+		if !end.IsZero() {
+			pred += fmt.Sprintf(" AND time < '%s'", end.Format(time.RFC3339))
+		}
+
+		aggParts := make([]string, len(aggregations))
+		for i, agg := range aggregations {
+			aggParts[i] = sink.aggregationFunc(agg, fieldName)
+		}
+
+		queries[i] = fmt.Sprintf("SELECT %s FROM %q WHERE %s", strings.Join(aggParts, ", "), seriesName, pred)
+
+		if bucketSize != 0 {
+			// group by time requires we have at least one time bound
+			if start.IsZero() && end.IsZero() {
+				queries[i] += fmt.Sprintf(" AND time < now()")
+			}
+
+			// fill(none) makes sure we skip data points will null values (otherwise we'll get a *bunch* of null
+			// values when we go back beyond the time where we started collecting data).
+			queries[i] += fmt.Sprintf(" GROUP BY time(%vu) fill(none)", bucketSizeNanoSeconds)
+		}
+	}
+
+	return strings.Join(queries, "; ")
+}
+
+// parseRawQueryRow parses a set of timestamped aggregation values from unstructured JSON output into the
+// appropriate Heapster form
+func (sink *influxdbSink) parseAggregateQueryRow(rawRow influx_models.Row, aggregationLookup map[core.AggregationType]int, bucketSize time.Duration) ([]core.TimestampedAggregationValue, error) {
+	vals := make([]core.TimestampedAggregationValue, len(rawRow.Values))
+	wasInt := make(map[string]bool, len(aggregationLookup))
+
+	for i, rawVal := range rawRow.Values {
+		val := core.TimestampedAggregationValue{
+			BucketSize: bucketSize,
+			AggregationValue: core.AggregationValue{
+				Aggregations: map[core.AggregationType]core.MetricValue{},
+			},
+		}
+
+		if ts, err := time.Parse(time.RFC3339, rawVal[0].(string)); err != nil {
+			return nil, fmt.Errorf("Unable to parse timestamp %q in series %q", rawVal[0].(string), rawRow.Name)
+		} else {
+			val.Timestamp = ts
+		}
+
+		// The Influx client decods numeric fields to json.Number (a string), so we have to try decoding to both types of numbers
+
+		// Count is always a uint64
+		if countIndex, ok := aggregationLookup[core.AggregationTypeCount]; ok {
+			if err := json.Unmarshal([]byte(rawVal[countIndex].(json.Number).String()), &val.Count); err != nil {
+				glog.Errorf("Unable to parse count value in series %q: %v", rawRow.Name, err)
+				return nil, fmt.Errorf("Unable to parse values in series %q", rawRow.Name)
+			}
+		}
+
+		// The rest of the aggregation values can be either float or int, so attempt to parse both
+		if err := populateAggregations(rawRow.Name, rawVal, &val, aggregationLookup, wasInt); err != nil {
+			return nil, err
+		}
+
+		vals[i] = val
+	}
+
+	// figure out whether each aggregation was full of float values, or int values
+	setAggregationValueTypes(vals, wasInt)
+
+	return vals, nil
+}
+
+// GetAggregation fetches the given aggregations for one or more objects (specified by metricKeys) of
+// the same type, within the given time interval, calculated over a series of buckets
+func (sink *influxdbSink) GetAggregation(metricName string, aggregations []core.AggregationType, metricKeys []core.HistoricalKey, start, end time.Time, bucketSize time.Duration) (map[core.HistoricalKey][]core.TimestampedAggregationValue, error) {
+	for _, key := range metricKeys {
+		if err := sink.checkSanitizedKey(&key); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := sink.checkSanitizedMetricName(metricName); err != nil {
+		return nil, err
+	}
+
+	// make it easy to look up where the different aggregations are in the list
+	aggregationLookup := make(map[core.AggregationType]int, len(aggregations))
+	for i, agg := range aggregations {
+		aggregationLookup[agg] = i + 1
+	}
+
+	query := sink.composeAggregateQuery(metricName, aggregations, metricKeys, start, end, bucketSize)
+
+	sink.RLock()
+	defer sink.RUnlock()
+
+	resp, err := sink.runQuery(query)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: when there are too many points (e.g. certain times when a start time is not specified), Influx will sometimes return only a single bucket
+	//       instead of returning an error.  We should detect this case and return an error ourselves (or maybe just require a start time at the API level)
+	res := make(map[core.HistoricalKey][]core.TimestampedAggregationValue, len(metricKeys))
+	for i, key := range metricKeys {
+		vals, err := sink.parseAggregateQueryRow(resp[i].Series[0], aggregationLookup, bucketSize)
+		if err != nil {
+			return nil, err
+		}
+		res[key] = vals
+	}
+
+	return res, nil
+}
+
+// setAggregationValueIfPresent checks to to if the given metric value is present in the list of raw values, and if so,
+// copies it to the output format
+func setAggregationValueIfPresent(aggName core.AggregationType, rawVal []interface{}, aggregations *core.AggregationValue, indexLookup map[core.AggregationType]int, wasInt map[string]bool) error {
+	if fieldIndex, ok := indexLookup[aggName]; ok {
+		targetValue := &core.MetricValue{}
+		if err := tryParseMetricValue(string(aggName), rawVal, targetValue, fieldIndex, wasInt); err != nil {
+			return err
+		}
+
+		aggregations.Aggregations[aggName] = *targetValue
+	}
+
+	return nil
+}
+
+// tryParseMetricValue attempts to parse a raw metric value into the appropriate go type.
+func tryParseMetricValue(aggName string, rawVal []interface{}, targetValue *core.MetricValue, fieldIndex int, wasInt map[string]bool) error {
+	// the Influx client decodes numeric fields to json.Number (a string), so we have to deal with that --
+	// assume, starting off, that values may be either float or int.  Try int until we fail once, and always
+	// try float.  At the end, figure out which is which.
+
+	var rv string
+	if rvN, ok := rawVal[fieldIndex].(json.Number); !ok {
+		return fmt.Errorf("Value %q of metric %q was not a json.Number", rawVal[fieldIndex], aggName)
+	} else {
+		rv = rvN.String()
+	}
+
+	tryInt := false
+	isInt, triedBefore := wasInt[aggName]
+	tryInt = isInt || !triedBefore
+
+	if tryInt {
+		if err := json.Unmarshal([]byte(rv), &targetValue.IntValue); err != nil {
+			wasInt[aggName] = false
+		} else {
+			wasInt[aggName] = true
+		}
+	}
+
+	if err := json.Unmarshal([]byte(rv), &targetValue.FloatValue); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// GetMetricNames retrieves the available metric names for the given object
+func (sink *influxdbSink) GetMetricNames(metricKey core.HistoricalKey) ([]string, error) {
+	if err := sink.checkSanitizedKey(&metricKey); err != nil {
+		return nil, err
+	}
+	return sink.stringListQuery(fmt.Sprintf("SHOW MEASUREMENTS WHERE %s", sink.keyToSelector(metricKey)), "Unable to list available metrics")
+}
+
+// GetNodes retrieves the list of nodes in the cluster
+func (sink *influxdbSink) GetNodes() ([]string, error) {
+	return sink.stringListQuery(fmt.Sprintf("SHOW TAG VALUES WITH KEY = %s", core.LabelNodename.Key), "Unable to list all nodes")
+}
+
+// GetNamespaces retrieves the list of namespaces in the cluster
+func (sink *influxdbSink) GetNamespaces() ([]string, error) {
+	return sink.stringListQuery(fmt.Sprintf("SHOW TAG VALUES WITH KEY = %s", core.LabelNamespaceName.Key), "Unable to list all namespaces")
+}
+
+// GetPodsFromNamespace retrieves the list of pods in a given namespace
+func (sink *influxdbSink) GetPodsFromNamespace(namespace string) ([]string, error) {
+	if !nameAllowedChars.MatchString(namespace) {
+		return nil, fmt.Errorf("Invalid namespace name %q", namespace)
+	}
+	// This is a bit difficult for the influx query language, so we cheat a bit here --
+	// we just get all series for the uptime measurement for pods which match our namespace
+	// (any measurement should work here, though)
+	q := fmt.Sprintf("SHOW SERIES FROM %q WHERE %s = '%s' AND type = '%s'", core.MetricUptime.MetricDescriptor.Name, core.LabelNamespaceName.Key, namespace, core.MetricSetTypePod)
+	return sink.stringListQueryCol(q, core.LabelPodName.Key, fmt.Sprintf("Unable to list pods in namespace %q", namespace))
+}
+
+// GetSystemContainersFromNode retrieves the list of free containers for a given node
+func (sink *influxdbSink) GetSystemContainersFromNode(node string) ([]string, error) {
+	if !nameAllowedChars.MatchString(node) {
+		return nil, fmt.Errorf("Invalid node name %q", node)
+	}
+	// This is a bit difficult for the influx query language, so we cheat a bit here --
+	// we just get all series for the uptime measurement for system containers on our node
+	// (any measurement should work here, though)
+	q := fmt.Sprintf("SHOW SERIES FROM %q WHERE %s = '%s' AND type = '%s'", core.MetricUptime.MetricDescriptor.Name, core.LabelNodename.Key, node, core.MetricSetTypeSystemContainer)
+	return sink.stringListQueryCol(q, core.LabelContainerName.Key, fmt.Sprintf("Unable to list system containers on node %q", node))
+}
+
+// stringListQueryCol runs the given query, and returns all results from the given column as a string list
+func (sink *influxdbSink) stringListQueryCol(q, colName string, errStr string) ([]string, error) {
+	resp, err := sink.runQuery(q)
+	if err != nil {
+		return nil, fmt.Errorf(errStr)
+	}
+
+	if len(resp[0].Series) < 1 {
+		return nil, fmt.Errorf(errStr)
+	}
+
+	colInd := -1
+	for i, col := range resp[0].Series[0].Columns {
+		if col == colName {
+			colInd = i
+			break
+		}
+	}
+
+	if colInd == -1 {
+		glog.Errorf("%s: results did not contain the %q column", errStr, core.LabelPodName.Key)
+		return nil, fmt.Errorf(errStr)
+	}
+
+	res := make([]string, len(resp[0].Series[0].Values))
+	for i, rv := range resp[0].Series[0].Values {
+		res[i] = rv[colInd].(string)
+	}
+	return res, nil
+}
+
+// stringListQuery runs the given query, and returns all results from the first column as a string list
+func (sink *influxdbSink) stringListQuery(q string, errStr string) ([]string, error) {
+	resp, err := sink.runQuery(q)
+	if err != nil {
+		return nil, fmt.Errorf(errStr)
+	}
+
+	if len(resp[0].Series) < 1 {
+		return nil, fmt.Errorf(errStr)
+	}
+
+	res := make([]string, len(resp[0].Series[0].Values))
+	for i, rv := range resp[0].Series[0].Values {
+		res[i] = rv[0].(string)
+	}
+	return res, nil
+}
+
+// runQuery executes the given query against InfluxDB (using the default database for this sink)
+func (sink *influxdbSink) runQuery(queryStr string) ([]influxdb.Result, error) {
+	q := influxdb.Query{
+		Command:  queryStr,
+		Database: sink.c.DbName,
+	}
+
+	glog.V(4).Infof("Executing query %q against database %q", q.Command, q.Database)
+
+	resp, err := sink.client.Query(q)
+	if err != nil {
+		glog.Errorf("Unable to perform query %q against database %q: %v", q.Command, q.Database, err)
+		return nil, err
+	} else if resp.Error() != nil {
+		glog.Errorf("Unable to perform query %q against database %q: %v", q.Command, q.Database, resp.Error())
+		return nil, resp.Error()
+	}
+
+	if len(resp.Results) < 1 {
+		glog.Errorf("Unable to perform query %q against database %q: no results returned", q.Command, q.Database)
+		return nil, fmt.Errorf("No results returned")
+	}
+
+	return resp.Results, nil
+}
+
+// populateAggregations extracts aggregation values from a given data point
+func populateAggregations(rawRowName string, rawVal []interface{}, val *core.TimestampedAggregationValue, aggregationLookup map[core.AggregationType]int, wasInt map[string]bool) error {
+	for _, aggregation := range core.MultiTypedAggregations {
+		if err := setAggregationValueIfPresent(aggregation, rawVal, &val.AggregationValue, aggregationLookup, wasInt); err != nil {
+			glog.Errorf("Unable to parse field %q in series %q: %v", aggregation, rawRowName, err)
+			return fmt.Errorf("Unable to parse values in series %q", rawRowName)
+		}
+	}
+
+	return nil
+}
+
+// setAggregationValueTypes inspects a set of aggregation values and figures out whether each aggregation value
+// returned as a float column, or an int column
+func setAggregationValueTypes(vals []core.TimestampedAggregationValue, wasInt map[string]bool) {
+	for _, aggregation := range core.MultiTypedAggregations {
+		if isInt, ok := wasInt[string(aggregation)]; ok && isInt {
+			for i := range vals {
+				val := vals[i].Aggregations[aggregation]
+				val.ValueType = core.ValueInt64
+				vals[i].Aggregations[aggregation] = val
+			}
+		} else if ok {
+			for i := range vals {
+				val := vals[i].Aggregations[aggregation]
+				val.ValueType = core.ValueFloat
+				vals[i].Aggregations[aggregation] = val
+			}
+		}
+	}
+}

--- a/metrics/sinks/influxdb/influxdb_test.go
+++ b/metrics/sinks/influxdb/influxdb_test.go
@@ -15,12 +15,14 @@
 package influxdb
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
 	"net/http/httptest"
 	"net/url"
 
+	influx_models "github.com/influxdata/influxdb/models"
 	"github.com/stretchr/testify/assert"
 	influxdb_common "k8s.io/heapster/common/influxdb"
 	"k8s.io/heapster/metrics/core"
@@ -32,12 +34,16 @@ type fakeInfluxDBDataSink struct {
 	fakeDbClient *influxdb_common.FakeInfluxDBClient
 }
 
+func newRawInfluxSink() *influxdbSink {
+	return &influxdbSink{
+		client: influxdb_common.Client,
+		c:      influxdb_common.Config,
+	}
+}
+
 func NewFakeSink() fakeInfluxDBDataSink {
 	return fakeInfluxDBDataSink{
-		&influxdbSink{
-			client: influxdb_common.Client,
-			c:      influxdb_common.Config,
-		},
+		newRawInfluxSink(),
 		influxdb_common.Client,
 	}
 }
@@ -163,4 +169,390 @@ func TestCreateInfluxdbSink(t *testing.T) {
 
 	//check sink name
 	assert.Equal(t, sink.Name(), "InfluxDB Sink")
+}
+
+func makeRow(results [][]string) influx_models.Row {
+	resRow := influx_models.Row{
+		Values: make([][]interface{}, len(results)),
+	}
+
+	for setInd, valSet := range results {
+		outVals := make([]interface{}, len(valSet))
+		for valInd, val := range valSet {
+			if valInd == 0 {
+				// timestamp should just be a string
+				outVals[valInd] = val
+			} else {
+				outVals[valInd] = json.Number(val)
+			}
+		}
+		resRow.Values[setInd] = outVals
+	}
+
+	return resRow
+}
+
+func checkMetricVal(expected, actual core.MetricValue) bool {
+	if expected.ValueType != actual.ValueType {
+		return false
+	}
+
+	// only check the relevant value type
+	switch expected.ValueType {
+	case core.ValueFloat:
+		return expected.FloatValue == actual.FloatValue
+	case core.ValueInt64:
+		return expected.IntValue == actual.IntValue
+	default:
+		return expected == actual
+	}
+}
+
+func TestHistoricalInfluxRawMetricsParsing(t *testing.T) {
+	// in order to just test the parsing, we just go directly to the sink type
+	sink := newRawInfluxSink()
+
+	baseTime := time.Time{}
+
+	rawTests := []struct {
+		name            string
+		rawData         influx_models.Row
+		expectedResults []core.TimestampedMetricValue
+		expectedError   bool
+	}{
+		{
+			name: "all-integer data",
+			rawData: makeRow([][]string{
+				{
+					baseTime.Add(24 * time.Hour).Format(time.RFC3339),
+					"1234",
+				},
+				{
+					baseTime.Add(48 * time.Hour).Format(time.RFC3339),
+					"5678",
+				},
+			}),
+			expectedResults: []core.TimestampedMetricValue{
+				{
+					Timestamp:   baseTime.Add(24 * time.Hour),
+					MetricValue: core.MetricValue{IntValue: 1234, ValueType: core.ValueInt64},
+				},
+				{
+					Timestamp:   baseTime.Add(48 * time.Hour),
+					MetricValue: core.MetricValue{IntValue: 5678, ValueType: core.ValueInt64},
+				},
+			},
+		},
+		{
+			name: "all-float data",
+			rawData: makeRow([][]string{
+				{
+					baseTime.Add(24 * time.Hour).Format(time.RFC3339),
+					"1.23e10",
+				},
+				{
+					baseTime.Add(48 * time.Hour).Format(time.RFC3339),
+					"4.56e11",
+				},
+			}),
+			expectedResults: []core.TimestampedMetricValue{
+				{
+					Timestamp:   baseTime.Add(24 * time.Hour),
+					MetricValue: core.MetricValue{FloatValue: 12300000000.0, ValueType: core.ValueFloat},
+				},
+				{
+					Timestamp:   baseTime.Add(48 * time.Hour),
+					MetricValue: core.MetricValue{FloatValue: 456000000000.0, ValueType: core.ValueFloat},
+				},
+			},
+		},
+		{
+			name: "mixed data",
+			rawData: makeRow([][]string{
+				{
+					baseTime.Add(24 * time.Hour).Format(time.RFC3339),
+					"123",
+				},
+				{
+					baseTime.Add(48 * time.Hour).Format(time.RFC3339),
+					"4.56e11",
+				},
+			}),
+			expectedResults: []core.TimestampedMetricValue{
+				{
+					Timestamp:   baseTime.Add(24 * time.Hour),
+					MetricValue: core.MetricValue{FloatValue: 123.0, ValueType: core.ValueFloat},
+				},
+				{
+					Timestamp:   baseTime.Add(48 * time.Hour),
+					MetricValue: core.MetricValue{FloatValue: 456000000000.0, ValueType: core.ValueFloat},
+				},
+			},
+		},
+		{
+			name: "data with invalid value",
+			rawData: makeRow([][]string{
+				{
+					baseTime.Add(24 * time.Hour).Format(time.RFC3339),
+					"true",
+				},
+			}),
+			expectedError: true,
+		},
+	}
+
+RAWTESTLOOP:
+	for _, test := range rawTests {
+		parsedRawResults, err := sink.parseRawQueryRow(test.rawData)
+		if (err != nil) != test.expectedError {
+			t.Errorf("When parsing raw %s: expected error %v != actual error %v", test.name, test.expectedError, err)
+			continue RAWTESTLOOP
+		}
+
+		if len(parsedRawResults) != len(test.expectedResults) {
+			t.Errorf("When parsing raw %s: expected results %#v != actual results %#v", test.name, test.expectedResults, parsedRawResults)
+			continue RAWTESTLOOP
+		}
+
+		for i, metricVal := range parsedRawResults {
+			if !test.expectedResults[i].Timestamp.Equal(metricVal.Timestamp) {
+				t.Errorf("When parsing raw %s: expected results %#v != actual results %#v", test.name, test.expectedResults, parsedRawResults)
+				continue RAWTESTLOOP
+			}
+
+			if !checkMetricVal(test.expectedResults[i].MetricValue, metricVal.MetricValue) {
+				t.Errorf("When parsing raw %s: expected results %#v != actual results %#v", test.name, test.expectedResults, parsedRawResults)
+				continue RAWTESTLOOP
+			}
+		}
+	}
+
+	var countVal2 uint64 = 2
+	aggregatedTests := []struct {
+		name            string
+		rawData         influx_models.Row
+		expectedResults []core.TimestampedAggregationValue
+		expectedError   bool
+	}{
+		{
+			name: "all-integer data",
+			rawData: makeRow([][]string{
+				{
+					baseTime.Add(24 * time.Hour).Format(time.RFC3339),
+					"2",
+					"1234",
+				},
+				{
+					baseTime.Add(48 * time.Hour).Format(time.RFC3339),
+					"2",
+					"5678",
+				},
+			}),
+			expectedResults: []core.TimestampedAggregationValue{
+				{
+					Timestamp: baseTime.Add(24 * time.Hour),
+					AggregationValue: core.AggregationValue{
+						Count: &countVal2,
+						Aggregations: map[core.AggregationType]core.MetricValue{
+							core.AggregationTypeAverage: {IntValue: 1234, ValueType: core.ValueInt64},
+						},
+					},
+				},
+				{
+					Timestamp: baseTime.Add(48 * time.Hour),
+					AggregationValue: core.AggregationValue{
+						Count: &countVal2,
+						Aggregations: map[core.AggregationType]core.MetricValue{
+							core.AggregationTypeAverage: {IntValue: 5678, ValueType: core.ValueInt64},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "all-float data",
+			rawData: makeRow([][]string{
+				{
+					baseTime.Add(24 * time.Hour).Format(time.RFC3339),
+					"2",
+					"1.23e10",
+				},
+				{
+					baseTime.Add(48 * time.Hour).Format(time.RFC3339),
+					"2",
+					"4.56e11",
+				},
+			}),
+			expectedResults: []core.TimestampedAggregationValue{
+				{
+					Timestamp: baseTime.Add(24 * time.Hour),
+					AggregationValue: core.AggregationValue{
+						Count: &countVal2,
+						Aggregations: map[core.AggregationType]core.MetricValue{
+							core.AggregationTypeAverage: {FloatValue: 12300000000.0, ValueType: core.ValueFloat},
+						},
+					},
+				},
+				{
+					Timestamp: baseTime.Add(48 * time.Hour),
+					AggregationValue: core.AggregationValue{
+						Count: &countVal2,
+						Aggregations: map[core.AggregationType]core.MetricValue{
+							core.AggregationTypeAverage: {FloatValue: 456000000000.0, ValueType: core.ValueFloat},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "mixed data",
+			rawData: makeRow([][]string{
+				{
+					baseTime.Add(24 * time.Hour).Format(time.RFC3339),
+					"2",
+					"123",
+				},
+				{
+					baseTime.Add(48 * time.Hour).Format(time.RFC3339),
+					"2",
+					"4.56e11",
+				},
+			}),
+			expectedResults: []core.TimestampedAggregationValue{
+				{
+					Timestamp: baseTime.Add(24 * time.Hour),
+					AggregationValue: core.AggregationValue{
+						Count: &countVal2,
+						Aggregations: map[core.AggregationType]core.MetricValue{
+							core.AggregationTypeAverage: {FloatValue: 123.0, ValueType: core.ValueFloat},
+						},
+					},
+				},
+				{
+					Timestamp: baseTime.Add(48 * time.Hour),
+					AggregationValue: core.AggregationValue{
+						Count: &countVal2,
+						Aggregations: map[core.AggregationType]core.MetricValue{
+							core.AggregationTypeAverage: {FloatValue: 456000000000.0, ValueType: core.ValueFloat},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "data with invalid value",
+			rawData: makeRow([][]string{
+				{
+					baseTime.Add(24 * time.Hour).Format(time.RFC3339),
+					"2",
+					"true",
+				},
+			}),
+			expectedError: true,
+		},
+	}
+
+	aggregationLookup := map[core.AggregationType]int{
+		core.AggregationTypeCount:   1,
+		core.AggregationTypeAverage: 2,
+	}
+AGGTESTLOOP:
+	for _, test := range aggregatedTests {
+		parsedAggResults, err := sink.parseAggregateQueryRow(test.rawData, aggregationLookup, 24*time.Hour)
+		if (err != nil) != test.expectedError {
+			t.Errorf("When parsing aggregated %s: expected error %v != actual error %v", test.name, test.expectedError, err)
+			continue AGGTESTLOOP
+		}
+
+		if len(parsedAggResults) != len(test.expectedResults) {
+			t.Errorf("When parsing aggregated %s: expected results %#v had a different length from actual results %#v", test.name, test.expectedResults, parsedAggResults)
+			continue AGGTESTLOOP
+		}
+
+		for i, metricVal := range parsedAggResults {
+			expVal := test.expectedResults[i]
+			if !expVal.Timestamp.Equal(metricVal.Timestamp) {
+				t.Errorf("When parsing aggregated %s: expected results %#v had a different timestamp from actual results %#v", test.name, expVal, metricVal)
+				continue AGGTESTLOOP
+			}
+
+			if len(expVal.Aggregations) != len(metricVal.Aggregations) {
+				t.Errorf("When parsing aggregated %s: expected results %#v had a number of aggregations from actual results %#v", test.name, expVal, metricVal)
+				continue AGGTESTLOOP
+			}
+
+			for aggName, aggVal := range metricVal.Aggregations {
+				if expAggVal, ok := expVal.Aggregations[aggName]; !ok || !checkMetricVal(expAggVal, aggVal) {
+					t.Errorf("When parsing aggregated %s: expected results %#v != actual results %#v", test.name, expAggVal, aggVal)
+					continue AGGTESTLOOP
+				}
+			}
+		}
+	}
+}
+
+func TestSanitizers(t *testing.T) {
+	badMetricName := "foo; baz"
+	goodMetricName := "cheese/types-crackers"
+
+	goodKeyValue := "cheddar.CHEESE-ritz.Crackers_1"
+	badKeyValue := "foobar'; baz"
+
+	sink := newRawInfluxSink()
+
+	if err := sink.checkSanitizedMetricName(goodMetricName); err != nil {
+		t.Errorf("Expected %q to be a valid metric name, but it was not: %v", goodMetricName, err)
+	}
+
+	if err := sink.checkSanitizedMetricName(badMetricName); err == nil {
+		t.Errorf("Expected %q to be an invalid metric name, but it was valid", badMetricName)
+	}
+
+	badKeys := []core.HistoricalKey{
+		{
+			NodeName: badKeyValue,
+		},
+		{
+			NamespaceName: badKeyValue,
+		},
+		{
+			PodName: badKeyValue,
+		},
+		{
+			ContainerName: badKeyValue,
+		},
+		{
+			PodId: badKeyValue,
+		},
+	}
+
+	for _, key := range badKeys {
+		if err := sink.checkSanitizedKey(&key); err == nil {
+			t.Errorf("Expected key %#v to be invalid, but it was not", key)
+		}
+	}
+
+	goodKeys := []core.HistoricalKey{
+		{
+			NodeName: goodKeyValue,
+		},
+		{
+			NamespaceName: goodKeyValue,
+		},
+		{
+			PodName: goodKeyValue,
+		},
+		{
+			ContainerName: goodKeyValue,
+		},
+		{
+			PodId: goodKeyValue,
+		},
+	}
+
+	for _, key := range goodKeys {
+		if err := sink.checkSanitizedKey(&key); err != nil {
+			t.Errorf("Expected key %#v to be valid, but it was not: %v", key, err)
+		}
+	}
 }

--- a/metrics/sinks/metric/metric_sink.go
+++ b/metrics/sinks/metric/metric_sink.go
@@ -51,11 +51,6 @@ type multimetricStore struct {
 	store map[string]int64Store
 }
 
-type TimestampedMetricValue struct {
-	core.MetricValue
-	Timestamp time.Time
-}
-
 func buildMultimetricStore(metrics []string, batch *core.DataBatch) *multimetricStore {
 	store := multimetricStore{
 		timestamp: batch.Timestamp,
@@ -115,7 +110,7 @@ func (this *MetricSink) GetShortStore() []*core.DataBatch {
 	return result
 }
 
-func (this *MetricSink) GetMetric(metricName string, keys []string, start, end time.Time) map[string][]TimestampedMetricValue {
+func (this *MetricSink) GetMetric(metricName string, keys []string, start, end time.Time) map[string][]core.TimestampedMetricValue {
 	this.lock.Lock()
 	defer this.lock.Unlock()
 
@@ -126,7 +121,7 @@ func (this *MetricSink) GetMetric(metricName string, keys []string, start, end t
 		}
 	}
 
-	result := make(map[string][]TimestampedMetricValue)
+	result := make(map[string][]core.TimestampedMetricValue)
 	if useLongStore {
 		for _, store := range this.longStore {
 			// Inclusive start and end.
@@ -134,7 +129,7 @@ func (this *MetricSink) GetMetric(metricName string, keys []string, start, end t
 				substore := store.store[metricName]
 				for _, key := range keys {
 					if val, found := substore[key]; found {
-						result[key] = append(result[key], TimestampedMetricValue{
+						result[key] = append(result[key], core.TimestampedMetricValue{
 							Timestamp: store.timestamp,
 							MetricValue: core.MetricValue{
 								IntValue:   val,
@@ -161,9 +156,9 @@ func (this *MetricSink) GetMetric(metricName string, keys []string, start, end t
 					}
 					keyResult, found := result[key]
 					if !found {
-						keyResult = make([]TimestampedMetricValue, 0)
+						keyResult = make([]core.TimestampedMetricValue, 0)
 					}
-					keyResult = append(keyResult, TimestampedMetricValue{
+					keyResult = append(keyResult, core.TimestampedMetricValue{
 						Timestamp:   batch.Timestamp,
 						MetricValue: metricValue,
 					})


### PR DESCRIPTION
This PR introduces Oldtimer, proposed in [docs/proposals/old-timer.md](https://github.com/kubernetes/heapster/blob/master/docs/proposals/old-timer.md).

Oldtimer is accessible from the `/api/v1/historical`, and mirrors the model API.  It can be enabled by passing `--historical_source` with one of the URIs used in the `--sink` argument.

Currently this PR supports the InfluxDB sink.  Support for the rest of the metrics sinks should be coming along shortly in separate PRs (although if someone more familiar with one of the individual sinks is interested in writing the Oldtimer support for that sink, that would be appreciated).

cc @burmanm @piosz @mwielgus @bryk 
