### PR TITLE
Remove quoting around --sink argument

### DIFF
--- a/deploy/kube-config/kafka/heapster-controller.yaml
+++ b/deploy/kube-config/kafka/heapster-controller.yaml
@@ -25,4 +25,4 @@ spec:
         command:
         - /heapster
         - --source=kubernetes:https://kubernetes.default
-        - --sink="kafka:?brokers=monitoring-kafka:9092&timeseriestopic=timeseries&eventstopic=events"
+        - --sink=kafka:?brokers=monitoring-kafka:9092&timeseriestopic=timeseries&eventstopic=events


### PR DESCRIPTION
after two days of debugging why we're not getting any metrics, we tried removing the quotes around the --sink argument and it started working.
