### PR TITLE
Code to find the node Hostname and Ip based on external ip

### DIFF
--- a/metrics/sources/kubelet/kubelet.go
+++ b/metrics/sources/kubelet/kubelet.go
@@ -307,6 +307,9 @@ func getNodeHostnameAndIP(node *kube_api.Node) (string, string, error) {
 		if addr.Type == kube_api.NodeLegacyHostIP && addr.Address != "" && ip == "" {
 			ip = addr.Address
 		}
+		if addr.Type == kube_api.NodeExternalIP && addr.Address != "" && ip == "" {
+			ip = addr.Address
+		}
 	}
 	if ip != "" {
 		return hostname, ip, nil


### PR DESCRIPTION
Heapster unable to detect external ip and fails with the following error

`E0701 00:27:05.002358       1 kubelet.go:279] Node tess-node-r28pj-7533.slc01.dev.ebayc3.com has no valid hostname and/or IP address: test-node.ebayc3.com`

Here is my node details

```
apiVersion: v1
kind: Node
metadata:
  labels:
    kubernetes.io/hostname: test-node.dev.ebay.com
  name: test-node.dev.ebay.com
  resourceVersion: "34759517"
  selfLink: /api/v1/nodes/test-node.dev.ebay.com
  uid: 43e10356-18e2-11e6-b7b4-74dbd1a0fb73
spec:
  externalID: c0e6ac76-0b1c-49dc-9f69-038bdc50e9ad
  providerID: openstack:///c0e6ac76-0b1c-49dc-9f69-038bdc50e9ad
status:
  addresses:
  - address: 10.35.212.10
    type: ExternalIP
  - address: ""
    type: ExternalIP
```

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/heapster/1206)
<!-- Reviewable:end -->
