### PR TITLE
Dont strip basic authentication from apiserver url

### DIFF
--- a/common/kubernetes/configs.go
+++ b/common/kubernetes/configs.go
@@ -42,8 +42,10 @@ func getConfigOverrides(uri *url.URL) (*kubeClientCmd.ConfigOverrides, error) {
 			APIVersion: APIVersion,
 		},
 	}
-	if len(uri.Scheme) != 0 && len(uri.Host) != 0 {
+	if len(uri.Scheme) != 0 && len(uri.Host) != 0 && len(uri.User) != 0 {
 		kubeConfigOverride.ClusterInfo.Server = fmt.Sprintf("%s://%s@%s", uri.Scheme, uri.User, uri.Host)
+	} else if len(uri.Scheme) != 0 && len(uri.Host) != 0 {
+		kubeConfigOverride.ClusterInfo.Server = fmt.Sprintf("%s://%s", uri.Scheme, uri.Host)
 	}
 
 	opts := uri.Query()

--- a/common/kubernetes/configs.go
+++ b/common/kubernetes/configs.go
@@ -43,7 +43,7 @@ func getConfigOverrides(uri *url.URL) (*kubeClientCmd.ConfigOverrides, error) {
 		},
 	}
 	if len(uri.Scheme) != 0 && len(uri.Host) != 0 {
-		kubeConfigOverride.ClusterInfo.Server = fmt.Sprintf("%s://%s", uri.Scheme, uri.Host)
+		kubeConfigOverride.ClusterInfo.Server = fmt.Sprintf("%s://%s@%s", uri.Scheme, uri.User, uri.Host)
 	}
 
 	opts := uri.Query()


### PR DESCRIPTION
The following ensures that the following url retains its basic auth credentials.

```
./heapster --source=kubernetes:https://XXXXXX:XXXXXX@kubernetes.local:6443?inClusterConfig=false
```

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/heapster/1178)
<!-- Reviewable:end -->
