### PR TITLE
Hawkular Oldtimer support

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -147,8 +147,8 @@
 		},
 		{
 			"ImportPath": "github.com/hawkular/hawkular-client-go/metrics",
-			"Comment": "v0.6.0",
-			"Rev": "50f4099dfd739f913ed7d8f33288aeeca338516a"
+			"Comment": "v0.7.0",
+			"Rev": "d3a0e3ccb068e354fc61c5811a24414792e6159b"
 		},
 		{
 			"ImportPath": "github.com/imdario/mergo",

--- a/metrics/core/metrics.go
+++ b/metrics/core/metrics.go
@@ -37,12 +37,16 @@ var StandardMetrics = []Metric{
 	MetricNetworkTx,
 	MetricNetworkTxErrors}
 
+var StandardMetricsMapping map[string]Metric
+
 // Metrics computed based on cluster state using Kubernetes API.
 var AdditionalMetrics = []Metric{
 	MetricCpuRequest,
 	MetricCpuLimit,
 	MetricMemoryRequest,
 	MetricMemoryLimit}
+
+var AdditionalMetricsMapping map[string]Metric
 
 // Computed based on corresponding StandardMetrics.
 var RateMetrics = []Metric{
@@ -69,6 +73,8 @@ var LabeledMetrics = []Metric{
 	MetricFilesystemAvailable,
 }
 
+var LabeledMetricsMapping map[string]Metric
+
 var NodeAutoscalingMetrics = []Metric{
 	MetricNodeCpuCapacity,
 	MetricNodeMemoryCapacity,
@@ -78,8 +84,12 @@ var NodeAutoscalingMetrics = []Metric{
 	MetricNodeMemoryReservation,
 }
 
+var NodeAutoscalingMetricsMapping map[string]Metric
+
 var AllMetrics = append(append(append(append(StandardMetrics, AdditionalMetrics...), RateMetrics...), LabeledMetrics...),
 	NodeAutoscalingMetrics...)
+
+var AllMetricsMapping map[string]Metric
 
 // Definition of Standard Metrics.
 var MetricUptime = Metric{
@@ -559,4 +569,22 @@ type Metric struct {
 
 	// Returns a slice of internal point objects that contain metric values and associated labels.
 	GetLabeledMetric func(*cadvisor.ContainerSpec, *cadvisor.ContainerStats) []LabeledMetric
+}
+
+func init() {
+	// Create Mapping maps
+	createMap := func(sourceMetrics []Metric) map[string]Metric {
+		targetMap := make(map[string]Metric, len(sourceMetrics))
+		for _, metric := range sourceMetrics {
+			targetMap[metric.MetricDescriptor.Name] = metric
+		}
+		return targetMap
+	}
+
+	AllMetricsMapping = createMap(AllMetrics)
+	StandardMetricsMapping = createMap(StandardMetrics)
+	AdditionalMetricsMapping = createMap(AdditionalMetrics)
+	//	RateMetricsMapping = createMap(RateMetrics)
+	LabeledMetricsMapping = createMap(LabeledMetrics)
+	NodeAutoscalingMetricsMapping = createMap(NodeAutoscalingMetrics)
 }

--- a/metrics/sinks/hawkular/driver_historical.go
+++ b/metrics/sinks/hawkular/driver_historical.go
@@ -1,0 +1,433 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hawkular
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/hawkular/hawkular-client-go/metrics"
+	"k8s.io/heapster/metrics/core"
+)
+
+// Historical returns the historical data access interface for this sink
+func (h *hawkularSink) Historical() core.HistoricalSource {
+	return h
+}
+
+// GetMetric retrieves the given metric for one or more objects (specified by metricKeys) of
+// the same type, within the given time interval
+func (h *hawkularSink) GetMetric(metricName string, metricKeys []core.HistoricalKey, start, end time.Time) (map[core.HistoricalKey][]core.TimestampedMetricValue, error) {
+	typ := h.metricNameToHawkularType(metricName)
+
+	resLock := &sync.Mutex{}
+	res := make(map[core.HistoricalKey][]core.TimestampedMetricValue, len(metricKeys))
+
+	errChan := make(chan error, len(metricKeys))
+	wg := &sync.WaitGroup{}
+
+	for _, keyM := range metricKeys {
+		wg.Add(1)
+		go func(key core.HistoricalKey) {
+			defer wg.Done()
+			tags := h.keyToTags(&key)
+			tags[descriptorTag] = metricName
+
+			o := []metrics.Modifier{metrics.Filters(metrics.TagsFilter(tags), metrics.TypeFilter(typ))}
+			if h.isNamespaceTenant() && key.NamespaceName != "" && key.ObjectType != core.MetricSetTypeCluster {
+				o = append(o, metrics.Tenant(key.NamespaceName))
+			}
+
+			// Remove in favor of using ReadRaw with filters to reduce the amount of queries to HWKMETRICS,
+			// but that API is still considered unstable in current release
+			metricDefs, err := h.client.Definitions(o...)
+			if err != nil {
+				errChan <- err
+				return
+			}
+
+			if len(metricDefs) > 1 {
+				errChan <- fmt.Errorf("Given metric query (metricName=%q, key=%q) did not result in unique metricId, found %d results", metricName, key, len(metricDefs))
+				return
+			} else if len(metricDefs) < 1 {
+				return
+			}
+
+			filters := make([]metrics.Filter, 0, 2)
+
+			// Without start & endTime, the default is requesting 8 hours to the past
+			if !end.IsZero() {
+				filters = append(filters, metrics.EndTimeFilter(end))
+			}
+
+			if !start.IsZero() {
+				filters = append(filters, metrics.StartTimeFilter(start))
+			}
+
+			datapoints, err := h.client.ReadRaw(metricDefs[0].Type, metricDefs[0].ID, metrics.Filters(filters...))
+			if err != nil {
+				errChan <- err
+				return
+			}
+
+			if len(datapoints) > 0 {
+				metricValues := make([]core.TimestampedMetricValue, 0, len(datapoints))
+
+				for _, datapoint := range datapoints {
+					value, err := h.datapointToMetricValue(datapoint, &typ)
+					if err != nil {
+						errChan <- err
+						return
+					}
+					metricValues = append(metricValues, value)
+				}
+
+				resLock.Lock()
+				res[key] = metricValues
+				resLock.Unlock()
+			}
+
+		}(keyM)
+	}
+	wg.Wait()
+	close(errChan)
+
+	// Check for errors first
+	for e := range errChan {
+		return nil, e
+	}
+
+	return res, nil
+}
+
+// GetAggregation fetches the given aggregations for one or more objects (specified by metricKeys) of
+// the same type, within the given time interval, calculated over a series of buckets
+func (h *hawkularSink) GetAggregation(metricName string, aggregations []core.AggregationType, metricKeys []core.HistoricalKey, start, end time.Time, bucketSize time.Duration) (map[core.HistoricalKey][]core.TimestampedAggregationValue, error) {
+	typ := h.metricNameToHawkularType(metricName)
+
+	resLock := &sync.Mutex{}
+	res := make(map[core.HistoricalKey][]core.TimestampedAggregationValue, len(metricKeys))
+
+	errChan := make(chan error, len(metricKeys))
+	wg := &sync.WaitGroup{}
+
+	// While we could read everything in a single query to Hawkular-Metrics, we could not reliably parse the results back to HistoricalKey
+	for _, keyM := range metricKeys {
+		wg.Add(1)
+		go func(key core.HistoricalKey) {
+			defer wg.Done()
+			tags := h.keyToTags(&key)
+			tags[descriptorTag] = metricName
+
+			o := make([]metrics.Modifier, 0, 2)
+			if h.isNamespaceTenant() && key.NamespaceName != "" && key.ObjectType != core.MetricSetTypeCluster {
+				o = append(o, metrics.Tenant(key.NamespaceName))
+			}
+
+			filters := make([]metrics.Filter, 0, 5)
+			filters = append(filters, metrics.TagsFilter(tags))
+
+			if bucketSize != 0 {
+				filters = append(filters, metrics.BucketsDurationFilter(bucketSize))
+			} else {
+				// No bucketSize defined, lets request a single bucket over all the data
+				filters = append(filters, metrics.BucketsFilter(1))
+			}
+
+			// Without start & endTime, the default is requesting 8 hours to the past
+			if !end.IsZero() {
+				filters = append(filters, metrics.EndTimeFilter(end))
+			}
+
+			if !start.IsZero() {
+				filters = append(filters, metrics.StartTimeFilter(start))
+			}
+
+			// No need to request percentile 50 as that equals median
+			filters = append(filters, metrics.PercentilesFilter([]float64{95.0, 99.0}))
+
+			o = append(o, metrics.Filters(filters...))
+			buckets, err := h.client.ReadBuckets(typ, o...)
+			if err != nil {
+				errChan <- err
+				return
+			}
+
+			if len(buckets) > 0 {
+				aggregationValues := make([]core.TimestampedAggregationValue, 0, len(buckets))
+
+				for _, bucketPoint := range buckets {
+					value, err := h.bucketPointToAggregationValue(bucketPoint, &typ, aggregations, bucketSize)
+					if err != nil {
+						errChan <- err
+						return
+					}
+
+					aggregationValues = append(aggregationValues, value)
+				}
+				resLock.Lock()
+				res[key] = aggregationValues
+				resLock.Unlock()
+			}
+
+		}(keyM)
+	}
+	wg.Wait()
+	close(errChan)
+
+	// Check for errors first
+	for e := range errChan {
+		return nil, e
+	}
+
+	return res, nil
+}
+
+// GetMetricNames retrieves the available metric names for the given object
+func (h *hawkularSink) GetMetricNames(metricKey core.HistoricalKey) ([]string, error) {
+	tags := h.keyToTags(&metricKey)
+	tags[descriptorTag] = "*"
+
+	var r map[string][]string
+	var err error
+
+	if h.isNamespaceTenant() && metricKey.NamespaceName != "" {
+		r, err = h.client.TagValues(tags, metrics.Tenant(metricKey.NamespaceName))
+	} else {
+		r, err = h.client.TagValues(tags)
+	}
+
+	if r != nil {
+		return r[descriptorTag], err
+	}
+	return nil, err
+}
+
+// GetNodes retrieves the list of nodes in the cluster
+func (h *hawkularSink) GetNodes() ([]string, error) {
+	tags := make(map[string]string)
+	tags[core.LabelHostname.Key] = "*"
+	tags[core.LabelMetricSetType.Key] = core.MetricSetTypeNode
+	r, err := h.client.TagValues(tags) // Assume these are stored in the system tenant
+	if r != nil {
+		return r[core.LabelHostname.Key], err
+	}
+	return nil, err
+}
+
+// GetPodsFromNamespace retrieves the list of pods in a given namespace
+func (h *hawkularSink) GetPodsFromNamespace(namespace string) ([]string, error) {
+	tags := make(map[string]string)
+	tags[core.LabelPodName.Key] = "*"
+	tags[core.LabelMetricSetType.Key] = core.MetricSetTypePod
+
+	var r map[string][]string
+	var err error
+
+	if h.isNamespaceTenant() {
+		r, err = h.client.TagValues(tags, metrics.Tenant(namespace))
+	} else {
+		tags[core.LabelNamespaceName.Key] = namespace
+		r, err = h.client.TagValues(tags)
+	}
+
+	if r != nil {
+		return r[core.LabelPodName.Key], err
+	}
+	return nil, err
+}
+
+// GetSystemContainersFromNode retrieves the list of free containers for a given node
+func (h *hawkularSink) GetSystemContainersFromNode(node string) ([]string, error) {
+	tags := make(map[string]string)
+	tags[core.LabelContainerName.Key] = "*"
+	tags[core.LabelHostname.Key] = node
+	tags[core.LabelMetricSetType.Key] = core.MetricSetTypeSystemContainer
+	r, err := h.client.TagValues(tags) // I assume these are stored at the system tenant
+	if r != nil {
+		return r[core.LabelContainerName.Key], err
+	}
+	return nil, err
+}
+
+// GetNamespaces retrieves the list of namespaces in the cluster
+func (h *hawkularSink) GetNamespaces() ([]string, error) {
+	// Fetch tenants, if the labelToTenantId is set (and includes namespace label)
+	if h.isNamespaceTenant() {
+		tds, err := h.client.Tenants()
+		if err != nil {
+			return nil, err
+		}
+		ns := make([]string, 0, len(tds))
+		for _, td := range tds {
+			ns = append(ns, td.ID)
+		}
+		return ns, nil
+	}
+
+	return h.getLabelTagValues(core.LabelNamespaceName.Key)
+}
+
+// Internal functions
+
+func (h *hawkularSink) getLabelTagValues(labelKey string, o ...metrics.Modifier) ([]string, error) {
+	tags := make(map[string]string)
+	tags[labelKey] = "*"
+	r, err := h.client.TagValues(tags, o...)
+	if r != nil {
+		return r[labelKey], err
+	}
+	return nil, err
+}
+
+// isNamespaceTenant tries to detect if namespace labels are used as target tenant. This is in use on Openshift as default (and Hawkular images)
+// if this returns true, the namespace information should be used when sending a query to the Hawkular, and only cluster level statistics are
+// fetched from the default tenant
+func (h *hawkularSink) isNamespaceTenant() bool {
+	// This could be a bit problematic.. are we really storing the right info?
+	if h.labelTenant != "" && (h.labelTenant == core.LabelPodNamespace.Key || h.labelTenant == core.LabelPodNamespaceUID.Key) {
+		return true
+	}
+	return false
+}
+
+func (h *hawkularSink) bucketPointToAggregationValue(bp *metrics.Bucketpoint, mt *metrics.MetricType, aggregations []core.AggregationType, bucketSize time.Duration) (core.TimestampedAggregationValue, error) {
+	aggregationValues := core.TimestampedAggregationValue{
+		Timestamp:  bp.Start,
+		BucketSize: bucketSize,
+		AggregationValue: core.AggregationValue{
+			Count: &bp.Samples,
+		},
+	}
+
+	aggs := make(map[core.AggregationType]core.MetricValue, len(aggregations))
+
+	for _, a := range aggregations {
+		var val float64
+		switch a {
+		case core.AggregationTypeAverage:
+			val = bp.Avg
+		case core.AggregationTypeMaximum:
+			val = bp.Max
+		case core.AggregationTypeMinimum:
+			val = bp.Min
+		case core.AggregationTypeMedian:
+			val = bp.Median
+		case core.AggregationTypePercentile50:
+			val = bp.Median // Percentile 50 and Median are the same thing
+		case core.AggregationTypePercentile95:
+			for _, v := range bp.Percentiles {
+				if v.Quantile == 95.0 {
+					val = v.Value
+				}
+			}
+		case core.AggregationTypePercentile99:
+			for _, v := range bp.Percentiles {
+				if v.Quantile == 99.0 {
+					val = v.Value
+				}
+			}
+		}
+
+		mv := core.MetricValue{
+			MetricType: core.MetricGauge,
+			ValueType:  core.ValueFloat,
+			FloatValue: float32(val),
+		}
+		f, err := metrics.ConvertToFloat64(val)
+		if err != nil {
+			return aggregationValues, err
+		}
+		mv.FloatValue = float32(f)
+
+		aggs[a] = mv
+	}
+
+	aggregationValues.AggregationValue.Aggregations = aggs
+	return aggregationValues, nil
+}
+
+func (h *hawkularSink) datapointToMetricValue(dp *metrics.Datapoint, mt *metrics.MetricType) (core.TimestampedMetricValue, error) {
+	mv := core.MetricValue{
+		MetricType: hawkularTypeToHeapsterType(*mt),
+	}
+
+	tmv := core.TimestampedMetricValue{
+		Timestamp: dp.Timestamp,
+	}
+
+	switch *mt {
+	case metrics.Counter:
+		mv.ValueType = core.ValueInt64
+		if v, ok := dp.Value.(int64); ok {
+			mv.IntValue = int64(v)
+		}
+	case metrics.Gauge:
+		mv.ValueType = core.ValueFloat
+		f, err := metrics.ConvertToFloat64(dp.Value)
+		if err != nil {
+			return tmv, err
+		}
+		mv.FloatValue = float32(f)
+		// if v, ok := dp.Value.(float64); ok {
+
+		// }
+	}
+	tmv.MetricValue = mv
+
+	return tmv, nil
+}
+
+func (h *hawkularSink) metricNameToHawkularType(metricName string) metrics.MetricType {
+	if metric, found := core.AllMetricsMapping[metricName]; found {
+		return heapsterTypeToHawkularType(metric.Type)
+	}
+	return metrics.Gauge
+}
+
+func (h *hawkularSink) keyToTags(metricKey *core.HistoricalKey) map[string]string {
+	tags := make(map[string]string)
+	tags[core.LabelMetricSetType.Key] = metricKey.ObjectType
+
+	switch metricKey.ObjectType {
+	case core.MetricSetTypeSystemContainer:
+		tags[core.LabelNodename.Key] = metricKey.NodeName
+		tags[core.LabelContainerName.Key] = metricKey.ContainerName
+	case core.MetricSetTypePodContainer:
+		tags[core.LabelContainerName.Key] = metricKey.ContainerName
+
+		if metricKey.PodId != "" {
+			tags[core.LabelPodId.Key] = metricKey.PodId
+		} else {
+			tags[core.LabelPodName.Key] = metricKey.PodName
+			tags[core.LabelNamespaceName.Key] = metricKey.NamespaceName
+		}
+	case core.MetricSetTypePod:
+		if metricKey.PodId != "" {
+			tags[core.LabelPodId.Key] = metricKey.PodId
+		} else {
+			tags[core.LabelNamespaceName.Key] = metricKey.NamespaceName
+			tags[core.LabelPodName.Key] = metricKey.PodName
+		}
+	case core.MetricSetTypeNamespace:
+		tags[core.LabelNamespaceName.Key] = metricKey.NamespaceName
+	case core.MetricSetTypeNode:
+		tags[core.LabelNodename.Key] = metricKey.NodeName
+	case core.MetricSetTypeCluster:
+		// System tenant
+	}
+	return tags
+}

--- a/metrics/sinks/hawkular/driver_historical_test.go
+++ b/metrics/sinks/hawkular/driver_historical_test.go
@@ -1,0 +1,453 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hawkular
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hawkular/hawkular-client-go/metrics"
+	"k8s.io/heapster/metrics/core"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+// Helpers
+
+func testServer() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		tenant := r.Header.Get("Hawkular-Tenant")
+
+		rPath := r.URL.Path[18:]
+		values := r.URL.Query()
+
+		path := strings.Split(rPath, "/")
+		typ := path[0]
+
+		var b []byte
+		empty := false
+
+		// Tenants emulation
+		if typ == "tenants" {
+			b = []byte(`[{"id": "1CE77F8206798F1C587611A4574683C7"}, {"id": "test-heapster", "retentions": {"gauge": 5}}]`)
+			// w.WriteHeader(http.StatusOK)
+			// return
+		}
+
+		if typ == "metrics" {
+			// TagValues emulation
+			if len(path) > 1 && path[1] == "tags" {
+				tags := parseTags(path[2])
+				resp := make(map[string][]string)
+				for k, v := range tags {
+					if !strings.HasSuffix(v, "*") { // * is something we"ll add later
+						resp[k] = []string{v}
+						continue
+					}
+
+					switch k {
+					case core.LabelPodName.Key:
+						resp[core.LabelPodName.Key] = []string{"pod1", "pod2", "pod3"}
+					case core.LabelHostname.Key:
+						resp[core.LabelHostname.Key] = []string{"host1", "host2"}
+					case core.LabelContainerName.Key:
+						if tenant != "test-heapster" {
+							empty = true
+						} else {
+							resp[core.LabelContainerName.Key] = []string{"hawkular", "heapster"}
+						}
+					case core.LabelPodId.Key:
+						if v == "terrible*" {
+							resp[descriptorTag] = []string{"terribleghost"}
+						}
+					case core.LabelNamespaceName.Key:
+						resp[core.LabelNamespaceName.Key] = []string{"namespacey"}
+					}
+				}
+
+				if !empty {
+					b, _ = json.Marshal(resp)
+				}
+			}
+
+			if len(values) > 0 {
+				tags := parseTags(values.Get("tags"))
+				// Mixed metric definition fetching emulation
+				if values.Get("type") == "counter" && tags[descriptorTag] == "cpu/usage" {
+					// Value: tags -> [type:cluster,descriptor_name:cpu/usage]
+					if tags["type"] == "cluster" {
+						b = []byte(`[{"type": "counter", "id": "heapster.test.cluster.cpu.usage", "tags": {"type": "cluster", "descriptor_name": "cpu/usage"}, "dataRetention": 7, "tenantId": "test-heapster"}]`)
+					}
+					// Value: tags -> [type:sys_container,nodename:node_1,container_name:container_1,descriptor_name:cpu/usage]
+					// Value: tags -> [descriptor_name:cpu/usage,type:pod,namespace_name:namespace_1,pod_name:pod_name_2]
+					// Value: tags -> [pod_id:pod_id_2,descriptor_name:cpu/usage,type:pod]
+					if tags["type"] == "pod" && tags["pod_id"] == "pod_id_2" {
+						b = []byte(`[{"type": "counter", "id": "heapster.test.podid.cpu.usage", "tags": {"type": "pod", "pod_id": "pod_id_2", "descriptor_name": "cpu/usage"}, "dataRetention": 7, "tenantId": "test-heapster"}]`)
+					}
+					// Value: tags -> [pod_name:pod_name_1,namespace_name:namespace_1,descriptor_name:cpu/usage,type:pod_container,container_name:container_2]
+					// Value: tags -> [type:node,nodename:nodename_1,descriptor_name:cpu/usage]
+					// Value: tags -> [type:pod_container,container_name:container_2,pod_id:pod_id_1,descriptor_name:cpu/usage]
+					// Value: tags -> [type:ns,namespace_name:namespace_2,descriptor_name:cpu/usage]
+				}
+			}
+		}
+
+		if typ == "counters" {
+			// Emulate metric datapoint fetching
+			id := path[1]
+
+			start, err := strconv.ParseInt(values.Get("start"), 10, 64)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			end, err := strconv.ParseInt(values.Get("end"), 10, 64)
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+
+			if id == "stats" {
+				// Emulate aggregate datapoint fetching with tags
+
+				// PATH: counters/stats
+				// Value: bucketDuration -> [3600000ms]
+				// Value: end -> [1467725505218]
+				// Value: percentiles -> [95,99]
+				// Value: start -> [1467721905218]
+				// Value: tags -> [type:cluster,descriptor_name:cpu/usage]
+
+				tags := parseTags(values.Get("tags"))
+				if tags[descriptorTag] == "cpu/usage" && tags["type"] == "pod" && tags["pod_id"] == "pod_id_2" {
+					buckets := []metrics.Bucketpoint{
+						metrics.Bucketpoint{
+							Start:   metrics.FromUnixMilli(start),
+							End:     metrics.FromUnixMilli(end),
+							Min:     float64(1.0),
+							Max:     float64(16.0),
+							Avg:     float64(6.2),
+							Median:  float64(4.0),
+							Samples: 5,
+							Percentiles: []metrics.Percentile{
+								metrics.Percentile{
+									Quantile: 95.0,
+									Value:    4.0, // Not really, but for testing purposes
+								},
+								metrics.Percentile{
+									Quantile: 99.0,
+									Value:    8.0,
+								},
+							},
+							Empty: false,
+						},
+					}
+					b, _ = json.Marshal(buckets)
+				}
+			} else {
+				queryType := path[2]
+				if queryType == "raw" {
+					// Emulate raw datapoint fetching
+					if id == "heapster.test.podid.cpu.usage" {
+
+						data := []metrics.Datapoint{
+							metrics.Datapoint{
+								Timestamp: metrics.FromUnixMilli(start + 1),
+								Value:     3,
+							},
+							metrics.Datapoint{
+								Timestamp: metrics.FromUnixMilli(end - 1),
+								Value:     4,
+							},
+						}
+						b, _ = json.Marshal(data)
+					} else if id == "heapster.test.cluster.cpu.usage" {
+						data := []metrics.Datapoint{
+							metrics.Datapoint{
+								Timestamp: metrics.FromUnixMilli(start + 1),
+								Value:     2,
+							},
+						}
+						b, _ = json.Marshal(data)
+					}
+				}
+			}
+		}
+		if !empty && b != nil {
+			w.WriteHeader(http.StatusOK)
+			w.Write(b)
+		} else {
+			w.WriteHeader(http.StatusNoContent)
+		}
+	}))
+}
+
+func parseTags(tagParam string) map[string]string {
+	tags := make(map[string]string)
+	for _, v := range strings.Split(tagParam, ",") {
+		tagsSplit := strings.Split(v, ":")
+		tags[tagsSplit[0]] = tagsSplit[1]
+	}
+	return tags
+}
+
+func historicKeys() []core.HistoricalKey {
+	return []core.HistoricalKey{
+		core.HistoricalKey{
+			ObjectType:    core.MetricSetTypeSystemContainer,
+			NodeName:      "node_1",
+			ContainerName: "container_1",
+		},
+		core.HistoricalKey{
+			ObjectType:    core.MetricSetTypePodContainer,
+			PodId:         "pod_id_1",
+			ContainerName: "container_2",
+		},
+		core.HistoricalKey{
+			ObjectType:    core.MetricSetTypePodContainer,
+			ContainerName: "container_2",
+			NamespaceName: "namespace_1",
+			PodName:       "pod_name_1",
+		},
+		core.HistoricalKey{
+			ObjectType: core.MetricSetTypePod,
+			PodId:      "pod_id_2",
+		},
+		core.HistoricalKey{
+			ObjectType:    core.MetricSetTypePod,
+			NamespaceName: "namespace_1",
+			PodName:       "pod_name_2",
+		},
+		core.HistoricalKey{
+			ObjectType:    core.MetricSetTypeNamespace,
+			NamespaceName: "namespace_2",
+		},
+		core.HistoricalKey{
+			ObjectType: core.MetricSetTypeNode,
+			NodeName:   "nodename_1",
+		},
+		core.HistoricalKey{
+			ObjectType:    core.MetricSetTypeCluster,
+			NamespaceName: "namespace_3",
+			NodeName:      "cluster_node_1",
+		},
+	}
+}
+
+func historicTest(t *testing.T) *hawkularSink {
+	s := testServer()
+
+	hSink, err := integSink(s.URL + "?tenant=test-heapster&labelToTenant=pod_namespace&batchSize=20&concurrencyLimit=5")
+	assert.NoError(t, err)
+
+	return hSink
+}
+
+// Public functions
+func TestGetMetricNames(t *testing.T) {
+
+	hSink := historicTest(t)
+
+	hKey := core.HistoricalKey{
+		ObjectType: core.MetricSetTypePod,
+		PodId:      "terrible*",
+	}
+
+	names, err := hSink.GetMetricNames(hKey)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(names))
+
+	hKey.PodId = "unknown*"
+	names, err = hSink.GetMetricNames(hKey)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, len(names))
+}
+
+func TestGetNodes(t *testing.T) {
+	hSink := historicTest(t)
+
+	nodes, err := hSink.GetNodes()
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(nodes))
+}
+
+func TestGetMetric(t *testing.T) {
+	hSink := historicTest(t)
+
+	metricName := core.MetricCpuUsage.Name
+	metricKeys := historicKeys()
+
+	tmvs, err := hSink.GetMetric(metricName, metricKeys, time.Now().Add(-1*time.Hour), time.Now())
+	assert.NoError(t, err)
+
+	assert.Equal(t, 2, len(tmvs))
+	assert.Equal(t, 1, len(tmvs[metricKeys[7]]))
+	assert.Equal(t, 2, len(tmvs[metricKeys[3]]))
+}
+
+func TestGetAggregation(t *testing.T) {
+	hSink := historicTest(t)
+
+	metricName := core.MetricCpuUsage.Name
+	metricKeys := historicKeys()
+
+	tavs, err := hSink.GetAggregation(metricName, core.MultiTypedAggregations, metricKeys, time.Now().Add(-1*time.Hour), time.Now(), time.Hour)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 1, len(tavs))
+	assert.Equal(t, 1, len(tavs[metricKeys[3]]))
+	assert.Equal(t, uint64(5), *tavs[metricKeys[3]][0].Count)
+}
+
+func TestGetPodsFromNamespace(t *testing.T) {
+	hSink := historicTest(t)
+
+	pods, err := hSink.GetPodsFromNamespace("namespacey")
+	assert.NoError(t, err)
+	assert.Equal(t, 3, len(pods))
+}
+
+func TestGetSystemContainersFromNode(t *testing.T) {
+	hSink := historicTest(t)
+
+	sysContainers, err := hSink.GetSystemContainersFromNode("host1")
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(sysContainers))
+}
+
+func TestGetNamespaces(t *testing.T) {
+	s := testServer()
+
+	hSink, err := integSink(s.URL + "?tenant=test-heapster&labelToTenant=pod_namespace&batchSize=20&concurrencyLimit=5")
+	assert.NoError(t, err)
+
+	// From tenants
+	namespaces, err := hSink.GetNamespaces()
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(namespaces))
+
+	// From tags
+	hSink, err = integSink(s.URL + "?tenant=test-heapster")
+	assert.NoError(t, err)
+	namespaces, err = hSink.GetNamespaces()
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(namespaces))
+}
+
+// Internal functions
+
+func TestDatapointToMetricValue(t *testing.T) {
+	hSink := dummySink()
+
+	mt := metrics.Gauge
+
+	ts := time.Now()
+	val := float64(1.45)
+
+	dp := metrics.Datapoint{
+		Timestamp: ts,
+		Value:     val,
+	}
+
+	tmv, err := hSink.datapointToMetricValue(&dp, &mt)
+	assert.NoError(t, err)
+
+	assert.Equal(t, val, tmv.MetricValue.FloatValue)
+	assert.Equal(t, core.MetricGauge, tmv.MetricType)
+	assert.Equal(t, core.ValueFloat, tmv.MetricValue.ValueType)
+
+	mt = metrics.Counter
+	vali := int64(3)
+	dp = metrics.Datapoint{
+		Timestamp: ts,
+		Value:     vali,
+	}
+
+	tmv, err = hSink.datapointToMetricValue(&dp, &mt)
+	assert.NoError(t, err)
+
+	assert.Equal(t, vali, tmv.MetricValue.IntValue)
+	assert.Equal(t, core.MetricCumulative, tmv.MetricType)
+	assert.Equal(t, core.ValueInt64, tmv.MetricValue.ValueType)
+}
+
+func TestBucketPointToAggregationValue(t *testing.T) {
+	hSink := dummySink()
+
+	start := time.Now()
+
+	bp := metrics.Bucketpoint{
+		Start:   start,
+		End:     start.Add(time.Second),
+		Min:     float64(1.1),
+		Max:     float64(2.1),
+		Median:  float64(1.6),
+		Avg:     float64(1.6),
+		Empty:   false,
+		Samples: uint64(3),
+		Percentiles: []metrics.Percentile{
+			metrics.Percentile{
+				Quantile: float64(95.0),
+				Value:    float64(1.6),
+			},
+		},
+	}
+
+	mt := metrics.Gauge
+	bucketSize := time.Minute
+
+	tav, err := hSink.bucketPointToAggregationValue(&bp, &mt, core.MultiTypedAggregations, bucketSize)
+	assert.NoError(t, err)
+
+	assert.Equal(t, len(core.MultiTypedAggregations), len(tav.Aggregations))
+	assert.Equal(t, uint64(3), *tav.Count)
+	assert.Equal(t, start, tav.Timestamp) // Agreed value on the PR review
+}
+
+func TestKeyToTags(t *testing.T) {
+	hSink := dummySink()
+
+	hKey := core.HistoricalKey{
+		ObjectType: core.MetricSetTypePod,
+		PodId:      "terrible",
+	}
+
+	mmap := hSink.keyToTags(&hKey)
+
+	assert.Equal(t, core.MetricSetTypePod, mmap[core.LabelMetricSetType.Key])
+	assert.Equal(t, "terrible", mmap[core.LabelPodId.Key])
+
+	// hKeys := historicKeys()
+	// for _, key := range hKeys {
+	//     tags := hSink.keyToTags(key)
+	// }
+}
+
+func TestIsNamespaceTenant(t *testing.T) {
+	c, err := integSink("http://doesnotmatter:8080/?tenant=test-heapster&labelToTenant=pod_namespace")
+	assert.NoError(t, err)
+
+	assert.True(t, c.isNamespaceTenant())
+
+	c, err = integSink("http://doesnotmatter:8080/?tenant=test-heapster")
+	assert.NoError(t, err)
+
+	assert.False(t, c.isNamespaceTenant())
+}

--- a/metrics/sinks/hawkular/driver_historical_test.go
+++ b/metrics/sinks/hawkular/driver_historical_test.go
@@ -369,7 +369,7 @@ func TestDatapointToMetricValue(t *testing.T) {
 	tmv, err := hSink.datapointToMetricValue(&dp, &mt)
 	assert.NoError(t, err)
 
-	assert.Equal(t, val, tmv.MetricValue.FloatValue)
+	assert.Equal(t, float32(val), tmv.MetricValue.FloatValue)
 	assert.Equal(t, core.MetricGauge, tmv.MetricType)
 	assert.Equal(t, core.ValueFloat, tmv.MetricValue.ValueType)
 
@@ -433,11 +433,6 @@ func TestKeyToTags(t *testing.T) {
 
 	assert.Equal(t, core.MetricSetTypePod, mmap[core.LabelMetricSetType.Key])
 	assert.Equal(t, "terrible", mmap[core.LabelPodId.Key])
-
-	// hKeys := historicKeys()
-	// for _, key := range hKeys {
-	//     tags := hSink.keyToTags(key)
-	// }
 }
 
 func TestIsNamespaceTenant(t *testing.T) {

--- a/metrics/sinks/hawkular/driver_test.go
+++ b/metrics/sinks/hawkular/driver_test.go
@@ -57,7 +57,7 @@ func TestDescriptorTransform(t *testing.T) {
 
 	md := hSink.descriptorToDefinition(&smd)
 
-	assert.Equal(t, smd.Name, md.Id)
+	assert.Equal(t, smd.Name, md.ID)
 	assert.Equal(t, 3, len(md.Tags)) // descriptorTag, unitsTag, typesTag, k1
 
 	assert.Equal(t, smd.Units.String(), md.Tags[unitsTag])
@@ -122,7 +122,7 @@ func TestMetricTransform(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, fmt.Sprintf("%s/%s/%s", metricSet.Labels[core.LabelContainerName.Key],
-		metricSet.Labels[core.LabelPodId.Key], metricName), m.Id)
+		metricSet.Labels[core.LabelPodId.Key], metricName), m.ID)
 
 	assert.Equal(t, 1, len(m.Data))
 	_, ok := m.Data[0].Value.(float64)
@@ -134,7 +134,7 @@ func TestMetricTransform(t *testing.T) {
 	m, err = hSink.pointToLabeledMetricHeader(&metricSet, metricSet.LabeledMetrics[2], now)
 	assert.NoError(t, err)
 
-	assert.Equal(t, fmt.Sprintf("%s/%s/%s", metricSet.Labels[core.LabelContainerName.Key], metricSet.Labels[core.LabelNodename.Key], metricName), m.Id)
+	assert.Equal(t, fmt.Sprintf("%s/%s/%s", metricSet.Labels[core.LabelContainerName.Key], metricSet.Labels[core.LabelNodename.Key], metricName), m.ID)
 
 	//
 	m, err = hSink.pointToLabeledMetricHeader(&metricSet, metricSet.LabeledMetrics[0], now)
@@ -142,13 +142,13 @@ func TestMetricTransform(t *testing.T) {
 
 	assert.Equal(t, fmt.Sprintf("%s/%s/%s/%s", metricSet.Labels[core.LabelContainerName.Key],
 		metricSet.Labels[core.LabelNodename.Key], labeledMetricNameA,
-		metricSet.LabeledMetrics[0].Labels[core.LabelResourceID.Key]), m.Id)
+		metricSet.LabeledMetrics[0].Labels[core.LabelResourceID.Key]), m.ID)
 
 	//
 	m, err = hSink.pointToLabeledMetricHeader(&metricSet, metricSet.LabeledMetrics[1], now)
 	assert.NoError(t, err)
 	assert.Equal(t, fmt.Sprintf("%s/%s/%s", metricSet.Labels[core.LabelContainerName.Key],
-		metricSet.Labels[core.LabelNodename.Key], labeledMetricNameB), m.Id)
+		metricSet.Labels[core.LabelNodename.Key], labeledMetricNameB), m.ID)
 }
 
 func TestMetricIds(t *testing.T) {
@@ -181,43 +181,43 @@ func TestMetricIds(t *testing.T) {
 	//
 	m, err := hSink.pointToLabeledMetricHeader(&metricSet, metricSet.LabeledMetrics[0], now)
 	assert.NoError(t, err)
-	assert.Equal(t, fmt.Sprintf("%s/%s/%s", metricSet.Labels[core.LabelContainerName.Key], metricSet.Labels[core.LabelPodId.Key], metricName), m.Id)
+	assert.Equal(t, fmt.Sprintf("%s/%s/%s", metricSet.Labels[core.LabelContainerName.Key], metricSet.Labels[core.LabelPodId.Key], metricName), m.ID)
 
 	//
 	metricSet.Labels[core.LabelMetricSetType.Key] = core.MetricSetTypeNode
 	m, err = hSink.pointToLabeledMetricHeader(&metricSet, metricSet.LabeledMetrics[0], now)
 	assert.NoError(t, err)
-	assert.Equal(t, fmt.Sprintf("%s/%s/%s", "machine", metricSet.Labels[core.LabelNodename.Key], metricName), m.Id)
+	assert.Equal(t, fmt.Sprintf("%s/%s/%s", "machine", metricSet.Labels[core.LabelNodename.Key], metricName), m.ID)
 
 	//
 	metricSet.Labels[core.LabelMetricSetType.Key] = core.MetricSetTypePod
 	m, err = hSink.pointToLabeledMetricHeader(&metricSet, metricSet.LabeledMetrics[0], now)
 	assert.NoError(t, err)
-	assert.Equal(t, fmt.Sprintf("%s/%s/%s", core.MetricSetTypePod, metricSet.Labels[core.LabelPodId.Key], metricName), m.Id)
+	assert.Equal(t, fmt.Sprintf("%s/%s/%s", core.MetricSetTypePod, metricSet.Labels[core.LabelPodId.Key], metricName), m.ID)
 
 	//
 	metricSet.Labels[core.LabelMetricSetType.Key] = core.MetricSetTypePodContainer
 	m, err = hSink.pointToLabeledMetricHeader(&metricSet, metricSet.LabeledMetrics[0], now)
 	assert.NoError(t, err)
-	assert.Equal(t, fmt.Sprintf("%s/%s/%s", metricSet.Labels[core.LabelContainerName.Key], metricSet.Labels[core.LabelPodId.Key], metricName), m.Id)
+	assert.Equal(t, fmt.Sprintf("%s/%s/%s", metricSet.Labels[core.LabelContainerName.Key], metricSet.Labels[core.LabelPodId.Key], metricName), m.ID)
 
 	//
 	metricSet.Labels[core.LabelMetricSetType.Key] = core.MetricSetTypeSystemContainer
 	m, err = hSink.pointToLabeledMetricHeader(&metricSet, metricSet.LabeledMetrics[0], now)
 	assert.NoError(t, err)
-	assert.Equal(t, fmt.Sprintf("%s/%s/%s/%s", core.MetricSetTypeSystemContainer, metricSet.Labels[core.LabelContainerName.Key], metricSet.Labels[core.LabelPodId.Key], metricName), m.Id)
+	assert.Equal(t, fmt.Sprintf("%s/%s/%s/%s", core.MetricSetTypeSystemContainer, metricSet.Labels[core.LabelContainerName.Key], metricSet.Labels[core.LabelPodId.Key], metricName), m.ID)
 
 	//
 	metricSet.Labels[core.LabelMetricSetType.Key] = core.MetricSetTypeCluster
 	m, err = hSink.pointToLabeledMetricHeader(&metricSet, metricSet.LabeledMetrics[0], now)
 	assert.NoError(t, err)
-	assert.Equal(t, fmt.Sprintf("%s/%s", core.MetricSetTypeCluster, metricName), m.Id)
+	assert.Equal(t, fmt.Sprintf("%s/%s", core.MetricSetTypeCluster, metricName), m.ID)
 
 	//
 	metricSet.Labels[core.LabelMetricSetType.Key] = core.MetricSetTypeNamespace
 	m, err = hSink.pointToLabeledMetricHeader(&metricSet, metricSet.LabeledMetrics[0], now)
 	assert.NoError(t, err)
-	assert.Equal(t, fmt.Sprintf("%s/%s/%s", core.MetricSetTypeNamespace, metricSet.Labels[core.LabelNamespaceName.Key], metricName), m.Id)
+	assert.Equal(t, fmt.Sprintf("%s/%s/%s", core.MetricSetTypeNamespace, metricSet.Labels[core.LabelNamespaceName.Key], metricName), m.ID)
 
 }
 
@@ -232,7 +232,7 @@ func TestRecentTest(t *testing.T) {
 	modelT["hep"+descriptionTag] = "n"
 
 	model := metrics.MetricDefinition{
-		Id:   id,
+		ID:   id,
 		Tags: modelT,
 	}
 
@@ -242,7 +242,7 @@ func TestRecentTest(t *testing.T) {
 	}
 
 	live := metrics.MetricDefinition{
-		Id:   "test/" + id,
+		ID:   "test/" + id,
 		Tags: liveT,
 	}
 
@@ -381,7 +381,7 @@ func TestStoreTimeseries(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 
 		typ := r.RequestURI[strings.Index(r.RequestURI, "hawkular/metrics/")+17:]
-		typ = typ[:len(typ)-5]
+		typ = typ[:strings.LastIndex(typ, "/")]
 
 		switch typ {
 		case "counters":
@@ -404,7 +404,7 @@ func TestStoreTimeseries(t *testing.T) {
 
 		assert.Equal(t, 1, len(mH))
 
-		ids = append(ids, mH[0].Id)
+		ids = append(ids, mH[0].ID)
 	}))
 	defer s.Close()
 
@@ -494,7 +494,7 @@ func TestFiltering(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		m.Lock()
 		defer m.Unlock()
-		if strings.Contains(r.RequestURI, "data") {
+		if strings.Contains(r.RequestURI, "raw") {
 			defer r.Body.Close()
 			b, err := ioutil.ReadAll(r.Body)
 			assert.NoError(t, err)
@@ -621,7 +621,7 @@ func TestBatchingTimeseries(t *testing.T) {
 		assert.NoError(t, err)
 
 		for _, v := range mH {
-			ids = append(ids, v.Id)
+			ids = append(ids, v.ID)
 		}
 
 		calls++
@@ -671,3 +671,5 @@ func TestBatchingTimeseries(t *testing.T) {
 		newIds[v] = true
 	}
 }
+
+// HistoricalSource tests

--- a/metrics/sinks/hawkular/types.go
+++ b/metrics/sinks/hawkular/types.go
@@ -71,3 +71,14 @@ func heapsterTypeToHawkularType(t core.MetricType) metrics.MetricType {
 		return metrics.Gauge
 	}
 }
+
+func hawkularTypeToHeapsterType(t metrics.MetricType) core.MetricType {
+	switch t {
+	case metrics.Gauge:
+		return core.MetricGauge
+	case metrics.Counter:
+		return core.MetricCumulative
+	default:
+		return core.MetricGauge
+	}
+}

--- a/vendor/github.com/hawkular/hawkular-client-go/metrics/client.go
+++ b/vendor/github.com/hawkular/hawkular-client-go/metrics/client.go
@@ -30,8 +30,6 @@ import (
 	"time"
 )
 
-// TODO Instrumentation? To get statistics?
-
 func (c *HawkularClientError) Error() string {
 	return fmt.Sprintf("Hawkular returned status code %d, error message: %s", c.Code, c.msg)
 }
@@ -44,7 +42,7 @@ const (
 	timeout            time.Duration = time.Duration(30 * time.Second)
 )
 
-// Tenant Override function to replace the Tenant (defaults to Client default)
+// Tenant function replaces the Tenant in the request (instead of using the default in Client parameters)
 func Tenant(tenant string) Modifier {
 	return func(r *http.Request) error {
 		r.Header.Set("Hawkular-Tenant", tenant)
@@ -52,7 +50,7 @@ func Tenant(tenant string) Modifier {
 	}
 }
 
-// Data Add payload to the request
+// Data adds payload to the request
 func Data(data interface{}) Modifier {
 	return func(r *http.Request) error {
 		jsonb, err := json.Marshal(data)
@@ -64,8 +62,6 @@ func Data(data interface{}) Modifier {
 		rc := ioutil.NopCloser(b)
 		r.Body = rc
 
-		// fmt.Printf("Sending: %s\n", string(jsonb))
-
 		if b != nil {
 			r.ContentLength = int64(b.Len())
 		}
@@ -73,9 +69,10 @@ func Data(data interface{}) Modifier {
 	}
 }
 
-// URL Set the request URL
-func (c *Client) Url(method string, e ...Endpoint) Modifier {
+// URL sets the request URL
+func (c *Client) URL(method string, e ...Endpoint) Modifier {
 	// TODO Create composite URLs? Add().Add().. etc? Easier to modify on the fly..
+	// And also remove the necessary order of Adds
 	return func(r *http.Request) error {
 		u := c.createURL(e...)
 		r.URL = u
@@ -84,7 +81,7 @@ func (c *Client) Url(method string, e ...Endpoint) Modifier {
 	}
 }
 
-// Filters Multiple Filter types to execute
+// Filters allows using multiple Filter types in the same request
 func Filters(f ...Filter) Modifier {
 	return func(r *http.Request) error {
 		for _, filter := range f {
@@ -94,7 +91,7 @@ func Filters(f ...Filter) Modifier {
 	}
 }
 
-// Param Add query parameters
+// Param adds query parameters to the request
 func Param(k string, v string) Filter {
 	return func(r *http.Request) {
 		q := r.URL.Query()
@@ -103,38 +100,45 @@ func Param(k string, v string) Filter {
 	}
 }
 
-// TypeFilter Query parameter filtering with type
+// TypeFilter is a query parameter to filter by type
 func TypeFilter(t MetricType) Filter {
-	return Param("type", t.shortForm())
+	return Param("type", fmt.Sprint(t))
 }
 
-// TagsFilter Query parameter filtering with tags
+// TagsFilter is a query parameter to filter with tags query
 func TagsFilter(t map[string]string) Filter {
 	j := tagsEncoder(t)
 	return Param("tags", j)
 }
 
-// IdFilter Query parameter to add filtering by id name
+// IdFilter is a query parameter to add filtering by id name
 func IdFilter(regexp string) Filter {
 	return Param("id", regexp)
 }
 
-// StartTimeFilter Query parameter to filter with start time
+// StartTimeFilter is a query parameter to filter with start time
 func StartTimeFilter(startTime time.Time) Filter {
-	return Param("start", strconv.Itoa(int(startTime.Unix())))
+	// return Param("start", strconv.Itoa(int(startTime.Unix())))
+	return Param("start", strconv.Itoa(int(ToUnixMilli(startTime))))
 }
 
-// EndTimeFilter Query parameter to filter with end time
+// EndTimeFilter is a query parameter to filter with end time
 func EndTimeFilter(endTime time.Time) Filter {
-	return Param("end", strconv.Itoa(int(endTime.Unix())))
+	return Param("end", strconv.Itoa(int(ToUnixMilli(endTime))))
 }
 
-// BucketsFilter Query parameter to define amount of buckets
+// BucketsFilter is a query parameter to define amount of buckets
 func BucketsFilter(buckets int) Filter {
 	return Param("buckets", strconv.Itoa(buckets))
 }
 
-// LimitFilter Query parameter to limit result count
+// BucketsDurationFilter is a query parameter to set the size of a bucket based on duration
+// Minimum supported bucket is 1 millisecond
+func BucketsDurationFilter(duration time.Duration) Filter {
+	return Param("bucketDuration", fmt.Sprintf("%dms", (duration.Nanoseconds()/1e6)))
+}
+
+// LimitFilter is a query parameter to limit result count
 func LimitFilter(limit int) Filter {
 	return Param("limit", strconv.Itoa(limit))
 }
@@ -144,17 +148,17 @@ func OrderFilter(order Order) Filter {
 	return Param("order", order.String())
 }
 
-// StartFromBeginningFilter Return data from the oldest stored datapoint
+// StartFromBeginningFilter returns data from the oldest stored datapoint
 func StartFromBeginningFilter() Filter {
 	return Param("fromEarliest", "true")
 }
 
-// StackedFilter Force downsampling of stacked return values
+// StackedFilter forces downsampling of stacked return values
 func StackedFilter() Filter {
 	return Param("stacked", "true")
 }
 
-// PercentilesFilter Query parameter to define the requested percentiles
+// PercentilesFilter is a query parameter to define the requested percentiles
 func PercentilesFilter(percentiles []float64) Filter {
 	s := make([]string, 0, len(percentiles))
 	for _, v := range percentiles {
@@ -184,7 +188,8 @@ func (c *Client) createRequest() *http.Request {
 	return req
 }
 
-// Send Sends a constructed request to the Hawkular-Metrics server
+// Send sends a constructed request to the Hawkular-Metrics server.
+// All the requests are pooled and limited by set concurrency limits
 func (c *Client) Send(o ...Modifier) (*http.Response, error) {
 	// Initialize
 	r := c.createRequest()
@@ -210,10 +215,39 @@ func (c *Client) Send(o ...Modifier) (*http.Response, error) {
 
 // Commands
 
-// Create Creates new metric Definition
-func (c *Client) Create(md MetricDefinition, o ...Modifier) (bool, error) {
-	// Keep the order, add custom prepend
-	o = prepend(o, c.Url("POST", TypeEndpoint(md.Type)), Data(md))
+// Tenants returns a list of tenants from the server
+func (c *Client) Tenants(o ...Modifier) ([]*TenantDefinition, error) {
+	o = prepend(o, c.URL("GET", TenantEndpoint()))
+
+	r, err := c.Send(o...)
+	if err != nil {
+		return nil, err
+	}
+
+	defer r.Body.Close()
+
+	if r.StatusCode == http.StatusOK {
+		b, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			return nil, err
+		}
+		tenants := []*TenantDefinition{}
+		if b != nil {
+			if err = json.Unmarshal(b, &tenants); err != nil {
+				return nil, err
+			}
+		}
+		return tenants, err
+	} else if r.StatusCode > 399 {
+		return nil, c.parseErrorResponse(r)
+	}
+
+	return nil, nil
+}
+
+// CreateTenant creates a tenant definition on the server
+func (c *Client) CreateTenant(tenant TenantDefinition, o ...Modifier) (bool, error) {
+	o = prepend(o, c.URL("POST", TenantEndpoint()), Data(tenant))
 
 	r, err := c.Send(o...)
 	if err != nil {
@@ -236,9 +270,35 @@ func (c *Client) Create(md MetricDefinition, o ...Modifier) (bool, error) {
 	return true, nil
 }
 
-// Definitions Fetch metric definitions
+// Create creates a new metric definition
+func (c *Client) Create(md MetricDefinition, o ...Modifier) (bool, error) {
+	// Keep the order, add custom prepend
+	o = prepend(o, c.URL("POST", TypeEndpoint(md.Type)), Data(md))
+
+	r, err := c.Send(o...)
+	if err != nil {
+		return false, err
+	}
+
+	defer r.Body.Close()
+
+	if r.StatusCode > 399 {
+		err = c.parseErrorResponse(r)
+		if err, ok := err.(*HawkularClientError); ok {
+			if err.Code != http.StatusConflict {
+				return false, err
+			} else {
+				return false, nil
+			}
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// Definitions fetches metric definitions from the server
 func (c *Client) Definitions(o ...Modifier) ([]*MetricDefinition, error) {
-	o = prepend(o, c.Url("GET", TypeEndpoint(Generic)))
+	o = prepend(o, c.URL("GET", TypeEndpoint(Generic)))
 
 	r, err := c.Send(o...)
 	if err != nil {
@@ -266,9 +326,9 @@ func (c *Client) Definitions(o ...Modifier) ([]*MetricDefinition, error) {
 	return nil, nil
 }
 
-// Definition Return a single definition
+// Definition returns a single metric definition
 func (c *Client) Definition(t MetricType, id string, o ...Modifier) (*MetricDefinition, error) {
-	o = prepend(o, c.Url("GET", TypeEndpoint(t), SingleMetricEndpoint(id)))
+	o = prepend(o, c.URL("GET", TypeEndpoint(t), SingleMetricEndpoint(id)))
 
 	r, err := c.Send(o...)
 	if err != nil {
@@ -296,9 +356,39 @@ func (c *Client) Definition(t MetricType, id string, o ...Modifier) (*MetricDefi
 	return nil, nil
 }
 
-// UpdateTags Update tags of a metric (or create if not existing)
+// TagValues queries for available tagValues
+func (c *Client) TagValues(tagQuery map[string]string, o ...Modifier) (map[string][]string, error) {
+	o = prepend(o, c.URL("GET", TypeEndpoint(Generic), TagEndpoint(), TagsEndpoint(tagQuery)))
+
+	r, err := c.Send(o...)
+	if err != nil {
+		return nil, err
+	}
+
+	defer r.Body.Close()
+
+	if r.StatusCode == http.StatusOK {
+		b, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			return nil, err
+		}
+		md := make(map[string][]string)
+		if b != nil {
+			if err = json.Unmarshal(b, &md); err != nil {
+				return nil, err
+			}
+		}
+		return md, err
+	} else if r.StatusCode > 399 {
+		return nil, c.parseErrorResponse(r)
+	}
+
+	return nil, nil
+}
+
+// UpdateTags modifies the tags of a metric definition
 func (c *Client) UpdateTags(t MetricType, id string, tags map[string]string, o ...Modifier) error {
-	o = prepend(o, c.Url("PUT", TypeEndpoint(t), SingleMetricEndpoint(id), TagEndpoint()), Data(tags))
+	o = prepend(o, c.URL("PUT", TypeEndpoint(t), SingleMetricEndpoint(id), TagEndpoint()), Data(tags))
 
 	r, err := c.Send(o...)
 	if err != nil {
@@ -314,9 +404,9 @@ func (c *Client) UpdateTags(t MetricType, id string, tags map[string]string, o .
 	return nil
 }
 
-// DeleteTags Delete given tags from the definition
+// DeleteTags deletes given tags from the definition
 func (c *Client) DeleteTags(t MetricType, id string, tags map[string]string, o ...Modifier) error {
-	o = prepend(o, c.Url("DELETE", TypeEndpoint(t), SingleMetricEndpoint(id), TagEndpoint(), TagsEndpoint(tags)))
+	o = prepend(o, c.URL("DELETE", TypeEndpoint(t), SingleMetricEndpoint(id), TagEndpoint(), TagsEndpoint(tags)))
 
 	r, err := c.Send(o...)
 	if err != nil {
@@ -332,9 +422,9 @@ func (c *Client) DeleteTags(t MetricType, id string, tags map[string]string, o .
 	return nil
 }
 
-// Tags Fetch metric definition's tags
+// Tags fetches metric definition's tags
 func (c *Client) Tags(t MetricType, id string, o ...Modifier) (map[string]string, error) {
-	o = prepend(o, c.Url("GET", TypeEndpoint(t), SingleMetricEndpoint(id), TagEndpoint()))
+	o = prepend(o, c.URL("GET", TypeEndpoint(t), SingleMetricEndpoint(id), TagEndpoint()))
 
 	r, err := c.Send(o...)
 	if err != nil {
@@ -362,7 +452,7 @@ func (c *Client) Tags(t MetricType, id string, o ...Modifier) (map[string]string
 	return nil, nil
 }
 
-// Write Write datapoints to the server
+// Write writes datapoints to the server
 func (c *Client) Write(metrics []MetricHeader, o ...Modifier) error {
 	if len(metrics) > 0 {
 		mHs := make(map[MetricType][]MetricHeader)
@@ -383,7 +473,7 @@ func (c *Client) Write(metrics []MetricHeader, o ...Modifier) error {
 
 				// Should be sorted and splitted by type & tenant..
 				on := o
-				on = prepend(on, c.Url("POST", TypeEndpoint(k), DataEndpoint()), Data(v))
+				on = prepend(on, c.URL("POST", TypeEndpoint(k), RawEndpoint()), Data(v))
 
 				r, err := c.Send(on...)
 				if err != nil {
@@ -413,9 +503,9 @@ func (c *Client) Write(metrics []MetricHeader, o ...Modifier) error {
 	return nil
 }
 
-// ReadMetric Read metric datapoints from the server
-func (c *Client) ReadMetric(t MetricType, id string, o ...Modifier) ([]*Datapoint, error) {
-	o = prepend(o, c.Url("GET", TypeEndpoint(t), SingleMetricEndpoint(id), DataEndpoint()))
+// ReadMetric reads metric datapoints from the server for the given metric
+func (c *Client) ReadRaw(t MetricType, id string, o ...Modifier) ([]*Datapoint, error) {
+	o = prepend(o, c.URL("GET", TypeEndpoint(t), SingleMetricEndpoint(id), RawEndpoint()))
 
 	r, err := c.Send(o...)
 	if err != nil {
@@ -430,7 +520,6 @@ func (c *Client) ReadMetric(t MetricType, id string, o ...Modifier) ([]*Datapoin
 			return nil, err
 		}
 
-		// Check for GaugeBucketpoint and so on for the rest.. uh
 		dp := []*Datapoint{}
 		if b != nil {
 			if err = json.Unmarshal(b, &dp); err != nil {
@@ -445,9 +534,9 @@ func (c *Client) ReadMetric(t MetricType, id string, o ...Modifier) ([]*Datapoin
 	return nil, nil
 }
 
-// ReadBuckets Read datapoints from the server with in buckets (aggregates)
+// ReadBuckets reads datapoints from the server, aggregated to buckets with given parameters.
 func (c *Client) ReadBuckets(t MetricType, o ...Modifier) ([]*Bucketpoint, error) {
-	o = prepend(o, c.Url("GET", TypeEndpoint(t), DataEndpoint()))
+	o = prepend(o, c.URL("GET", TypeEndpoint(t), StatsEndpoint()))
 
 	r, err := c.Send(o...)
 	if err != nil {
@@ -477,7 +566,7 @@ func (c *Client) ReadBuckets(t MetricType, o ...Modifier) ([]*Bucketpoint, error
 	return nil, nil
 }
 
-// NewHawkularClient Initialization
+// NewHawkularClient returns a new initialized instance of client
 func NewHawkularClient(p Parameters) (*Client, error) {
 	uri, err := url.Parse(p.Url)
 	if err != nil {
@@ -522,7 +611,7 @@ func NewHawkularClient(p Parameters) (*Client, error) {
 	return client, nil
 }
 
-// Close Safely close the Hawkular-Metrics client and flush remaining work
+// Close safely closes the Hawkular-Metrics client and flushes remaining writes to the server
 func (c *Client) Close() {
 	close(c.pool)
 }
@@ -562,38 +651,59 @@ func (c *Client) createURL(e ...Endpoint) *url.URL {
 	return &mu
 }
 
-// TypeEndpoint URL endpoint setting metricType
-func TypeEndpoint(t MetricType) Endpoint {
+// TenantEndpoint is a URL endpoint to fetch tenant related information
+func TenantEndpoint() Endpoint {
 	return func(u *url.URL) {
-		addToURL(u, t.String())
+		addToURL(u, "tenants")
 	}
 }
 
-// SingleMetricEndpoint URL endpoint for requesting single metricID
+// TypeEndpoint is a URL endpoint setting metricType
+func TypeEndpoint(t MetricType) Endpoint {
+	return func(u *url.URL) {
+		switch t {
+		case Gauge:
+			addToURL(u, "gauges")
+		case Counter:
+			addToURL(u, "counters")
+		default:
+			addToURL(u, string(t))
+		}
+	}
+}
+
+// SingleMetricEndpoint is a URL endpoint for requesting single metricID
 func SingleMetricEndpoint(id string) Endpoint {
 	return func(u *url.URL) {
 		addToURL(u, url.QueryEscape(id))
 	}
 }
 
-// TagEndpoint URL endpoint to check tags information
+// TagEndpoint is a URL endpoint to check tags information
 func TagEndpoint() Endpoint {
 	return func(u *url.URL) {
 		addToURL(u, "tags")
 	}
 }
 
-// TagsEndpoint URL endpoint which adds tags query
+// TagsEndpoint is a URL endpoint which adds tags query
 func TagsEndpoint(tags map[string]string) Endpoint {
 	return func(u *url.URL) {
 		addToURL(u, tagsEncoder(tags))
 	}
 }
 
-// DataEndpoint URL endpoint for inserting / requesting datapoints
-func DataEndpoint() Endpoint {
+// RawEndpoint is an endpoint to read and write raw datapoints
+func RawEndpoint() Endpoint {
 	return func(u *url.URL) {
-		addToURL(u, "data")
+		addToURL(u, "raw")
+	}
+}
+
+// StatsEndpoint is an endpoint to read aggregated metrics
+func StatsEndpoint() Endpoint {
+	return func(u *url.URL) {
+		addToURL(u, "stats")
 	}
 }
 

--- a/vendor/github.com/hawkular/hawkular-client-go/metrics/helpers.go
+++ b/vendor/github.com/hawkular/hawkular-client-go/metrics/helpers.go
@@ -75,9 +75,14 @@ func ConvertToFloat64(v interface{}) (float64, error) {
 	}
 }
 
-// UnixMilli Returns milliseconds since epoch
-func UnixMilli(t time.Time) int64 {
-	return t.UnixNano() / 1e6
+// ToUnixMilli returns milliseconds since epoch from time.Time
+func ToUnixMilli(t time.Time) int64 {
+	return t.UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond))
+}
+
+// FromUnixMilli returns time.Time from milliseconds since epoch
+func FromUnixMilli(milli int64) time.Time {
+	return time.Unix(0, milli*int64(time.Millisecond))
 }
 
 // Prepend Helper function to insert modifier in the beginning of slice


### PR DESCRIPTION
Adds the ability of Oldtimer to use Hawkular as the backend.
- It's not in every situation possible to get 1:1 matching against internal API. This is because it's possible to configure Hawkular-Metrics sink with parameters that can't be transformed back with the information available in the requests in the Oldtimer API.
- Updates the Hawkular-Metrics client and current sink with small changes.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/heapster/1209)

<!-- Reviewable:end -->
