### PR TITLE
Push Metrics

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -180,6 +180,11 @@
 			"Rev": "ca53cad383cad2479bbba7f7a1a05797ec1386e4"
 		},
 		{
+			"ImportPath": "github.com/prometheus/client_golang/extraction",
+			"Comment": "0.4.0-1-g692492e",
+			"Rev": "692492e54b553a81013254cc1fba4b6dd76fad30"
+		},
+		{
 			"ImportPath": "github.com/prometheus/client_golang/model",
 			"Comment": "0.4.0-1-g692492e",
 			"Rev": "692492e54b553a81013254cc1fba4b6dd76fad30"
@@ -198,6 +203,18 @@
 			"ImportPath": "github.com/prometheus/client_model/go",
 			"Comment": "model-0.0.2-12-gfa8ad6f",
 			"Rev": "fa8ad6fec33561be4280a8f0514318c79d7f6cb6"
+		},
+		{
+			"ImportPath": "github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg",
+			"Rev": "c16e34897a744c32f6733ee720e60c4de13887fb"
+		},
+		{
+			"ImportPath": "github.com/prometheus/common/expfmt",
+			"Rev": "c16e34897a744c32f6733ee720e60c4de13887fb"
+		},
+		{
+			"ImportPath": "github.com/prometheus/common/model",
+			"Rev": "c16e34897a744c32f6733ee720e60c4de13887fb"
 		},
 		{
 			"ImportPath": "github.com/prometheus/procfs",

--- a/metrics/api/v1/api.go
+++ b/metrics/api/v1/api.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/heapster/metrics/api/v1/types"
 	"k8s.io/heapster/metrics/core"
 	metricsink "k8s.io/heapster/metrics/sinks/metric"
+	"k8s.io/heapster/metrics/sources/push"
 )
 
 type Api struct {
@@ -94,6 +95,23 @@ func (a *Api) Register(container *restful.Container) {
 	if a.historicalSource != nil {
 		a.RegisterHistorical(container)
 	}
+}
+
+type PushApi struct {
+	pushSource push.PushSource
+}
+
+// Create a new PushApi to serve from the specified cache.
+func NewPushApi(pushSource push.PushSource) *PushApi {
+	return &PushApi{
+		pushSource: pushSource,
+	}
+}
+
+// Register the mainApi on the specified endpoint.
+func (a *PushApi) Register(container *restful.Container) {
+	// Register the available push metric formats
+	a.RegisterFormatHandlers(container)
 }
 
 func convertLabelDescriptor(ld core.LabelDescriptor) types.LabelDescriptor {

--- a/metrics/api/v1/push_handlers.go
+++ b/metrics/api/v1/push_handlers.go
@@ -1,0 +1,356 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	restful "github.com/emicklei/go-restful"
+	prompb "github.com/prometheus/client_model/go"
+	promfmt "github.com/prometheus/common/expfmt"
+	authinfo "k8s.io/kubernetes/pkg/auth/user"
+
+	"k8s.io/heapster/metrics/core"
+	"k8s.io/heapster/metrics/util"
+	"k8s.io/heapster/metrics/util/metrics"
+)
+
+func (a *PushApi) RegisterFormatHandlers(container *restful.Container) {
+	ws := new(restful.WebService)
+	ws.Path("/api/v1/push").
+		Doc("Root endpoint of the push metrics target").
+		Consumes("*/*").
+		Produces(restful.MIME_JSON)
+	// The /prometheus/ endpoint is normal prometheus push metrics destination
+	ws.Route(ws.POST("/prometheus").
+		To(metrics.InstrumentRouteFunc("prometheusPushRequest", a.prometheusPushRequest)).
+		Doc("Push metrics in prometheus (text or protobuf) format").
+		Operation("prometheusPushRequest"))
+
+	// These routes are just like the /prometheus/ endpoint, but exist for
+	// quasi-compatibility with Prometheus push gateway
+	ws.Route(ws.POST("/prometheus/metrics/jobs/{producer}").
+		To(metrics.InstrumentRouteFunc("prometheusPushRequest", a.prometheusPushRequest)).
+		Doc("Push metrics in prometheus (text or protobuf) format").
+		Operation("prometheusPushRequest"))
+	ws.Route(ws.POST("/prometheus/metrics/job/{producer}").
+		To(metrics.InstrumentRouteFunc("prometheusPushRequest", a.prometheusPushRequest)).
+		Doc("Push metrics in prometheus (text or protobuf) format").
+		Operation("prometheusPushRequest"))
+	container.Add(ws)
+}
+
+// ingestPrometheusMetrics takes a set of headers and body content (plus a source name), and
+// extract and processes the body, converting it from a Prometheus metrics format (specified
+// in the headers) into a Heapster DataBatch.
+func ingestPrometheusMetrics(user string, headers http.Header, body io.Reader) (*core.DataBatch, int, error) {
+	metricsFormat := promfmt.ResponseFormat(headers)
+	if metricsFormat == promfmt.FmtUnknown {
+		return nil, http.StatusUnsupportedMediaType, fmt.Errorf("Unable to determine format of submitted Prometheus metrics")
+	}
+
+	decoder := promfmt.NewDecoder(body, metricsFormat)
+	ingester := &dataBatchIngester{
+		nameFormat: fmt.Sprintf("custom/%s/%%s", user),
+		batch: &core.DataBatch{
+			Timestamp:  nowFunc(),
+			MetricSets: map[string]*core.MetricSet{},
+		},
+		defaultTimestamp: nowFunc(),
+	}
+
+	if err := ingester.IngestAll(decoder); err != nil {
+		actualErr := fmt.Errorf("Unable to process submitted Prometheus metrics: %v", err)
+		return nil, http.StatusBadRequest, actualErr
+	}
+
+	return ingester.batch, 0, nil
+}
+
+// prometheusPushRequest processes a request to push metrics in the prometheus format, converting
+// them into internal Heapster form and storing them in the PushSource
+func (a *PushApi) prometheusPushRequest(req *restful.Request, resp *restful.Response) {
+	userInfo := req.Attribute(util.UserAttributeName).(authinfo.Info)
+	userName := userInfo.GetName()
+	// Double check here just to make sure we don't have a bad prefix
+	if userName == "" {
+		resp.WriteError(http.StatusUnauthorized, fmt.Errorf("Metrics must be submitted as a specific user"))
+		return
+	}
+
+	pathUser := req.PathParameter("producer")
+	if pathUser != "" && pathUser != userName {
+		resp.WriteError(http.StatusUnauthorized, fmt.Errorf("Metrics must be submitted as the authenticated user"))
+	}
+
+	batch, errStatus, err := ingestPrometheusMetrics(userName, req.Request.Header, req.Request.Body)
+	if err != nil {
+		resp.WriteError(errStatus, err)
+		return
+	}
+
+	// TODO: do we need to do this ourselves?
+	req.Request.Body.Close()
+
+	a.pushSource.PushMetrics(batch, userName)
+
+	resp.WriteHeader(http.StatusAccepted)
+}
+
+// dataBatchIngester is a Prometheus ingester for use with a processor which
+// ingests into a Heapster DataBatch
+type dataBatchIngester struct {
+	batch            *core.DataBatch
+	nameFormat       string
+	defaultTimestamp time.Time
+}
+
+func (ing *dataBatchIngester) ingestNormalMetricEntry(metricType core.MetricType, familyName string, metric *prompb.Metric, value float64) error {
+	key, setLabels, normalLabels, err := extractKeyAndFilterLabels(metric.Label)
+	if err != nil {
+		return err
+	}
+
+	metricSet, wasPresent := ing.batch.MetricSets[key]
+	if !wasPresent {
+		metricSet = &core.MetricSet{
+			MetricValues:   make(map[string]core.MetricValue),
+			Labels:         setLabels,
+			LabeledMetrics: nil,
+		}
+
+		if metric.TimestampMs != nil {
+			metricSet.ScrapeTime = time.Unix(0, *metric.TimestampMs*1000000)
+		} else {
+			metricSet.ScrapeTime = ing.defaultTimestamp
+		}
+
+		ing.batch.MetricSets[key] = metricSet
+	}
+
+	// NB: all prometheus values are float64 values
+	val := core.MetricValue{
+		// WHY?  WHY ARE WE USING FLOAT32 BUT INT64?
+		FloatValue: float32(value),
+		ValueType:  core.ValueFloat,
+		MetricType: metricType,
+	}
+
+	metricName := fmt.Sprintf(ing.nameFormat, familyName)
+
+	// check to see if this metric needs to be added as a labeled metric
+	if len(normalLabels) != 0 {
+		labeledMetric := core.LabeledMetric{
+			Name:        metricName,
+			Labels:      normalLabels,
+			MetricValue: val,
+		}
+		metricSet.LabeledMetrics = append(metricSet.LabeledMetrics, labeledMetric)
+		return nil
+	}
+
+	metricSet.MetricValues[metricName] = val
+
+	return nil
+}
+
+func (ing *dataBatchIngester) ingestCumulative(family *prompb.MetricFamily) error {
+	familyName := family.GetName()
+
+	for _, metricEntry := range family.Metric {
+		if metricEntry.Counter == nil {
+			continue
+		}
+
+		if err := ing.ingestNormalMetricEntry(core.MetricCumulative, familyName, metricEntry, metricEntry.Counter.GetValue()); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (ing *dataBatchIngester) ingestGauge(family *prompb.MetricFamily) error {
+	familyName := family.GetName()
+
+	for _, metricEntry := range family.Metric {
+		if metricEntry.Gauge == nil {
+			continue
+		}
+
+		if err := ing.ingestNormalMetricEntry(core.MetricGauge, familyName, metricEntry, metricEntry.Gauge.GetValue()); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (ing *dataBatchIngester) ingestUntyped(family *prompb.MetricFamily) error {
+	familyName := family.GetName()
+
+	for _, metricEntry := range family.Metric {
+		if metricEntry.Untyped == nil {
+			continue
+		}
+
+		// assume untyped is a gauge
+		if err := ing.ingestNormalMetricEntry(core.MetricGauge, familyName, metricEntry, metricEntry.Untyped.GetValue()); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (ing *dataBatchIngester) IngestMetricFamily(family *prompb.MetricFamily) error {
+	switch family.GetType() {
+	case prompb.MetricType_COUNTER:
+		return ing.ingestCumulative(family)
+	case prompb.MetricType_GAUGE:
+		return ing.ingestGauge(family)
+	case prompb.MetricType_UNTYPED:
+		return ing.ingestUntyped(family)
+	case prompb.MetricType_SUMMARY:
+		return fmt.Errorf("unsupported metric type %q encountered", "Summary")
+	case prompb.MetricType_HISTOGRAM:
+		return fmt.Errorf("unsupported metric type %q encountered", "Histogram")
+	default:
+		return fmt.Errorf("unknown metric type identifier %v encountered", family.GetType())
+	}
+}
+
+func (ing *dataBatchIngester) IngestAll(decoder promfmt.Decoder) error {
+	metricFamily := &prompb.MetricFamily{}
+	var err error
+	for {
+		err = decoder.Decode(metricFamily)
+		if err != nil {
+			break
+		}
+		ing.IngestMetricFamily(metricFamily)
+	}
+
+	if err == io.EOF {
+		// EOF isn't actually an error
+		err = nil
+	}
+
+	return err
+
+}
+
+// extractKeyAndFilterLabels extracts a key (as defined in ms_keys.go) from the given
+// set of labels, and splits the remaining labels into those appropriate for a metric set
+// referred to by that key and any other normal labels.
+func extractKeyAndFilterLabels(labelPairs []*prompb.LabelPair) (key string, setLabels map[string]string, normalLabels map[string]string, err error) {
+	setLabels = make(map[string]string)
+	normalLabels = make(map[string]string)
+
+	var (
+		hasNS   = false
+		hasPod  = false
+		hasCont = false
+		hasNode = false
+
+		ns   string
+		pod  string
+		cont string
+		node string
+	)
+
+	for _, labelPair := range labelPairs {
+		labelName := labelPair.GetName()
+		switch labelName {
+		case PushLabelNamespace:
+			hasNS = true
+			ns = labelPair.GetValue()
+			setLabels[core.LabelNamespaceName.Key] = ns
+			continue
+		case PushLabelPod:
+			hasPod = true
+			pod = labelPair.GetValue()
+			setLabels[core.LabelPodName.Key] = pod
+			continue
+		case PushLabelContainer:
+			hasCont = true
+			cont = labelPair.GetValue()
+			setLabels[core.LabelContainerName.Key] = cont
+			continue
+		case PushLabelNode:
+			hasNode = true
+			node = labelPair.GetValue()
+			setLabels[core.LabelNodename.Key] = node
+			continue
+		}
+
+		if _, ok := allLabels[labelName]; ok {
+			setLabels[labelName] = labelPair.GetValue()
+			continue
+		}
+
+		normalLabels[labelName] = labelPair.GetValue()
+	}
+
+	switch {
+	case hasNS && hasPod && hasCont:
+		setLabels[core.LabelMetricSetType.Key] = core.MetricSetTypePodContainer
+		setLabels[core.LabelPodNamespace.Key] = ns
+		key = core.PodContainerKey(ns, pod, cont)
+	case hasNS && hasPod:
+		setLabels[core.LabelMetricSetType.Key] = core.MetricSetTypePod
+		setLabels[core.LabelPodNamespace.Key] = ns
+		key = core.PodKey(ns, pod)
+	case hasNS:
+		setLabels[core.LabelMetricSetType.Key] = core.MetricSetTypeNamespace
+		key = core.NamespaceKey(ns)
+	case hasNode && hasCont:
+		setLabels[core.LabelMetricSetType.Key] = core.MetricSetTypeSystemContainer
+		key = core.NodeContainerKey(node, cont)
+	case hasNode:
+		setLabels[core.LabelMetricSetType.Key] = core.MetricSetTypeNode
+		key = core.NodeKey(node)
+	case !hasNode && !hasNS && !hasPod && !hasCont:
+		key = core.ClusterKey()
+	default:
+		return "", nil, nil, fmt.Errorf("invalid label configuration for specifying metric key: must have labels namespace[+pod[+container]] or node[+container], or none of the above (for cluster metrics)")
+	}
+
+	return key, setLabels, normalLabels, nil
+}
+
+const (
+	PushLabelNamespace = "namespace"
+	PushLabelPod       = "pod"
+	PushLabelContainer = "container"
+	PushLabelNode      = "node"
+)
+
+var allLabels = map[string]struct{}{
+	core.LabelNodename.Key: {},
+	core.LabelHostname.Key: {},
+	core.LabelHostID.Key:   {},
+
+	core.LabelNamespaceName.Key: {},
+
+	core.LabelPodId.Key:        {},
+	core.LabelPodName.Key:      {},
+	core.LabelPodNamespace.Key: {},
+
+	core.LabelContainerName.Key: {},
+}

--- a/metrics/api/v1/push_handlers_test.go
+++ b/metrics/api/v1/push_handlers_test.go
@@ -1,0 +1,126 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"k8s.io/heapster/metrics/core"
+)
+
+func makePodMetrics(ns, name string, time time.Time, metricName string, metricVal float32) *core.MetricSet {
+	return &core.MetricSet{
+		ScrapeTime: time,
+		MetricValues: map[string]core.MetricValue{
+			metricName: {
+				FloatValue: metricVal,
+				ValueType:  core.ValueFloat,
+				MetricType: core.MetricGauge,
+			},
+		},
+		Labels: map[string]string{
+			core.LabelNamespaceName.Key: ns,
+			core.LabelPodName.Key:       name,
+			core.LabelPodNamespace.Key:  ns,
+			core.LabelMetricSetType.Key: core.MetricSetTypePod,
+		},
+		LabeledMetrics: nil,
+	}
+}
+
+func TestPrometheusTextIngest(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	nowTime := time.Now().Truncate(time.Millisecond)
+	nowFunc = func() time.Time { return nowTime }
+
+	testPrometheusTextMetrics := `
+# This is a pod-level metric (it might be used for autoscaling)
+# TYPE http_requests_per_minute gauge
+http_requests_per_minute{namespace="webapp",pod="frontend-server-a-1"} 20
+http_requests_per_minute{namespace="webapp",pod="frontend-server-a-2"} 5
+http_requests_per_minute{namespace="webapp",pod="frontend-server-b-1"} 25
+
+# This is a service-level metric, which will be stored as frontend_hits_total
+# and restapi_hits_total (these might be used for auto-idling)
+# TYPE frontend_hits_total counter
+frontend_hits_total{namespace="webapp"} 5000
+# TYPE restapi_hits_total counter
+restapi_hits_total{namespace="webapp"} 6000
+
+# this is a labeled metric
+restapi_hits{namespace="webapp",endpoint="/cheeses/pepper-jack"} 2000
+restapi_hits{namespace="webapp",endpoint="/cheeses/cheddar"} 4000
+`
+
+	expectedResultBatch := &core.DataBatch{
+		Timestamp: nowTime,
+		MetricSets: map[string]*core.MetricSet{
+			core.PodKey("webapp", "frontend-server-a-1"): makePodMetrics("webapp", "frontend-server-a-1", nowTime, "custom/routermetrics/http_requests_per_minute", 20.0),
+			core.PodKey("webapp", "frontend-server-a-2"): makePodMetrics("webapp", "frontend-server-a-2", nowTime, "custom/routermetrics/http_requests_per_minute", 5.0),
+			core.PodKey("webapp", "frontend-server-b-1"): makePodMetrics("webapp", "frontend-server-b-1", nowTime, "custom/routermetrics/http_requests_per_minute", 25.0),
+
+			core.NamespaceKey("webapp"): {
+				ScrapeTime: nowTime,
+				MetricValues: map[string]core.MetricValue{
+					"custom/routermetrics/frontend_hits_total": {
+						FloatValue: 5000,
+						ValueType:  core.ValueFloat,
+						MetricType: core.MetricCumulative,
+					},
+					"custom/routermetrics/restapi_hits_total": {
+						FloatValue: 6000,
+						ValueType:  core.ValueFloat,
+						MetricType: core.MetricCumulative,
+					},
+				},
+				Labels: map[string]string{core.LabelNamespaceName.Key: "webapp", core.LabelMetricSetType.Key: core.MetricSetTypeNamespace},
+				LabeledMetrics: []core.LabeledMetric{
+					{
+						Name:   "custom/routermetrics/restapi_hits",
+						Labels: map[string]string{"endpoint": "/cheeses/pepper-jack"},
+						MetricValue: core.MetricValue{
+							FloatValue: 2000,
+							ValueType:  core.ValueFloat,
+							MetricType: core.MetricGauge,
+						},
+					},
+					{
+						Name:   "custom/routermetrics/restapi_hits",
+						Labels: map[string]string{"endpoint": "/cheeses/cheddar"},
+						MetricValue: core.MetricValue{
+							FloatValue: 4000,
+							ValueType:  core.ValueFloat,
+							MetricType: core.MetricGauge,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	batch, _, err := ingestPrometheusMetrics("routermetrics", http.Header{
+		"Content-Type": []string{"text/plain; version=0.0.4"},
+	}, strings.NewReader(testPrometheusTextMetrics))
+	require.NoError(err, "should have been able to process the metrics without error")
+	assert.Equal(expectedResultBatch, batch, "ingested data batch should have been as expected")
+}

--- a/metrics/core/types.go
+++ b/metrics/core/types.go
@@ -134,6 +134,9 @@ type DataBatch struct {
 // A place from where the metrics should be scraped.
 type MetricsSource interface {
 	Name() string
+	// IsCanonical returns whether or not this source should be treated as a canonical source of information
+	// (e.g. kubernetes is a canonical source, whereas push metrics is not)
+	IsCanonical() bool
 	ScrapeMetrics(start, end time.Time) *DataBatch
 }
 

--- a/metrics/heapster.go
+++ b/metrics/heapster.go
@@ -57,6 +57,7 @@ var (
 	argHistoricalSource    = flag.String("historical_source", "", "which source type to use for the historical API (should be exactly the same as one of the sink URIs), or empty to disable the historical API")
 	argTLSPushClientCAFile = flag.String("tls_push_client_ca", "", "file containing TLS client CA for client cert validation for push metrics")
 	argAllowedPushUsers    = flag.String("allowed_push_users", "", "comma-separated list of allowed users for push metrics")
+	argMaxPushMetrics      = flag.Int("max_push_metrics", 0, "maximum number of unique metrics per push source (defaults to 0 for unlimitted")
 )
 
 func main() {
@@ -76,7 +77,7 @@ func main() {
 		glog.Fatal("Wrong number of sources specified")
 	}
 	sourceFactory := sources.NewSourceFactory()
-	sourceProvider, pushSource, err := sourceFactory.BuildAll(argSources)
+	sourceProvider, pushSource, err := sourceFactory.BuildAll(argSources, *argMaxPushMetrics)
 	if err != nil {
 		glog.Fatalf("Failed to create source provide: %v", err)
 	}

--- a/metrics/heapster.go
+++ b/metrics/heapster.go
@@ -44,17 +44,19 @@ import (
 )
 
 var (
-	argMetricResolution = flag.Duration("metric_resolution", 60*time.Second, "The resolution at which heapster will retain metrics.")
-	argPort             = flag.Int("port", 8082, "port to listen to")
-	argIp               = flag.String("listen_ip", "", "IP to listen on, defaults to all IPs")
-	argMaxProcs         = flag.Int("max_procs", 0, "max number of CPUs that can be used simultaneously. Less than 1 for default (number of cores)")
-	argTLSCertFile      = flag.String("tls_cert", "", "file containing TLS certificate")
-	argTLSKeyFile       = flag.String("tls_key", "", "file containing TLS key")
-	argTLSClientCAFile  = flag.String("tls_client_ca", "", "file containing TLS client CA for client cert validation")
-	argAllowedUsers     = flag.String("allowed_users", "", "comma-separated list of allowed users")
-	argSources          flags.Uris
-	argSinks            flags.Uris
-	argHistoricalSource = flag.String("historical_source", "", "which source type to use for the historical API (should be exactly the same as one of the sink URIs), or empty to disable the historical API")
+	argMetricResolution    = flag.Duration("metric_resolution", 60*time.Second, "The resolution at which heapster will retain metrics.")
+	argPort                = flag.Int("port", 8082, "port to listen to")
+	argIp                  = flag.String("listen_ip", "", "IP to listen on, defaults to all IPs")
+	argMaxProcs            = flag.Int("max_procs", 0, "max number of CPUs that can be used simultaneously. Less than 1 for default (number of cores)")
+	argTLSCertFile         = flag.String("tls_cert", "", "file containing TLS certificate")
+	argTLSKeyFile          = flag.String("tls_key", "", "file containing TLS key")
+	argTLSClientCAFile     = flag.String("tls_client_ca", "", "file containing TLS client CA for client cert validation")
+	argAllowedUsers        = flag.String("allowed_users", "", "comma-separated list of allowed users")
+	argSources             flags.Uris
+	argSinks               flags.Uris
+	argHistoricalSource    = flag.String("historical_source", "", "which source type to use for the historical API (should be exactly the same as one of the sink URIs), or empty to disable the historical API")
+	argTLSPushClientCAFile = flag.String("tls_push_client_ca", "", "file containing TLS client CA for client cert validation for push metrics")
+	argAllowedPushUsers    = flag.String("allowed_push_users", "", "comma-separated list of allowed users for push metrics")
 )
 
 func main() {
@@ -70,11 +72,11 @@ func main() {
 	}
 
 	// sources
-	if len(argSources) != 1 {
+	if len(argSources) != 1 && len(argSources) != 2 {
 		glog.Fatal("Wrong number of sources specified")
 	}
 	sourceFactory := sources.NewSourceFactory()
-	sourceProvider, err := sourceFactory.BuildAll(argSources)
+	sourceProvider, pushSource, err := sourceFactory.BuildAll(argSources)
 	if err != nil {
 		glog.Fatalf("Failed to create source provide: %v", err)
 	}
@@ -178,20 +180,37 @@ func main() {
 	promHandler := prometheus.Handler()
 	if len(*argTLSCertFile) > 0 && len(*argTLSKeyFile) > 0 {
 		if len(*argTLSClientCAFile) > 0 {
-			authPprofHandler, err := newAuthHandler(handler)
+			authPprofHandler, err := newAuthHandler(handler, *argTLSClientCAFile, *argAllowedUsers)
 			if err != nil {
 				glog.Fatalf("Failed to create authorized pprof handler: %v", err)
 			}
 			handler = authPprofHandler
 
-			authPromHandler, err := newAuthHandler(promHandler)
+			authPromHandler, err := newAuthHandler(promHandler, *argTLSClientCAFile, *argAllowedUsers)
 			if err != nil {
 				glog.Fatalf("Failed to create authorized prometheus handler: %v", err)
 			}
 			promHandler = authPromHandler
+
 		}
+
 		mux.Handle("/", handler)
 		mux.Handle("/metrics", promHandler)
+
+		if pushSource != nil {
+			if len(*argTLSPushClientCAFile) > 0 {
+				// enable push metrics as well
+				pushAuthFilter, err := newAuthFilter(*argTLSPushClientCAFile, *argAllowedPushUsers)
+				if err != nil {
+					glog.Fatalf("Failed to create authorized push metrics handler: %v", err)
+				}
+				pushHandler := setupPushHandler(pushSource, pushAuthFilter)
+
+				mux.Handle("/api/v1/push/", pushHandler)
+			} else {
+				glog.Fatal("Unable to use push metrics without a push metrics CA")
+			}
+		}
 
 		// If allowed users is set, then we need to enable Client Authentication
 		if len(*argAllowedUsers) > 0 {
@@ -206,6 +225,10 @@ func main() {
 		}
 
 	} else {
+		if pushSource != nil {
+			glog.Fatal("Unable to set up push metrics without TLS support")
+		}
+
 		mux.Handle("/", handler)
 		mux.Handle("/metrics", promHandler)
 		glog.Fatal(http.ListenAndServe(addr, mux))

--- a/metrics/sources/factory.go
+++ b/metrics/sources/factory.go
@@ -40,7 +40,7 @@ func (this *SourceFactory) Build(uri flags.Uri) (core.MetricsSourceProvider, err
 	}
 }
 
-func (this *SourceFactory) BuildAll(uris flags.Uris) (core.MetricsSourceProvider, push.PushSource, error) {
+func (this *SourceFactory) BuildAll(uris flags.Uris, maxPushMetrics int) (core.MetricsSourceProvider, push.PushSource, error) {
 	// We can have 2 sources, if one is a push source
 	if len(uris) == 2 {
 		// we can't have two push sources
@@ -66,7 +66,7 @@ func (this *SourceFactory) BuildAll(uris flags.Uris) (core.MetricsSourceProvider
 			return nil, nil, err
 		}
 
-		return push.NewPushProvider(provider)
+		return push.NewPushProvider(provider, maxPushMetrics)
 	}
 
 	if len(uris) != 1 {
@@ -74,7 +74,7 @@ func (this *SourceFactory) BuildAll(uris flags.Uris) (core.MetricsSourceProvider
 	}
 
 	if uris[0].Key == "push" {
-		return push.NewPushProvider(nil)
+		return push.NewPushProvider(nil, maxPushMetrics)
 	}
 
 	provider, err := this.Build(uris[0])

--- a/metrics/sources/factory.go
+++ b/metrics/sources/factory.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/heapster/common/flags"
 	"k8s.io/heapster/metrics/core"
 	"k8s.io/heapster/metrics/sources/kubelet"
+	"k8s.io/heapster/metrics/sources/push"
 	"k8s.io/heapster/metrics/sources/summary"
 )
 
@@ -39,11 +40,45 @@ func (this *SourceFactory) Build(uri flags.Uri) (core.MetricsSourceProvider, err
 	}
 }
 
-func (this *SourceFactory) BuildAll(uris flags.Uris) (core.MetricsSourceProvider, error) {
-	if len(uris) != 1 {
-		return nil, fmt.Errorf("Only one source is supported")
+func (this *SourceFactory) BuildAll(uris flags.Uris) (core.MetricsSourceProvider, push.PushSource, error) {
+	// We can have 2 sources, if one is a push source
+	if len(uris) == 2 {
+		// we can't have two push sources
+		if uris[0].Key == "push" && uris[1].Key == "push" {
+			return nil, nil, fmt.Errorf("Cannot have multiple push sources")
+		}
+
+		// if we have more than one source, we need at least one push source
+		if uris[0].Key != "push" && uris[1].Key != "push" {
+			return nil, nil, fmt.Errorf("Only one non-push source is supported")
+		}
+
+		// figure out which source is the "normal" one, and build it
+		var provider core.MetricsSourceProvider
+		var err error
+		if uris[0].Key == "push" {
+			provider, err = this.Build(uris[1])
+		} else {
+			provider, err = this.Build(uris[0])
+		}
+
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return push.NewPushProvider(provider)
 	}
-	return this.Build(uris[0])
+
+	if len(uris) != 1 {
+		return nil, nil, fmt.Errorf("Only one non-push source is supported")
+	}
+
+	if uris[0].Key == "push" {
+		return push.NewPushProvider(nil)
+	}
+
+	provider, err := this.Build(uris[0])
+	return provider, nil, err
 }
 
 func NewSourceFactory() *SourceFactory {

--- a/metrics/sources/kubelet/kubelet.go
+++ b/metrics/sources/kubelet/kubelet.go
@@ -85,6 +85,10 @@ func (this *kubeletMetricsSource) String() string {
 	return fmt.Sprintf("kubelet:%s:%d", this.host.IP, this.host.Port)
 }
 
+func (this *kubeletMetricsSource) IsCanonical() bool {
+	return true
+}
+
 func (this *kubeletMetricsSource) handleSystemContainer(c *cadvisor.ContainerInfo, cMetrics *MetricSet) string {
 	glog.V(8).Infof("Found system container %v with labels: %+v", c.Name, c.Spec.Labels)
 	cName := c.Name

--- a/metrics/sources/manager.go
+++ b/metrics/sources/manager.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	. "k8s.io/heapster/metrics/core"
+	"k8s.io/heapster/metrics/util"
 
 	"github.com/golang/glog"
 	"github.com/prometheus/client_golang/prometheus"
@@ -29,6 +30,13 @@ const (
 	MaxDelayMs                  = 4 * 1000
 	DelayPerSourceMs            = 8
 )
+
+// identifiedDataBatch is a DataBatch with an associated source
+type identifiedDataBatch struct {
+	*DataBatch
+
+	source MetricsSource
+}
 
 var (
 	// Last time Heapster performed a scrape since unix epoch in seconds.
@@ -75,11 +83,15 @@ func (this *sourceManager) Name() string {
 	return "source_manager"
 }
 
+func (this *sourceManager) IsCanonical() bool {
+	return true
+}
+
 func (this *sourceManager) ScrapeMetrics(start, end time.Time) *DataBatch {
 	glog.Infof("Scraping metrics start: %s, end: %s", start, end)
 	sources := this.metricsSourceProvider.GetMetricsSources()
 
-	responseChannel := make(chan *DataBatch)
+	responseChannel := make(chan *identifiedDataBatch)
 	startTime := time.Now()
 	timeoutTime := startTime.Add(this.metricsScrapeTimeout)
 
@@ -90,7 +102,7 @@ func (this *sourceManager) ScrapeMetrics(start, end time.Time) *DataBatch {
 
 	for _, source := range sources {
 
-		go func(source MetricsSource, channel chan *DataBatch, start, end, timeoutTime time.Time, delayInMs int) {
+		go func(source MetricsSource, channel chan *identifiedDataBatch, start, end, timeoutTime time.Time, delayInMs int) {
 
 			// Prevents network congestion.
 			time.Sleep(time.Duration(rand.Intn(delayMs)) * time.Millisecond)
@@ -104,8 +116,13 @@ func (this *sourceManager) ScrapeMetrics(start, end time.Time) *DataBatch {
 			}
 			timeForResponse := timeoutTime.Sub(now)
 
+			idMetrics := &identifiedDataBatch{
+				DataBatch: metrics,
+				source:    source,
+			}
+
 			select {
-			case channel <- metrics:
+			case channel <- idMetrics:
 				// passed the response correctly.
 				return
 			case <-time.After(timeForResponse):
@@ -130,9 +147,16 @@ responseloop:
 		}
 
 		select {
-		case dataBatch := <-responseChannel:
-			if dataBatch != nil {
-				for key, value := range dataBatch.MetricSets {
+		case idDataBatch := <-responseChannel:
+			sourceIsCanonical := idDataBatch.source.IsCanonical()
+			if idDataBatch.DataBatch != nil {
+				for key, value := range idDataBatch.MetricSets {
+					if existingVal, valExists := response.MetricSets[key]; valExists {
+						// merge the new data into the old data, allowing "canonical" sources
+						// (e.g. kubernetes) to overwrite custom sources (e.g. push metrics)
+						util.MergeMetricSet(existingVal, value, sourceIsCanonical)
+						continue
+					}
 					response.MetricSets[key] = value
 				}
 			}

--- a/metrics/sources/push/push.go
+++ b/metrics/sources/push/push.go
@@ -1,0 +1,195 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package push
+
+import (
+	"sync"
+	"time"
+
+	. "k8s.io/heapster/metrics/core"
+	"k8s.io/heapster/metrics/util"
+
+	"github.com/golang/glog"
+)
+
+// for testing
+var nowFunc = time.Now
+
+// PushSource is a MetricsSource that stores pushed metrics until the next scrape
+// (instead of scraping from a remote location).
+type PushSource interface {
+	MetricsSource
+
+	// PushMetrics stores a batch of metrics to be retrived by the next call to ScrapeMetrics.
+	// The metrics should already be prefixed/namespaced by sourceName as appropriate.
+	PushMetrics(batch *DataBatch, sourceName string)
+}
+
+// pushProvider is a MetricsSourceProvider which returns both some sources from a base
+// MetricsSourceProvider, as well as a PushSource
+type pushProvider struct {
+	baseProvider MetricsSourceProvider
+	pushSource   PushSource
+}
+
+func (p *pushProvider) GetMetricsSources() []MetricsSource {
+	var sources []MetricsSource
+	if p.baseProvider != nil {
+		sources = p.baseProvider.GetMetricsSources()
+	} else {
+		sources = make([]MetricsSource, 0, 1)
+	}
+
+	sources = append(sources, p.pushSource)
+
+	return sources
+}
+
+// NewPushProvider returns a new MetricsSourceProvider which provides sources from the given
+// MetricsSourceProvider (if any), as well as providing a PushSource.
+func NewPushProvider(baseProvider MetricsSourceProvider) (MetricsSourceProvider, PushSource, error) {
+	pushSource := &memoryPushSource{
+		dataBatches: make(map[string]DataBatch),
+	}
+
+	provider := &pushProvider{
+		baseProvider: baseProvider,
+		pushSource:   pushSource,
+	}
+
+	return provider, pushSource, nil
+}
+
+type memoryPushSource struct {
+	dataBatches map[string]DataBatch
+	sync.Mutex
+}
+
+func (src *memoryPushSource) String() string {
+	return "push"
+}
+
+func (src *memoryPushSource) Name() string {
+	return src.String()
+}
+
+func (src *memoryPushSource) IsCanonical() bool {
+	return false
+}
+
+func (src *memoryPushSource) ScrapeMetrics(start, end time.Time) *DataBatch {
+	src.Lock()
+	defer src.Unlock()
+
+	resBatch := &DataBatch{
+		Timestamp:  nowFunc(),
+		MetricSets: map[string]*MetricSet{},
+	}
+
+	for sourceName, batch := range src.dataBatches {
+		// clear/free the dataBatch for when we "shorten" the slice later
+		if (!start.IsZero() && batch.Timestamp.Before(start)) || (!end.IsZero() && batch.Timestamp.After(end)) {
+			glog.V(2).Infof("Data batch from %q with invalid timestamp %s (not in [%s, %s])", "", batch.Timestamp, start, end)
+			continue
+		}
+
+		glog.V(5).Infof("Processing pushed batch from source %q: %#v", sourceName, batch)
+
+		mergeMetricSets(resBatch.MetricSets, batch.MetricSets, false)
+		delete(src.dataBatches, sourceName)
+	}
+
+	glog.V(5).Infof("Scraped batch from push source: %#v", resBatch)
+
+	return resBatch
+}
+
+func mergeTyped(destValues map[string]MetricValue, newValues map[string]MetricValue, _ bool) {
+	for valKey, newVal := range newValues {
+		// for gauges, we should always average multiple pushes in a single
+		// scrape period so that we don't lose values
+		if newVal.MetricType == MetricGauge {
+			if oldVal, oldValPresent := destValues[valKey]; oldValPresent {
+				// we use the unused value to keep track of the count
+				// (this is fine because the exporter just uses the correct value according to the value type)
+				// This is a *bit* hacky, but it's easier than keeping track of the averages elsewhere and then
+				// having to do an extra pass at the end.
+
+				// TODO: can we just assume gauges are going to be float values?
+				if oldVal.ValueType == ValueInt64 {
+					if oldVal.FloatValue == 0 {
+						// start a new running average
+						newVal.FloatValue = 2.0
+						newVal.IntValue = (oldVal.IntValue + newVal.IntValue) / 2
+					} else {
+						newVal.IntValue = (oldVal.IntValue*int64(oldVal.FloatValue) + newVal.IntValue) / int64(oldVal.FloatValue+1)
+						newVal.FloatValue = oldVal.FloatValue + 1
+					}
+				} else {
+					if oldVal.IntValue == 0 {
+						// start a new running average
+						newVal.IntValue = 2
+						newVal.FloatValue = (oldVal.FloatValue + newVal.FloatValue) / 2
+					} else {
+						// continue the existing running average
+						newVal.FloatValue = (oldVal.FloatValue*float32(oldVal.IntValue) + newVal.FloatValue) / float32(oldVal.IntValue+1)
+						newVal.IntValue = oldVal.IntValue + 1
+
+					}
+				}
+			}
+		}
+
+		destValues[valKey] = newVal
+	}
+}
+
+func mergeMetricSets(dest map[string]*MetricSet, src map[string]*MetricSet, overwrite bool) {
+	for setKey, newSet := range src {
+		presentSet, wasPresent := dest[setKey]
+		if !wasPresent {
+			dest[setKey] = newSet
+			continue
+		}
+
+		// set the scrape time to be the newest time
+		if presentSet.ScrapeTime.Before(newSet.ScrapeTime) {
+			presentSet.ScrapeTime = newSet.ScrapeTime
+		}
+
+		// do the rest of the merging
+		if overwrite {
+			util.MergeMetricSetCustom(presentSet, newSet, overwrite, mergeTyped)
+		} else {
+			util.MergeMetricSet(presentSet, newSet, overwrite)
+		}
+	}
+}
+
+// PushMetrics stores a batch of metrics to be retrived by the next call to ScrapeMetrics
+func (src *memoryPushSource) PushMetrics(batch *DataBatch, sourceName string) {
+	src.Lock()
+	defer src.Unlock()
+
+	// if an entry already exists, merge it with the existing set
+	// (overwriting duplicate entries), since we could have multiple
+	// producers with the same name (e.g. the same daemon on each node)
+	if oldBatch, ok := src.dataBatches[sourceName]; ok {
+		mergeMetricSets(oldBatch.MetricSets, batch.MetricSets, true)
+		return
+	}
+
+	src.dataBatches[sourceName] = *batch
+}

--- a/metrics/sources/push/push_test.go
+++ b/metrics/sources/push/push_test.go
@@ -1,0 +1,264 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package push
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	. "k8s.io/heapster/metrics/core"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func makeCntMetricValue(val int64) MetricValue {
+	return MetricValue{
+		IntValue:   val,
+		ValueType:  ValueInt64,
+		MetricType: MetricCumulative,
+	}
+}
+
+func makeGaugeMetricValue(val float32) MetricValue {
+	return MetricValue{
+		FloatValue: val,
+		ValueType:  ValueFloat,
+		MetricType: MetricGauge,
+	}
+}
+
+func makeBaseBatch1(nowTime time.Time) DataBatch {
+	return DataBatch{
+		Timestamp: nowTime.Add(-5 * time.Second),
+		MetricSets: map[string]*MetricSet{
+			PodKey("somens", "somepod"): {
+				ScrapeTime: nowTime.Add(-10 * time.Second),
+				MetricValues: map[string]MetricValue{
+					"custom/adminmetrics/mtn_dew_consumption": makeGaugeMetricValue(12.0),
+				},
+				Labels: map[string]string{
+					LabelNamespaceName.Key: "somens",
+					LabelPodName.Key:       "somepod",
+				},
+				LabeledMetrics: []LabeledMetric{
+					{
+						Name:        "custom/adminmetrics/doritos_eaten",
+						Labels:      map[string]string{"flavor": "original"},
+						MetricValue: makeGaugeMetricValue(10.0),
+					},
+					{
+						Name:        "custom/adminmetrics/doritos_eaten",
+						Labels:      map[string]string{"flavor": "cool_ranch"},
+						MetricValue: makeGaugeMetricValue(10.0),
+					},
+				},
+			},
+
+			NamespaceKey("somens"): {
+				ScrapeTime: nowTime.Add(-10 * time.Second),
+				MetricValues: map[string]MetricValue{
+					"custom/adminmetrics/cans_collected": makeCntMetricValue(48),
+				},
+				Labels: map[string]string{
+					LabelNamespaceName.Key: "somens",
+				},
+				LabeledMetrics: nil,
+			},
+		},
+	}
+}
+
+func makeBaseBatch2(nowTime time.Time) DataBatch {
+	return DataBatch{
+		Timestamp: nowTime.Add(-5 * time.Second),
+		MetricSets: map[string]*MetricSet{
+			NamespaceKey("somens"): {
+				ScrapeTime: nowTime.Add(-10 * time.Second),
+				MetricValues: map[string]MetricValue{
+					"custom/routermetrics/frontend_http_hits": makeGaugeMetricValue(20000.0),
+					"custom/routermetrics/proxy_http_hits":    makeGaugeMetricValue(500000.0),
+				},
+				Labels: map[string]string{
+					LabelNamespaceName.Key: "somens",
+				},
+				LabeledMetrics: nil,
+			},
+			NamespaceKey("somens2"): {
+				ScrapeTime: nowTime.Add(-10 * time.Second),
+				MetricValues: map[string]MetricValue{
+					"custom/routermetrics/frontend_http_hits": makeGaugeMetricValue(20.0),
+					"custom/routermetrics/proxy_http_hits":    makeGaugeMetricValue(500.0),
+				},
+				Labels: map[string]string{
+					LabelNamespaceName.Key: "somens2",
+				},
+				LabeledMetrics: nil,
+			},
+		},
+	}
+}
+
+func TestPushMetricsIntoPushSource(t *testing.T) {
+	assert := assert.New(t)
+	nowTime := time.Now()
+	nowFunc = func() time.Time { return nowTime }
+
+	batch1 := makeBaseBatch1(nowTime)
+	batchBefore := makeBaseBatch1(nowTime.Add(-2 * time.Minute))
+	batchAfter := makeBaseBatch2(nowTime.Add(2 * time.Minute))
+
+	batch1Multi := makeBaseBatch1(nowTime)
+	batch1Multi.MetricSets[PodKey("somens", "somepod")].MetricValues["custom/adminmetrics/cheese_sticks_eaten"] = makeGaugeMetricValue(6.5)
+	avgedMetric := makeGaugeMetricValue(11.0)
+	avgedMetric.IntValue = 2
+	batch1Multi.MetricSets[PodKey("somens", "somepod")].MetricValues["custom/adminmetrics/mtn_dew_consumption"] = avgedMetric
+	batch1Multi.Timestamp = nowTime
+
+	batch1Multi2 := makeBaseBatch1(nowTime)
+	avgedMetric2 := makeGaugeMetricValue(10.0)
+	avgedMetric2.IntValue = 2
+	avgedMetric2New := makeGaugeMetricValue(32.0 / 3.0)
+	avgedMetric2New.IntValue = 3
+	batch1Multi2.MetricSets[PodKey("somens", "somepod")].MetricValues["custom/adminmetrics/mtn_dew_consumption"] = avgedMetric2New
+	batch1Multi2.Timestamp = nowTime
+
+	batch2 := makeBaseBatch2(nowTime)
+
+	mergedBatch := makeBaseBatch1(nowTime)
+	mergedBatch.Timestamp = nowTime
+	mergedBatch.MetricSets[NamespaceKey("somens2")] = batch2.MetricSets[NamespaceKey("somens2")]
+
+	for k, v := range batch2.MetricSets[NamespaceKey("somens")].MetricValues {
+		mergedBatch.MetricSets[NamespaceKey("somens")].MetricValues[k] = v
+	}
+
+	tests := []struct {
+		test           string
+		inputBatch     *DataBatch
+		inputName      string
+		presentBatches map[string]DataBatch
+		expectedBatch  *DataBatch
+		start          time.Time
+		end            time.Time
+	}{
+		{
+			test:       "new batch with the same name merges with older batch, overwrites when necessary",
+			inputBatch: &batch1,
+			inputName:  "adminmetrics",
+			presentBatches: map[string]DataBatch{
+				"adminmetrics": {
+					Timestamp: nowTime.Add(-10 * time.Second),
+					MetricSets: map[string]*MetricSet{
+						PodKey("somens", "somepod"): {
+							ScrapeTime: nowTime.Add(-10 * time.Second),
+							MetricValues: map[string]MetricValue{
+								"custom/adminmetrics/mtn_dew_consumption": makeGaugeMetricValue(10.0),
+								"custom/adminmetrics/cheese_sticks_eaten": makeGaugeMetricValue(6.5),
+							},
+							Labels: map[string]string{
+								LabelNamespaceName.Key: "somens",
+								LabelPodName.Key:       "somepod",
+							},
+						},
+
+						NamespaceKey("somens"): {
+							ScrapeTime: nowTime.Add(-10 * time.Second),
+							MetricValues: map[string]MetricValue{
+								"custom/adminmetrics/cans_collected": makeCntMetricValue(37),
+							},
+							Labels: map[string]string{
+								LabelNamespaceName.Key: "somens",
+							},
+						},
+					},
+				},
+			},
+			expectedBatch: &batch1Multi,
+		},
+		{
+			test:       "new batch with same name merges with older batch (averaging across multiple pushes)",
+			inputBatch: &batch1,
+			inputName:  "adminmetrics",
+			presentBatches: map[string]DataBatch{
+				"adminmetrics": {
+					Timestamp: nowTime.Add(-10 * time.Second),
+					MetricSets: map[string]*MetricSet{
+						PodKey("somens", "somepod"): {
+							ScrapeTime: nowTime.Add(-10 * time.Second),
+							MetricValues: map[string]MetricValue{
+								"custom/adminmetrics/mtn_dew_consumption": avgedMetric2,
+							},
+							Labels: map[string]string{
+								LabelNamespaceName.Key: "somens",
+								LabelPodName.Key:       "somepod",
+							},
+						},
+					},
+				},
+			},
+			expectedBatch: &batch1Multi2,
+		},
+		{
+			test:       "batch before start is ignored",
+			inputBatch: &batchBefore,
+			inputName:  "adminmetrics",
+			start:      nowTime.Add(-1 * time.Minute),
+			expectedBatch: &DataBatch{
+				Timestamp:  nowTime,
+				MetricSets: make(map[string]*MetricSet),
+			},
+		},
+		{
+			test:       "batch after end is ignored",
+			inputBatch: &batchAfter,
+			inputName:  "adminmetrics",
+			end:        nowTime.Add(1 * time.Minute),
+			expectedBatch: &DataBatch{
+				Timestamp:  nowTime,
+				MetricSets: make(map[string]*MetricSet),
+			},
+		},
+		{
+			// This test is dependent on the behavior of MergeMetricSet
+			test:       "two different sources' batches merge properly",
+			inputBatch: &batch2,
+			inputName:  "routermetrics",
+			presentBatches: map[string]DataBatch{
+				"adminmetrics": batch1,
+			},
+			expectedBatch: &mergedBatch,
+		},
+	}
+
+	for _, test := range tests {
+		if test.presentBatches == nil {
+			test.presentBatches = make(map[string]DataBatch)
+		}
+
+		src := memoryPushSource{
+			dataBatches: test.presentBatches,
+		}
+
+		src.PushMetrics(test.inputBatch, test.inputName)
+		outputBatch := src.ScrapeMetrics(test.start, test.end)
+		if !assert.Equal(test.expectedBatch, outputBatch, fmt.Sprintf("%s: scraped batch was not as expected", test.test)) {
+			for k, v := range test.expectedBatch.MetricSets {
+				assert.Equal(v, outputBatch.MetricSets[k])
+			}
+			continue
+		}
+	}
+}

--- a/metrics/sources/push/types.go
+++ b/metrics/sources/push/types.go
@@ -1,0 +1,260 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package push
+
+import (
+	"strings"
+	"time"
+
+	"k8s.io/heapster/metrics/core"
+)
+
+// MetricValue is a MetricValue that can also represent an accumulator to later be averaged
+type MetricValue struct {
+	// The sum value/normal value of the metric (possibly divided by StoredCount to get the final value)
+	core.MetricValue
+
+	// StoredCount is the divisor used when taking the average in the case of guage metrics
+	StoredCount int
+}
+
+func (v *MetricValue) FinalValue() core.MetricValue {
+	// no need to do anything fancy if this is not a gauge or only has one data point
+	if v.MetricType != core.MetricGauge || v.StoredCount < 2 {
+		return v.MetricValue
+	}
+
+	res := core.MetricValue{
+		ValueType:  v.ValueType,
+		MetricType: v.MetricType,
+	}
+
+	// take the average
+	switch v.ValueType {
+	case core.ValueInt64:
+		res.IntValue = v.IntValue / int64(v.StoredCount)
+	case core.ValueFloat:
+		res.FloatValue = v.FloatValue / float32(v.StoredCount)
+	}
+
+	return res
+}
+
+// Append return the new value (in case of a non-Gauge), or returns this value with the relavant
+// fields summed/incremented in case of a guage (for later averaging)
+func (v MetricValue) Append(newVal MetricValue) MetricValue {
+	if v.MetricType != core.MetricGauge {
+		return newVal
+	}
+
+	if v.StoredCount == 0 {
+		v.StoredCount = 2
+	} else {
+		v.StoredCount++
+	}
+
+	switch v.ValueType {
+	case core.ValueInt64:
+		v.IntValue += newVal.IntValue
+	case core.ValueFloat:
+		v.FloatValue += newVal.FloatValue
+	}
+
+	return v
+}
+
+// LabelPair is a key-value pair representing a label on a labeled metric
+type LabelPair struct {
+	Key   string
+	Value string
+}
+
+// LabelPairs implements sort.Interface for LabelPair
+type LabelPairs []LabelPair
+
+func (s LabelPairs) Len() int           { return len(s) }
+func (s LabelPairs) Less(i, j int) bool { return s[i].Key < s[j].Key }
+func (s LabelPairs) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+
+// A representation of core.LabeledMetric amenable to easy comparison
+type LabeledMetric struct {
+	// The Name of the metric
+	Name string
+	// Key-Value pairs representing the labels applied to the metric.
+	// Should be sorted by key.
+	Labels LabelPairs
+	// The value of the metric
+	MetricValue
+}
+
+// Append return the new value (in case of a non-Gauge), or returns this value with the relavant
+// fields summed/incremented in case of a guage (for later averaging)
+func (v LabeledMetric) Append(newVal LabeledMetric) LabeledMetric {
+	if v.MetricType != core.MetricGauge {
+		return newVal
+	}
+
+	v.MetricValue = v.MetricValue.Append(newVal.MetricValue)
+
+	return v
+}
+
+func (v LabeledMetric) FinalValue() core.LabeledMetric {
+	res := core.LabeledMetric{
+		Name:        v.Name,
+		Labels:      make(map[string]string, len(v.Labels)),
+		MetricValue: v.MetricValue.FinalValue(),
+	}
+
+	for _, pair := range v.Labels {
+		res.Labels[pair.Key] = pair.Value
+	}
+
+	return res
+}
+
+// LabeledMetricID is a comparable form the identifying information for a LabeledMetric
+type LabeledMetricID struct {
+	// The Name of a Metric
+	Name string
+
+	// An opaque, unique representation of the metric labels and values
+	// (currently sorted, null-separated key-value pairs)
+	JoinedLabels string
+}
+
+func (v *LabeledMetric) MakeID() LabeledMetricID {
+	labelList := make([]string, len(v.Labels)*2)
+	for i, lblPair := range v.Labels {
+		labelList[i*2] = lblPair.Key
+		labelList[i*2+1] = lblPair.Value
+	}
+
+	return LabeledMetricID{
+		Name:         v.Name,
+		JoinedLabels: strings.Join(labelList, "\000"),
+	}
+}
+
+type MetricSet struct {
+	// MetricValues are non-labeled metrics (mapping metric names to values)
+	MetricValues map[string]MetricValue
+	// Labels are the global lables associated with the key for this metric set
+	Labels map[string]string
+	// Labeled metrics are the labeled metrics for this key (mapping an unique
+	// identifier to the labeled metric for use in merging)
+	LabeledMetrics map[LabeledMetricID]LabeledMetric
+}
+
+// MergeInto extracts this push metric set into another push metric set, merging the two
+func (s *MetricSet) MergeInto(targetSet *MetricSet, overwrite bool) {
+	// add in normal labels
+	if len(s.Labels) > 0 && targetSet.Labels == nil {
+		targetSet.Labels = make(map[string]string, len(s.Labels))
+	}
+
+	for lblName, lblValue := range s.Labels {
+		if !overwrite {
+			if _, oldValPresent := targetSet.Labels[lblName]; oldValPresent {
+				continue
+			}
+		}
+		targetSet.Labels[lblName] = lblValue
+	}
+
+	// add in normal values
+	if len(s.MetricValues) > 0 && targetSet.MetricValues == nil {
+		targetSet.MetricValues = make(map[string]MetricValue)
+	}
+
+	for metricName, pushValue := range s.MetricValues {
+		if !overwrite {
+			if _, oldValPresent := targetSet.MetricValues[metricName]; oldValPresent {
+				continue
+			}
+			targetSet.MetricValues[metricName] = pushValue
+			continue
+		}
+
+		targetSet.MetricValues[metricName] = targetSet.MetricValues[metricName].Append(pushValue)
+	}
+
+	// add in the labeled metrics
+	if len(s.LabeledMetrics) > 0 && targetSet.LabeledMetrics == nil {
+		targetSet.LabeledMetrics = make(map[LabeledMetricID]LabeledMetric, len(targetSet.LabeledMetrics))
+	}
+
+	for lblID, labeledMetric := range s.LabeledMetrics {
+		if !overwrite {
+			if _, oldValPresent := targetSet.LabeledMetrics[lblID]; oldValPresent {
+				continue
+			}
+			targetSet.LabeledMetrics[lblID] = labeledMetric
+			continue
+		}
+
+		targetSet.LabeledMetrics[lblID] = targetSet.LabeledMetrics[lblID].Append(labeledMetric)
+	}
+}
+
+func (s *MetricSet) MetricSet() *core.MetricSet {
+	res := &core.MetricSet{
+		MetricValues:   make(map[string]core.MetricValue, len(s.MetricValues)),
+		Labels:         s.Labels,
+		LabeledMetrics: make([]core.LabeledMetric, 0, len(s.LabeledMetrics)),
+	}
+
+	for metricName, pushValue := range s.MetricValues {
+		res.MetricValues[metricName] = pushValue.FinalValue()
+	}
+
+	for _, pushLabeledMetric := range s.LabeledMetrics {
+		res.LabeledMetrics = append(res.LabeledMetrics, pushLabeledMetric.FinalValue())
+	}
+
+	return res
+}
+
+// DataBatch is a core.DataBatch for push metrics
+type DataBatch struct {
+	Timestamp  time.Time
+	MetricSets map[string]*MetricSet
+}
+
+func (b *DataBatch) DataBatch() *core.DataBatch {
+	res := &core.DataBatch{
+		Timestamp:  b.Timestamp,
+		MetricSets: make(map[string]*core.MetricSet, len(b.MetricSets)),
+	}
+
+	for key, pushSet := range b.MetricSets {
+		res.MetricSets[key] = pushSet.MetricSet()
+	}
+
+	return res
+}
+
+// MergeInto extracts this push batch's metric sets into another push batch's metric sets, merging the two
+func (b *DataBatch) MergeInto(targetSets map[string]*MetricSet, overwrite bool) {
+	for setKey, pushSet := range b.MetricSets {
+		presentSet, wasPresent := targetSets[setKey]
+		if !wasPresent {
+			presentSet = &MetricSet{}
+			targetSets[setKey] = presentSet
+		}
+
+		pushSet.MergeInto(presentSet, overwrite)
+	}
+}

--- a/metrics/sources/push/types_test.go
+++ b/metrics/sources/push/types_test.go
@@ -1,0 +1,215 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package push
+
+import (
+	"testing"
+
+	"k8s.io/heapster/metrics/core"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// MergeInto and DataBatch are exercised by the main push tests
+
+func TestMetricValueFinalValue(t *testing.T) {
+	assert := assert.New(t)
+
+	// non-gauge metrics
+	inputCumulative := &MetricValue{
+		MetricValue: core.MetricValue{
+			MetricType: core.MetricCumulative,
+			FloatValue: 10.0,
+			IntValue:   5,
+		},
+	}
+	assert.Equal(inputCumulative.MetricValue, inputCumulative.FinalValue(), "non-gauge metrics should return the value without modification")
+
+	// guage metrics with count of zero
+	inputGaugeSingle := &MetricValue{
+		MetricValue: core.MetricValue{
+			ValueType:  core.ValueFloat,
+			MetricType: core.MetricGauge,
+			FloatValue: 10,
+		},
+	}
+	assert.Equal(inputGaugeSingle.MetricValue, inputGaugeSingle.FinalValue(), "gauge metrics with a count of less than 2 should return the value without modification")
+
+	// gauge float values
+	inputGaugeFloat := &MetricValue{
+		StoredCount: 3,
+		MetricValue: core.MetricValue{
+			ValueType:  core.ValueFloat,
+			MetricType: core.MetricGauge,
+			FloatValue: 30,
+		},
+	}
+	expectedGaugeFloat := core.MetricValue{
+		ValueType:  core.ValueFloat,
+		MetricType: core.MetricGauge,
+		FloatValue: 10,
+	}
+	assert.Equal(expectedGaugeFloat, inputGaugeFloat.FinalValue(), "float guage metrics should return the average value")
+
+	// gauge int values
+	inputGaugeInt := &MetricValue{
+		StoredCount: 3,
+		MetricValue: core.MetricValue{
+			ValueType:  core.ValueInt64,
+			MetricType: core.MetricGauge,
+			IntValue:   30,
+		},
+	}
+	expectedGaugeInt := core.MetricValue{
+		ValueType:  core.ValueInt64,
+		MetricType: core.MetricGauge,
+		IntValue:   10,
+	}
+	assert.Equal(expectedGaugeInt, inputGaugeInt.FinalValue(), "int guage metrics should return the average value")
+}
+
+func TestMetricValueAppend(t *testing.T) {
+	assert := assert.New(t)
+
+	// base values
+	origValNonGauge := MetricValue{
+		MetricValue: core.MetricValue{
+			ValueType:  core.ValueInt64,
+			MetricType: core.MetricCumulative,
+			IntValue:   10,
+		},
+	}
+	origValZero := MetricValue{
+		MetricValue: core.MetricValue{
+			ValueType:  core.ValueInt64,
+			MetricType: core.MetricGauge,
+			IntValue:   10,
+		},
+	}
+	origValMultInt := MetricValue{
+		StoredCount: 2,
+		MetricValue: core.MetricValue{
+			ValueType:  core.ValueInt64,
+			MetricType: core.MetricGauge,
+			IntValue:   20,
+		},
+	}
+	origValMultFloat := MetricValue{
+		StoredCount: 2,
+		MetricValue: core.MetricValue{
+			ValueType:  core.ValueFloat,
+			MetricType: core.MetricGauge,
+			FloatValue: 20,
+		},
+	}
+
+	// new values
+	newValFloat := MetricValue{
+		MetricValue: core.MetricValue{
+			ValueType:  core.ValueFloat,
+			MetricType: core.MetricGauge,
+			FloatValue: 10,
+		},
+	}
+	newValInt := MetricValue{
+		MetricValue: core.MetricValue{
+			ValueType:  core.ValueInt64,
+			MetricType: core.MetricGauge,
+			IntValue:   10,
+		},
+	}
+
+	// expected vals
+	expectedValMultInt := MetricValue{
+		StoredCount: 3,
+		MetricValue: core.MetricValue{
+			ValueType:  core.ValueInt64,
+			MetricType: core.MetricGauge,
+			IntValue:   30,
+		},
+	}
+	expectedValMultFloat := MetricValue{
+		StoredCount: 3,
+		MetricValue: core.MetricValue{
+			ValueType:  core.ValueFloat,
+			MetricType: core.MetricGauge,
+			FloatValue: 30,
+		},
+	}
+	expectedValTwo := MetricValue{
+		StoredCount: 2,
+		MetricValue: core.MetricValue{
+			ValueType:  core.ValueInt64,
+			MetricType: core.MetricGauge,
+			IntValue:   20,
+		},
+	}
+
+	assert.Equal(newValFloat, origValNonGauge.Append(newValFloat), "non-gauge values should simply return the new value")
+	assert.Equal(expectedValTwo, origValZero.Append(newValInt), "gauge metrics with a count of zero should jump to a count of two")
+	assert.Equal(expectedValMultFloat, origValMultFloat.Append(newValFloat), "float gauge metrics should increment the count and add the float values")
+	assert.Equal(expectedValMultInt, origValMultInt.Append(newValInt), "int gauge metrics should increment the count and add the int values")
+}
+
+func TestLabeledMetricWrappers(t *testing.T) {
+	initialLabeledMetric := LabeledMetric{
+		Name:   "cheese",
+		Labels: []LabelPair{{"color", "white"}, {"sharpness", "extra"}},
+		MetricValue: MetricValue{
+			StoredCount: 2,
+			MetricValue: core.MetricValue{
+				ValueType:  core.ValueInt64,
+				MetricType: core.MetricGauge,
+				IntValue:   20,
+			},
+		},
+	}
+	newLabeledMetric := LabeledMetric{
+		Name:   "cheese",
+		Labels: []LabelPair{{"color", "white"}, {"sharpness", "extra"}},
+		MetricValue: MetricValue{
+			MetricValue: core.MetricValue{
+				ValueType:  core.ValueInt64,
+				MetricType: core.MetricGauge,
+				IntValue:   10,
+			},
+		},
+	}
+	expectedLabeledMetric := core.LabeledMetric{
+		Name:   "cheese",
+		Labels: map[string]string{"sharpness": "extra", "color": "white"},
+		MetricValue: core.MetricValue{
+			ValueType:  core.ValueInt64,
+			MetricType: core.MetricGauge,
+			IntValue:   10,
+		},
+	}
+
+	assert.Equal(t, expectedLabeledMetric, initialLabeledMetric.Append(newLabeledMetric).FinalValue(), "calling the same methods on labeled metrics as on normal metric values should work like calling the methods on their values and preserving the rest")
+}
+
+func TestLabeledMetricMakeID(t *testing.T) {
+	metric := LabeledMetric{
+		Name:   "cheese",
+		Labels: []LabelPair{{"color", "white"}, {"sharpness", "extra"}},
+	}
+
+	expectedID := LabeledMetricID{
+		Name:         "cheese",
+		JoinedLabels: "color\000white\000sharpness\000extra",
+	}
+
+	assert.Equal(t, expectedID, metric.MakeID(), "the ID of the labeled metric should consist of its name, plus its labels joined together")
+}

--- a/metrics/sources/summary/summary.go
+++ b/metrics/sources/summary/summary.go
@@ -89,6 +89,10 @@ func (this *summaryMetricsSource) String() string {
 	return fmt.Sprintf("kubelet_summary:%s:%d", this.node.IP, this.node.Port)
 }
 
+func (this *summaryMetricsSource) IsCanonical() bool {
+	return true
+}
+
 func (this *summaryMetricsSource) ScrapeMetrics(start, end time.Time) *DataBatch {
 	if this.useFallback {
 		return this.fallback.ScrapeMetrics(start, end)

--- a/metrics/sources/summary/summary_test.go
+++ b/metrics/sources/summary/summary_test.go
@@ -92,7 +92,8 @@ type fakeSource struct {
 	scraped bool
 }
 
-func (f *fakeSource) Name() string { return "fake" }
+func (f *fakeSource) Name() string      { return "fake" }
+func (f *fakeSource) IsCanonical() bool { return true }
 func (f *fakeSource) ScrapeMetrics(start, end time.Time) *core.DataBatch {
 	f.scraped = true
 	return nil

--- a/metrics/util/dummies.go
+++ b/metrics/util/dummies.go
@@ -72,6 +72,7 @@ func NewDummySink(name string, latency time.Duration) *DummySink {
 type DummyMetricsSource struct {
 	latency   time.Duration
 	metricSet core.MetricSet
+	canonical bool
 }
 
 func (this *DummyMetricsSource) Name() string {
@@ -88,6 +89,10 @@ func (this *DummyMetricsSource) ScrapeMetrics(start, end time.Time) *core.DataBa
 	}
 }
 
+func (this *DummyMetricsSource) IsCanonical() bool {
+	return this.canonical
+}
+
 func newDummyMetricSet(name string) core.MetricSet {
 	return core.MetricSet{
 		MetricValues: map[string]core.MetricValue{},
@@ -101,6 +106,7 @@ func NewDummyMetricsSource(name string, latency time.Duration) *DummyMetricsSour
 	return &DummyMetricsSource{
 		latency:   latency,
 		metricSet: newDummyMetricSet(name),
+		canonical: true,
 	}
 }
 

--- a/metrics/util/util.go
+++ b/metrics/util/util.go
@@ -19,7 +19,12 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"k8s.io/heapster/metrics/core"
 )
+
+// InternalUserHeader is the header set by the auth system to communicate the user extracted during auth
+const UserAttributeName = "Heapster-User-Info"
 
 // Concatenates a map of labels into a comma-separated key=value pairs.
 func LabelsToString(labels map[string]string, separator string) string {
@@ -46,4 +51,61 @@ func GetLatest(a, b time.Time) time.Time {
 		return a
 	}
 	return b
+}
+
+// MergeValuesFunc is a function for merging two maps of metric values.
+type MergeValuesFunc func(destValues map[string]core.MetricValue, newValues map[string]core.MetricValue, overwrite bool)
+
+// MergeMetricSetCustom works just like MergeMetricSet, except that a custom method for merging the actual metric
+// values is accepted.
+func MergeMetricSetCustom(destSet *core.MetricSet, newSet *core.MetricSet, overwrite bool, mergeValues MergeValuesFunc) {
+	// copy over times if they're not already set
+	if destSet.CreateTime.IsZero() || overwrite {
+		destSet.CreateTime = newSet.CreateTime
+	}
+
+	if destSet.ScrapeTime.IsZero() || overwrite {
+		destSet.ScrapeTime = newSet.ScrapeTime
+	}
+
+	// Merge labels
+	for lblName, newLblVal := range newSet.Labels {
+		if !overwrite {
+			if _, oldValPresent := destSet.Labels[lblName]; oldValPresent {
+				continue
+			}
+		}
+
+		destSet.Labels[lblName] = newLblVal
+	}
+
+	// Merge metric values
+	mergeValues(destSet.MetricValues, newSet.MetricValues, overwrite)
+
+	// Append labled metric values
+
+	// TODO: we should probably try to make sure there aren't any labeled metrics with
+	// the same name and label set, instead of just appending here
+	destSet.LabeledMetrics = append(destSet.LabeledMetrics, newSet.LabeledMetrics...)
+}
+
+// MergeMetricSet merges a new metric set into an existing (destination) metric set.
+// If overwrite is true, if there are conflicts between label and metric values,
+// the new set will overwrite the existing set.  Otherwise, conflicting values from
+// the new set will be ignored.  Overwrite also causes times from the new set batch
+// to replace those from the old one unconditionally (otherwise, replacement happens
+// with missing values only).
+func MergeMetricSet(destSet *core.MetricSet, newSet *core.MetricSet, overwrite bool) {
+
+	MergeMetricSetCustom(destSet, newSet, overwrite, func(destValues map[string]core.MetricValue, newValues map[string]core.MetricValue, _ bool) {
+		for valKey, newVal := range newValues {
+			if !overwrite {
+				if _, oldValPresent := destValues[valKey]; oldValPresent {
+					continue
+				}
+			}
+
+			destValues[valKey] = newVal
+		}
+	})
 }

--- a/metrics/util/util_test.go
+++ b/metrics/util/util_test.go
@@ -1,0 +1,263 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"k8s.io/heapster/metrics/core"
+)
+
+func TestMergeMetricSetAlwaysOverwritesZeroTimes(t *testing.T) {
+	nowTime := time.Now()
+	assert := assert.New(t)
+
+	destSet := &core.MetricSet{
+		CreateTime: time.Time{},
+		ScrapeTime: time.Time{},
+	}
+
+	newSet := &core.MetricSet{
+		CreateTime: nowTime.Add(10 * time.Second),
+		ScrapeTime: nowTime.Add(20 * time.Second),
+	}
+
+	MergeMetricSet(destSet, newSet, false)
+	assert.Equal(destSet.CreateTime, newSet.CreateTime, "Zero create time in the destination set should have been overwritten with the non-zero times in the new set")
+	assert.Equal(destSet.ScrapeTime, newSet.ScrapeTime, "Zero scrape time in the destination set should have been overwritten with the non-zero times in the new set")
+}
+
+func TestMergeMetricSetNoOverwriteWithTimes(t *testing.T) {
+	nowTime := time.Now()
+	assert := assert.New(t)
+
+	destSet := &core.MetricSet{
+		CreateTime: nowTime.Add(10 * time.Second),
+		ScrapeTime: nowTime.Add(20 * time.Second),
+
+		Labels: map[string]string{
+			"lbl1": "val1",
+			"lbl2": "val2",
+		},
+
+		MetricValues: map[string]core.MetricValue{
+			"metric1": {
+				IntValue: 3,
+			},
+			"metric2": {
+				FloatValue: 4.0,
+			},
+		},
+
+		LabeledMetrics: []core.LabeledMetric{
+			{
+				Name:   "lblMetric1",
+				Labels: map[string]string{"cheese": "cheddar"},
+				MetricValue: core.MetricValue{
+					IntValue: 3,
+				},
+			},
+		},
+	}
+
+	newSet := &core.MetricSet{
+		CreateTime: nowTime.Add(30 * time.Second),
+		ScrapeTime: nowTime.Add(40 * time.Second),
+
+		Labels: map[string]string{
+			"lbl1": "val1.2",
+			"lbl3": "val3",
+		},
+
+		MetricValues: map[string]core.MetricValue{
+			"metric1": {
+				IntValue: 5,
+			},
+			"metric3": {
+				FloatValue: 6.0,
+			},
+		},
+
+		LabeledMetrics: []core.LabeledMetric{
+			{
+				Name:   "lblMetric1",
+				Labels: map[string]string{"cheese": "pepperJack"},
+				MetricValue: core.MetricValue{
+					IntValue: 4,
+				},
+			},
+		},
+	}
+
+	MergeMetricSet(destSet, newSet, false)
+
+	// it should only set times if they're zero
+	assert.Equal(destSet.CreateTime, nowTime.Add(10*time.Second), "the destination set's non-zero create time should not have been overwritten")
+	assert.Equal(destSet.ScrapeTime, nowTime.Add(20*time.Second), "the destination set's non-zero scrape time should not have been overwritten")
+
+	// it should add new labels and keep existing ones
+	expectedLabels := map[string]string{
+		"lbl1": "val1",
+		"lbl2": "val2",
+		"lbl3": "val3",
+	}
+	assert.Equal(destSet.Labels, expectedLabels, "the destination set's labels should have the new labels from the new set, but should have kept any existing values")
+
+	// it should add new metric values and keep existing ones
+	expectedMetricValues := map[string]core.MetricValue{
+		"metric1": {
+			IntValue: 3,
+		},
+		"metric2": {
+			FloatValue: 4.0,
+		},
+		"metric3": {
+			FloatValue: 6.0,
+		},
+	}
+	assert.Equal(destSet.MetricValues, expectedMetricValues, "the destination set's metric values should have new metric values from the new set, but should have kept any existing values")
+
+	// it should append new labeled metrics
+	expectedLabeledMetrics := []core.LabeledMetric{
+		{
+			Name:   "lblMetric1",
+			Labels: map[string]string{"cheese": "cheddar"},
+			MetricValue: core.MetricValue{
+				IntValue: 3,
+			},
+		},
+		{
+			Name:   "lblMetric1",
+			Labels: map[string]string{"cheese": "pepperJack"},
+			MetricValue: core.MetricValue{
+				IntValue: 4,
+			},
+		},
+	}
+	assert.Equal(destSet.LabeledMetrics, expectedLabeledMetrics, "the destination set's labeled metrics should have included the labeled metrics it originally had, plus the labeled metrics from the new set")
+}
+
+func TestMergeMetricSetOverwrite(t *testing.T) {
+	nowTime := time.Now()
+	assert := assert.New(t)
+
+	destSet := &core.MetricSet{
+		CreateTime: nowTime.Add(10 * time.Second),
+		ScrapeTime: nowTime.Add(20 * time.Second),
+
+		Labels: map[string]string{
+			"lbl1": "val1",
+			"lbl2": "val2",
+		},
+
+		MetricValues: map[string]core.MetricValue{
+			"metric1": {
+				IntValue: 3,
+			},
+			"metric2": {
+				FloatValue: 4.0,
+			},
+		},
+
+		LabeledMetrics: []core.LabeledMetric{
+			{
+				Name:   "lblMetric1",
+				Labels: map[string]string{"cheese": "cheddar"},
+				MetricValue: core.MetricValue{
+					IntValue: 3,
+				},
+			},
+		},
+	}
+
+	newSet := &core.MetricSet{
+		CreateTime: nowTime.Add(30 * time.Second),
+		ScrapeTime: nowTime.Add(40 * time.Second),
+
+		Labels: map[string]string{
+			"lbl1": "val1.2",
+			"lbl3": "val3",
+		},
+
+		MetricValues: map[string]core.MetricValue{
+			"metric1": {
+				IntValue: 5,
+			},
+			"metric3": {
+				FloatValue: 6.0,
+			},
+		},
+
+		LabeledMetrics: []core.LabeledMetric{
+			{
+				Name:   "lblMetric1",
+				Labels: map[string]string{"cheese": "pepperJack"},
+				MetricValue: core.MetricValue{
+					IntValue: 4,
+				},
+			},
+		},
+	}
+
+	MergeMetricSet(destSet, newSet, true)
+
+	// it should overwrite times regardless
+	assert.Equal(destSet.CreateTime, nowTime.Add(30*time.Second), "the destination set's non-zero create time should have been overwritten")
+	assert.Equal(destSet.ScrapeTime, nowTime.Add(40*time.Second), "the destination set's non-zero scrape time should have been overwritten")
+
+	// it should add new labels and overwrite exiting ones
+	expectedLabels := map[string]string{
+		"lbl1": "val1.2",
+		"lbl2": "val2",
+		"lbl3": "val3",
+	}
+	assert.Equal(destSet.Labels, expectedLabels, "the destination set's labels should have the new labels from the new set and should have overwritten any existing duplicate label values")
+
+	// it should add new metric values and overwrite existing ones
+	expectedMetricValues := map[string]core.MetricValue{
+		"metric1": {
+			IntValue: 5,
+		},
+		"metric2": {
+			FloatValue: 4.0,
+		},
+		"metric3": {
+			FloatValue: 6.0,
+		},
+	}
+	assert.Equal(destSet.MetricValues, expectedMetricValues, "the destination set's metric values should have new metric values from the new set and should have overwritten any existing duplicate metric values")
+
+	// it should append new labeled metrics
+	expectedLabeledMetrics := []core.LabeledMetric{
+		{
+			Name:   "lblMetric1",
+			Labels: map[string]string{"cheese": "cheddar"},
+			MetricValue: core.MetricValue{
+				IntValue: 3,
+			},
+		},
+		{
+			Name:   "lblMetric1",
+			Labels: map[string]string{"cheese": "pepperJack"},
+			MetricValue: core.MetricValue{
+				IntValue: 4,
+			},
+		},
+	}
+	assert.Equal(destSet.LabeledMetrics, expectedLabeledMetrics, "the destination set's labeled metrics should have included the labeled metrics it originally had, plus the labeled metrics from the new set")
+}

--- a/vendor/github.com/prometheus/client_golang/extraction/discriminator.go
+++ b/vendor/github.com/prometheus/client_golang/extraction/discriminator.go
@@ -1,0 +1,74 @@
+// Copyright 2013 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extraction
+
+import (
+	"errors"
+	"fmt"
+	"mime"
+	"net/http"
+)
+
+// ProcessorForRequestHeader interprets a HTTP request header to determine
+// what Processor should be used for the given input.  If no acceptable
+// Processor can be found, an error is returned.
+func ProcessorForRequestHeader(header http.Header) (Processor, error) {
+	if header == nil {
+		return nil, errors.New("received illegal and nil header")
+	}
+
+	mediatype, params, err := mime.ParseMediaType(header.Get("Content-Type"))
+	if err != nil {
+		return nil, fmt.Errorf("invalid Content-Type header %q: %s", header.Get("Content-Type"), err)
+	}
+	switch mediatype {
+	case "application/vnd.google.protobuf":
+		if params["proto"] != "io.prometheus.client.MetricFamily" {
+			return nil, fmt.Errorf("unrecognized protocol message %s", params["proto"])
+		}
+		if params["encoding"] != "delimited" {
+			return nil, fmt.Errorf("unsupported encoding %s", params["encoding"])
+		}
+		return MetricFamilyProcessor, nil
+	case "text/plain":
+		switch params["version"] {
+		case "0.0.4":
+			return Processor004, nil
+		case "":
+			// Fallback: most recent version.
+			return Processor004, nil
+		default:
+			return nil, fmt.Errorf("unrecognized API version %s", params["version"])
+		}
+	case "application/json":
+		var prometheusAPIVersion string
+
+		if params["schema"] == "prometheus/telemetry" && params["version"] != "" {
+			prometheusAPIVersion = params["version"]
+		} else {
+			prometheusAPIVersion = header.Get("X-Prometheus-API-Version")
+		}
+
+		switch prometheusAPIVersion {
+		case "0.0.2":
+			return Processor002, nil
+		case "0.0.1":
+			return Processor001, nil
+		default:
+			return nil, fmt.Errorf("unrecognized API version %s", prometheusAPIVersion)
+		}
+	default:
+		return nil, fmt.Errorf("unsupported media type %q, expected %q", mediatype, "application/json")
+	}
+}

--- a/vendor/github.com/prometheus/client_golang/extraction/extraction.go
+++ b/vendor/github.com/prometheus/client_golang/extraction/extraction.go
@@ -1,0 +1,15 @@
+// Copyright 2013 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package extraction decodes Prometheus clients' data streams for consumers.
+package extraction

--- a/vendor/github.com/prometheus/client_golang/extraction/metricfamilyprocessor.go
+++ b/vendor/github.com/prometheus/client_golang/extraction/metricfamilyprocessor.go
@@ -1,0 +1,318 @@
+// Copyright 2013 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extraction
+
+import (
+	"fmt"
+	"io"
+	"math"
+
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/matttproud/golang_protobuf_extensions/pbutil"
+
+	"github.com/prometheus/client_golang/model"
+)
+
+type metricFamilyProcessor struct{}
+
+// MetricFamilyProcessor decodes varint encoded record length-delimited streams
+// of io.prometheus.client.MetricFamily.
+//
+// See http://godoc.org/github.com/matttproud/golang_protobuf_extensions/ext for
+// more details.
+var MetricFamilyProcessor = &metricFamilyProcessor{}
+
+func (m *metricFamilyProcessor) ProcessSingle(i io.Reader, out Ingester, o *ProcessOptions) error {
+	family := &dto.MetricFamily{}
+
+	for {
+		family.Reset()
+
+		if _, err := pbutil.ReadDelimited(i, family); err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return err
+		}
+		if err := extractMetricFamily(out, o, family); err != nil {
+			return err
+		}
+	}
+}
+
+func extractMetricFamily(out Ingester, o *ProcessOptions, family *dto.MetricFamily) error {
+	switch family.GetType() {
+	case dto.MetricType_COUNTER:
+		if err := extractCounter(out, o, family); err != nil {
+			return err
+		}
+	case dto.MetricType_GAUGE:
+		if err := extractGauge(out, o, family); err != nil {
+			return err
+		}
+	case dto.MetricType_SUMMARY:
+		if err := extractSummary(out, o, family); err != nil {
+			return err
+		}
+	case dto.MetricType_UNTYPED:
+		if err := extractUntyped(out, o, family); err != nil {
+			return err
+		}
+	case dto.MetricType_HISTOGRAM:
+		if err := extractHistogram(out, o, family); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func extractCounter(out Ingester, o *ProcessOptions, f *dto.MetricFamily) error {
+	samples := make(model.Samples, 0, len(f.Metric))
+
+	for _, m := range f.Metric {
+		if m.Counter == nil {
+			continue
+		}
+
+		sample := &model.Sample{
+			Metric: model.Metric{},
+			Value:  model.SampleValue(m.Counter.GetValue()),
+		}
+		samples = append(samples, sample)
+
+		if m.TimestampMs != nil {
+			sample.Timestamp = model.TimestampFromUnixNano(*m.TimestampMs * 1000000)
+		} else {
+			sample.Timestamp = o.Timestamp
+		}
+
+		metric := sample.Metric
+		for _, p := range m.Label {
+			metric[model.LabelName(p.GetName())] = model.LabelValue(p.GetValue())
+		}
+		metric[model.MetricNameLabel] = model.LabelValue(f.GetName())
+	}
+
+	return out.Ingest(samples)
+}
+
+func extractGauge(out Ingester, o *ProcessOptions, f *dto.MetricFamily) error {
+	samples := make(model.Samples, 0, len(f.Metric))
+
+	for _, m := range f.Metric {
+		if m.Gauge == nil {
+			continue
+		}
+
+		sample := &model.Sample{
+			Metric: model.Metric{},
+			Value:  model.SampleValue(m.Gauge.GetValue()),
+		}
+		samples = append(samples, sample)
+
+		if m.TimestampMs != nil {
+			sample.Timestamp = model.TimestampFromUnixNano(*m.TimestampMs * 1000000)
+		} else {
+			sample.Timestamp = o.Timestamp
+		}
+
+		metric := sample.Metric
+		for _, p := range m.Label {
+			metric[model.LabelName(p.GetName())] = model.LabelValue(p.GetValue())
+		}
+		metric[model.MetricNameLabel] = model.LabelValue(f.GetName())
+	}
+
+	return out.Ingest(samples)
+}
+
+func extractSummary(out Ingester, o *ProcessOptions, f *dto.MetricFamily) error {
+	samples := make(model.Samples, 0, len(f.Metric))
+
+	for _, m := range f.Metric {
+		if m.Summary == nil {
+			continue
+		}
+
+		timestamp := o.Timestamp
+		if m.TimestampMs != nil {
+			timestamp = model.TimestampFromUnixNano(*m.TimestampMs * 1000000)
+		}
+
+		for _, q := range m.Summary.Quantile {
+			sample := &model.Sample{
+				Metric:    model.Metric{},
+				Value:     model.SampleValue(q.GetValue()),
+				Timestamp: timestamp,
+			}
+			samples = append(samples, sample)
+
+			metric := sample.Metric
+			for _, p := range m.Label {
+				metric[model.LabelName(p.GetName())] = model.LabelValue(p.GetValue())
+			}
+			// BUG(matt): Update other names to "quantile".
+			metric[model.LabelName(model.QuantileLabel)] = model.LabelValue(fmt.Sprint(q.GetQuantile()))
+			metric[model.MetricNameLabel] = model.LabelValue(f.GetName())
+		}
+
+		if m.Summary.SampleSum != nil {
+			sum := &model.Sample{
+				Metric:    model.Metric{},
+				Value:     model.SampleValue(m.Summary.GetSampleSum()),
+				Timestamp: timestamp,
+			}
+			samples = append(samples, sum)
+
+			metric := sum.Metric
+			for _, p := range m.Label {
+				metric[model.LabelName(p.GetName())] = model.LabelValue(p.GetValue())
+			}
+			metric[model.MetricNameLabel] = model.LabelValue(f.GetName() + "_sum")
+		}
+
+		if m.Summary.SampleCount != nil {
+			count := &model.Sample{
+				Metric:    model.Metric{},
+				Value:     model.SampleValue(m.Summary.GetSampleCount()),
+				Timestamp: timestamp,
+			}
+			samples = append(samples, count)
+
+			metric := count.Metric
+			for _, p := range m.Label {
+				metric[model.LabelName(p.GetName())] = model.LabelValue(p.GetValue())
+			}
+			metric[model.MetricNameLabel] = model.LabelValue(f.GetName() + "_count")
+		}
+	}
+
+	return out.Ingest(samples)
+}
+
+func extractUntyped(out Ingester, o *ProcessOptions, f *dto.MetricFamily) error {
+	samples := make(model.Samples, 0, len(f.Metric))
+
+	for _, m := range f.Metric {
+		if m.Untyped == nil {
+			continue
+		}
+
+		sample := &model.Sample{
+			Metric: model.Metric{},
+			Value:  model.SampleValue(m.Untyped.GetValue()),
+		}
+		samples = append(samples, sample)
+
+		if m.TimestampMs != nil {
+			sample.Timestamp = model.TimestampFromUnixNano(*m.TimestampMs * 1000000)
+		} else {
+			sample.Timestamp = o.Timestamp
+		}
+
+		metric := sample.Metric
+		for _, p := range m.Label {
+			metric[model.LabelName(p.GetName())] = model.LabelValue(p.GetValue())
+		}
+		metric[model.MetricNameLabel] = model.LabelValue(f.GetName())
+	}
+
+	return out.Ingest(samples)
+}
+
+func extractHistogram(out Ingester, o *ProcessOptions, f *dto.MetricFamily) error {
+	samples := make(model.Samples, 0, len(f.Metric))
+
+	for _, m := range f.Metric {
+		if m.Histogram == nil {
+			continue
+		}
+
+		timestamp := o.Timestamp
+		if m.TimestampMs != nil {
+			timestamp = model.TimestampFromUnixNano(*m.TimestampMs * 1000000)
+		}
+
+		infSeen := false
+
+		for _, q := range m.Histogram.Bucket {
+			sample := &model.Sample{
+				Metric:    model.Metric{},
+				Value:     model.SampleValue(q.GetCumulativeCount()),
+				Timestamp: timestamp,
+			}
+			samples = append(samples, sample)
+
+			metric := sample.Metric
+			for _, p := range m.Label {
+				metric[model.LabelName(p.GetName())] = model.LabelValue(p.GetValue())
+			}
+			metric[model.LabelName(model.BucketLabel)] = model.LabelValue(fmt.Sprint(q.GetUpperBound()))
+			metric[model.MetricNameLabel] = model.LabelValue(f.GetName() + "_bucket")
+
+			if math.IsInf(q.GetUpperBound(), +1) {
+				infSeen = true
+			}
+		}
+
+		if m.Histogram.SampleSum != nil {
+			sum := &model.Sample{
+				Metric:    model.Metric{},
+				Value:     model.SampleValue(m.Histogram.GetSampleSum()),
+				Timestamp: timestamp,
+			}
+			samples = append(samples, sum)
+
+			metric := sum.Metric
+			for _, p := range m.Label {
+				metric[model.LabelName(p.GetName())] = model.LabelValue(p.GetValue())
+			}
+			metric[model.MetricNameLabel] = model.LabelValue(f.GetName() + "_sum")
+		}
+
+		if m.Histogram.SampleCount != nil {
+			count := &model.Sample{
+				Metric:    model.Metric{},
+				Value:     model.SampleValue(m.Histogram.GetSampleCount()),
+				Timestamp: timestamp,
+			}
+			samples = append(samples, count)
+
+			metric := count.Metric
+			for _, p := range m.Label {
+				metric[model.LabelName(p.GetName())] = model.LabelValue(p.GetValue())
+			}
+			metric[model.MetricNameLabel] = model.LabelValue(f.GetName() + "_count")
+
+			if !infSeen {
+				infBucket := &model.Sample{
+					Metric:    model.Metric{},
+					Value:     count.Value,
+					Timestamp: timestamp,
+				}
+				samples = append(samples, infBucket)
+
+				metric := infBucket.Metric
+				for _, p := range m.Label {
+					metric[model.LabelName(p.GetName())] = model.LabelValue(p.GetValue())
+				}
+				metric[model.LabelName(model.BucketLabel)] = model.LabelValue("+Inf")
+				metric[model.MetricNameLabel] = model.LabelValue(f.GetName() + "_bucket")
+			}
+		}
+	}
+
+	return out.Ingest(samples)
+}

--- a/vendor/github.com/prometheus/client_golang/extraction/processor.go
+++ b/vendor/github.com/prometheus/client_golang/extraction/processor.go
@@ -1,0 +1,84 @@
+// Copyright 2013 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extraction
+
+import (
+	"io"
+	"time"
+
+	"github.com/prometheus/client_golang/model"
+)
+
+// ProcessOptions dictates how the interpreted stream should be rendered for
+// consumption.
+type ProcessOptions struct {
+	// Timestamp is added to each value from the stream that has no explicit
+	// timestamp set.
+	Timestamp model.Timestamp
+}
+
+// Ingester consumes result streams in whatever way is desired by the user.
+type Ingester interface {
+	Ingest(model.Samples) error
+}
+
+// Processor is responsible for decoding the actual message responses from
+// stream into a format that can be consumed with the end result written
+// to the results channel.
+type Processor interface {
+	// ProcessSingle treats the input as a single self-contained message body and
+	// transforms it accordingly.  It has no support for streaming.
+	ProcessSingle(in io.Reader, out Ingester, o *ProcessOptions) error
+}
+
+// Helper function to convert map[string]string into LabelSet.
+//
+// NOTE: This should be deleted when support for go 1.0.3 is removed; 1.1 is
+//       smart enough to unmarshal JSON objects into LabelSet directly.
+func labelSet(labels map[string]string) model.LabelSet {
+	labelset := make(model.LabelSet, len(labels))
+
+	for k, v := range labels {
+		labelset[model.LabelName(k)] = model.LabelValue(v)
+	}
+
+	return labelset
+}
+
+// A basic interface only useful in testing contexts for dispensing the time
+// in a controlled manner.
+type instantProvider interface {
+	// The current instant.
+	Now() time.Time
+}
+
+// Clock is a simple means for fluently wrapping around standard Go timekeeping
+// mechanisms to enhance testability without compromising code readability.
+//
+// It is sufficient for use on bare initialization.  A provider should be
+// set only for test contexts.  When not provided, it emits the current
+// system time.
+type clock struct {
+	// The underlying means through which time is provided, if supplied.
+	Provider instantProvider
+}
+
+// Emit the current instant.
+func (t *clock) Now() time.Time {
+	if t.Provider == nil {
+		return time.Now()
+	}
+
+	return t.Provider.Now()
+}

--- a/vendor/github.com/prometheus/client_golang/extraction/processor0_0_1.go
+++ b/vendor/github.com/prometheus/client_golang/extraction/processor0_0_1.go
@@ -1,0 +1,127 @@
+// Copyright 2013 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extraction
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+
+	"github.com/prometheus/client_golang/model"
+)
+
+const (
+	baseLabels001 = "baseLabels"
+	counter001    = "counter"
+	docstring001  = "docstring"
+	gauge001      = "gauge"
+	histogram001  = "histogram"
+	labels001     = "labels"
+	metric001     = "metric"
+	type001       = "type"
+	value001      = "value"
+	percentile001 = "percentile"
+)
+
+// Processor001 is responsible for decoding payloads from protocol version
+// 0.0.1.
+var Processor001 = &processor001{}
+
+// processor001 is responsible for handling API version 0.0.1.
+type processor001 struct{}
+
+// entity001 represents a the JSON structure that 0.0.1 uses.
+type entity001 []struct {
+	BaseLabels map[string]string `json:"baseLabels"`
+	Docstring  string            `json:"docstring"`
+	Metric     struct {
+		MetricType string `json:"type"`
+		Value      []struct {
+			Labels map[string]string `json:"labels"`
+			Value  interface{}       `json:"value"`
+		} `json:"value"`
+	} `json:"metric"`
+}
+
+func (p *processor001) ProcessSingle(in io.Reader, out Ingester, o *ProcessOptions) error {
+	// TODO(matt): Replace with plain-jane JSON unmarshalling.
+	buffer, err := ioutil.ReadAll(in)
+	if err != nil {
+		return err
+	}
+
+	entities := entity001{}
+	if err = json.Unmarshal(buffer, &entities); err != nil {
+		return err
+	}
+
+	// TODO(matt): This outer loop is a great basis for parallelization.
+	pendingSamples := model.Samples{}
+	for _, entity := range entities {
+		for _, value := range entity.Metric.Value {
+			labels := labelSet(entity.BaseLabels).Merge(labelSet(value.Labels))
+
+			switch entity.Metric.MetricType {
+			case gauge001, counter001:
+				sampleValue, ok := value.Value.(float64)
+				if !ok {
+					return fmt.Errorf("could not convert value from %s %s to float64", entity, value)
+				}
+
+				pendingSamples = append(pendingSamples, &model.Sample{
+					Metric:    model.Metric(labels),
+					Timestamp: o.Timestamp,
+					Value:     model.SampleValue(sampleValue),
+				})
+
+				break
+
+			case histogram001:
+				sampleValue, ok := value.Value.(map[string]interface{})
+				if !ok {
+					return fmt.Errorf("could not convert value from %q to a map[string]interface{}", value.Value)
+				}
+
+				for percentile, percentileValue := range sampleValue {
+					individualValue, ok := percentileValue.(float64)
+					if !ok {
+						return fmt.Errorf("could not convert value from %q to a float64", percentileValue)
+					}
+
+					childMetric := make(map[model.LabelName]model.LabelValue, len(labels)+1)
+
+					for k, v := range labels {
+						childMetric[k] = v
+					}
+
+					childMetric[model.LabelName(percentile001)] = model.LabelValue(percentile)
+
+					pendingSamples = append(pendingSamples, &model.Sample{
+						Metric:    model.Metric(childMetric),
+						Timestamp: o.Timestamp,
+						Value:     model.SampleValue(individualValue),
+					})
+				}
+
+				break
+			}
+		}
+	}
+	if len(pendingSamples) > 0 {
+		return out.Ingest(pendingSamples)
+	}
+
+	return nil
+}

--- a/vendor/github.com/prometheus/client_golang/extraction/processor0_0_2.go
+++ b/vendor/github.com/prometheus/client_golang/extraction/processor0_0_2.go
@@ -1,0 +1,106 @@
+// Copyright 2013 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extraction
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/prometheus/client_golang/model"
+)
+
+// Processor002 is responsible for decoding payloads from protocol version
+// 0.0.2.
+var Processor002 = &processor002{}
+
+type histogram002 struct {
+	Labels map[string]string            `json:"labels"`
+	Values map[string]model.SampleValue `json:"value"`
+}
+
+type counter002 struct {
+	Labels map[string]string `json:"labels"`
+	Value  model.SampleValue `json:"value"`
+}
+
+type processor002 struct{}
+
+func (p *processor002) ProcessSingle(in io.Reader, out Ingester, o *ProcessOptions) error {
+	// Processor for telemetry schema version 0.0.2.
+	// container for telemetry data
+	var entities []struct {
+		BaseLabels map[string]string `json:"baseLabels"`
+		Docstring  string            `json:"docstring"`
+		Metric     struct {
+			Type   string          `json:"type"`
+			Values json.RawMessage `json:"value"`
+		} `json:"metric"`
+	}
+
+	if err := json.NewDecoder(in).Decode(&entities); err != nil {
+		return err
+	}
+
+	pendingSamples := model.Samples{}
+	for _, entity := range entities {
+		switch entity.Metric.Type {
+		case "counter", "gauge":
+			var values []counter002
+
+			if err := json.Unmarshal(entity.Metric.Values, &values); err != nil {
+				return fmt.Errorf("could not extract %s value: %s", entity.Metric.Type, err)
+			}
+
+			for _, counter := range values {
+				labels := labelSet(entity.BaseLabels).Merge(labelSet(counter.Labels))
+
+				pendingSamples = append(pendingSamples, &model.Sample{
+					Metric:    model.Metric(labels),
+					Timestamp: o.Timestamp,
+					Value:     counter.Value,
+				})
+			}
+
+		case "histogram":
+			var values []histogram002
+
+			if err := json.Unmarshal(entity.Metric.Values, &values); err != nil {
+				return fmt.Errorf("could not extract %s value: %s", entity.Metric.Type, err)
+			}
+
+			for _, histogram := range values {
+				for percentile, value := range histogram.Values {
+					labels := labelSet(entity.BaseLabels).Merge(labelSet(histogram.Labels))
+					labels[model.LabelName("percentile")] = model.LabelValue(percentile)
+
+					pendingSamples = append(pendingSamples, &model.Sample{
+						Metric:    model.Metric(labels),
+						Timestamp: o.Timestamp,
+						Value:     value,
+					})
+				}
+			}
+
+		default:
+			return fmt.Errorf("unknown metric type %q", entity.Metric.Type)
+		}
+	}
+
+	if len(pendingSamples) > 0 {
+		return out.Ingest(pendingSamples)
+	}
+
+	return nil
+}

--- a/vendor/github.com/prometheus/client_golang/extraction/textprocessor.go
+++ b/vendor/github.com/prometheus/client_golang/extraction/textprocessor.go
@@ -1,0 +1,40 @@
+// Copyright 2014 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extraction
+
+import (
+	"io"
+
+	"github.com/prometheus/client_golang/text"
+)
+
+type processor004 struct{}
+
+// Processor004 s responsible for decoding payloads from the text based variety
+// of protocol version 0.0.4.
+var Processor004 = &processor004{}
+
+func (t *processor004) ProcessSingle(i io.Reader, out Ingester, o *ProcessOptions) error {
+	var parser text.Parser
+	metricFamilies, err := parser.TextToMetricFamilies(i)
+	if err != nil {
+		return err
+	}
+	for _, metricFamily := range metricFamilies {
+		if err := extractMetricFamily(out, o, metricFamily); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/vendor/github.com/prometheus/common/LICENSE
+++ b/vendor/github.com/prometheus/common/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/prometheus/common/NOTICE
+++ b/vendor/github.com/prometheus/common/NOTICE
@@ -1,0 +1,5 @@
+Common libraries shared by Prometheus Go components.
+Copyright 2015 The Prometheus Authors
+
+This product includes software developed at
+SoundCloud Ltd. (http://soundcloud.com/).

--- a/vendor/github.com/prometheus/common/expfmt/decode.go
+++ b/vendor/github.com/prometheus/common/expfmt/decode.go
@@ -1,0 +1,433 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package expfmt
+
+import (
+	"fmt"
+	"io"
+	"math"
+	"mime"
+	"net/http"
+
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/matttproud/golang_protobuf_extensions/pbutil"
+	"github.com/prometheus/common/model"
+)
+
+// Decoder types decode an input stream into metric families.
+type Decoder interface {
+	Decode(*dto.MetricFamily) error
+}
+
+type DecodeOptions struct {
+	// Timestamp is added to each value from the stream that has no explicit timestamp set.
+	Timestamp model.Time
+}
+
+// ResponseFormat extracts the correct format from a HTTP response header.
+// If no matching format can be found FormatUnknown is returned.
+func ResponseFormat(h http.Header) Format {
+	ct := h.Get(hdrContentType)
+
+	mediatype, params, err := mime.ParseMediaType(ct)
+	if err != nil {
+		return FmtUnknown
+	}
+
+	const (
+		textType = "text/plain"
+		jsonType = "application/json"
+	)
+
+	switch mediatype {
+	case ProtoType:
+		if p, ok := params["proto"]; ok && p != ProtoProtocol {
+			return FmtUnknown
+		}
+		if e, ok := params["encoding"]; ok && e != "delimited" {
+			return FmtUnknown
+		}
+		return FmtProtoDelim
+
+	case textType:
+		if v, ok := params["version"]; ok && v != TextVersion {
+			return FmtUnknown
+		}
+		return FmtText
+
+	case jsonType:
+		var prometheusAPIVersion string
+
+		if params["schema"] == "prometheus/telemetry" && params["version"] != "" {
+			prometheusAPIVersion = params["version"]
+		} else {
+			prometheusAPIVersion = h.Get("X-Prometheus-API-Version")
+		}
+
+		switch prometheusAPIVersion {
+		case "0.0.2", "":
+			return fmtJSON2
+		default:
+			return FmtUnknown
+		}
+	}
+
+	return FmtUnknown
+}
+
+// NewDecoder returns a new decoder based on the given input format.
+// If the input format does not imply otherwise, a text format decoder is returned.
+func NewDecoder(r io.Reader, format Format) Decoder {
+	switch format {
+	case FmtProtoDelim:
+		return &protoDecoder{r: r}
+	case fmtJSON2:
+		return newJSON2Decoder(r)
+	}
+	return &textDecoder{r: r}
+}
+
+// protoDecoder implements the Decoder interface for protocol buffers.
+type protoDecoder struct {
+	r io.Reader
+}
+
+// Decode implements the Decoder interface.
+func (d *protoDecoder) Decode(v *dto.MetricFamily) error {
+	_, err := pbutil.ReadDelimited(d.r, v)
+	if err != nil {
+		return err
+	}
+	if !model.IsValidMetricName(model.LabelValue(v.GetName())) {
+		return fmt.Errorf("invalid metric name %q", v.GetName())
+	}
+	for _, m := range v.GetMetric() {
+		if m == nil {
+			continue
+		}
+		for _, l := range m.GetLabel() {
+			if l == nil {
+				continue
+			}
+			if !model.LabelValue(l.GetValue()).IsValid() {
+				return fmt.Errorf("invalid label value %q", l.GetValue())
+			}
+			if !model.LabelName(l.GetName()).IsValid() {
+				return fmt.Errorf("invalid label name %q", l.GetName())
+			}
+		}
+	}
+	return nil
+}
+
+// textDecoder implements the Decoder interface for the text protcol.
+type textDecoder struct {
+	r    io.Reader
+	p    TextParser
+	fams []*dto.MetricFamily
+}
+
+// Decode implements the Decoder interface.
+func (d *textDecoder) Decode(v *dto.MetricFamily) error {
+	// TODO(fabxc): Wrap this as a line reader to make streaming safer.
+	if len(d.fams) == 0 {
+		// No cached metric families, read everything and parse metrics.
+		fams, err := d.p.TextToMetricFamilies(d.r)
+		if err != nil {
+			return err
+		}
+		if len(fams) == 0 {
+			return io.EOF
+		}
+		d.fams = make([]*dto.MetricFamily, 0, len(fams))
+		for _, f := range fams {
+			d.fams = append(d.fams, f)
+		}
+	}
+
+	*v = *d.fams[0]
+	d.fams = d.fams[1:]
+
+	return nil
+}
+
+type SampleDecoder struct {
+	Dec  Decoder
+	Opts *DecodeOptions
+
+	f dto.MetricFamily
+}
+
+func (sd *SampleDecoder) Decode(s *model.Vector) error {
+	if err := sd.Dec.Decode(&sd.f); err != nil {
+		return err
+	}
+	*s = extractSamples(&sd.f, sd.Opts)
+	return nil
+}
+
+// Extract samples builds a slice of samples from the provided metric families.
+func ExtractSamples(o *DecodeOptions, fams ...*dto.MetricFamily) model.Vector {
+	var all model.Vector
+	for _, f := range fams {
+		all = append(all, extractSamples(f, o)...)
+	}
+	return all
+}
+
+func extractSamples(f *dto.MetricFamily, o *DecodeOptions) model.Vector {
+	switch f.GetType() {
+	case dto.MetricType_COUNTER:
+		return extractCounter(o, f)
+	case dto.MetricType_GAUGE:
+		return extractGauge(o, f)
+	case dto.MetricType_SUMMARY:
+		return extractSummary(o, f)
+	case dto.MetricType_UNTYPED:
+		return extractUntyped(o, f)
+	case dto.MetricType_HISTOGRAM:
+		return extractHistogram(o, f)
+	}
+	panic("expfmt.extractSamples: unknown metric family type")
+}
+
+func extractCounter(o *DecodeOptions, f *dto.MetricFamily) model.Vector {
+	samples := make(model.Vector, 0, len(f.Metric))
+
+	for _, m := range f.Metric {
+		if m.Counter == nil {
+			continue
+		}
+
+		lset := make(model.LabelSet, len(m.Label)+1)
+		for _, p := range m.Label {
+			lset[model.LabelName(p.GetName())] = model.LabelValue(p.GetValue())
+		}
+		lset[model.MetricNameLabel] = model.LabelValue(f.GetName())
+
+		smpl := &model.Sample{
+			Metric: model.Metric(lset),
+			Value:  model.SampleValue(m.Counter.GetValue()),
+		}
+
+		if m.TimestampMs != nil {
+			smpl.Timestamp = model.TimeFromUnixNano(*m.TimestampMs * 1000000)
+		} else {
+			smpl.Timestamp = o.Timestamp
+		}
+
+		samples = append(samples, smpl)
+	}
+
+	return samples
+}
+
+func extractGauge(o *DecodeOptions, f *dto.MetricFamily) model.Vector {
+	samples := make(model.Vector, 0, len(f.Metric))
+
+	for _, m := range f.Metric {
+		if m.Gauge == nil {
+			continue
+		}
+
+		lset := make(model.LabelSet, len(m.Label)+1)
+		for _, p := range m.Label {
+			lset[model.LabelName(p.GetName())] = model.LabelValue(p.GetValue())
+		}
+		lset[model.MetricNameLabel] = model.LabelValue(f.GetName())
+
+		smpl := &model.Sample{
+			Metric: model.Metric(lset),
+			Value:  model.SampleValue(m.Gauge.GetValue()),
+		}
+
+		if m.TimestampMs != nil {
+			smpl.Timestamp = model.TimeFromUnixNano(*m.TimestampMs * 1000000)
+		} else {
+			smpl.Timestamp = o.Timestamp
+		}
+
+		samples = append(samples, smpl)
+	}
+
+	return samples
+}
+
+func extractUntyped(o *DecodeOptions, f *dto.MetricFamily) model.Vector {
+	samples := make(model.Vector, 0, len(f.Metric))
+
+	for _, m := range f.Metric {
+		if m.Untyped == nil {
+			continue
+		}
+
+		lset := make(model.LabelSet, len(m.Label)+1)
+		for _, p := range m.Label {
+			lset[model.LabelName(p.GetName())] = model.LabelValue(p.GetValue())
+		}
+		lset[model.MetricNameLabel] = model.LabelValue(f.GetName())
+
+		smpl := &model.Sample{
+			Metric: model.Metric(lset),
+			Value:  model.SampleValue(m.Untyped.GetValue()),
+		}
+
+		if m.TimestampMs != nil {
+			smpl.Timestamp = model.TimeFromUnixNano(*m.TimestampMs * 1000000)
+		} else {
+			smpl.Timestamp = o.Timestamp
+		}
+
+		samples = append(samples, smpl)
+	}
+
+	return samples
+}
+
+func extractSummary(o *DecodeOptions, f *dto.MetricFamily) model.Vector {
+	samples := make(model.Vector, 0, len(f.Metric))
+
+	for _, m := range f.Metric {
+		if m.Summary == nil {
+			continue
+		}
+
+		timestamp := o.Timestamp
+		if m.TimestampMs != nil {
+			timestamp = model.TimeFromUnixNano(*m.TimestampMs * 1000000)
+		}
+
+		for _, q := range m.Summary.Quantile {
+			lset := make(model.LabelSet, len(m.Label)+2)
+			for _, p := range m.Label {
+				lset[model.LabelName(p.GetName())] = model.LabelValue(p.GetValue())
+			}
+			// BUG(matt): Update other names to "quantile".
+			lset[model.LabelName(model.QuantileLabel)] = model.LabelValue(fmt.Sprint(q.GetQuantile()))
+			lset[model.MetricNameLabel] = model.LabelValue(f.GetName())
+
+			samples = append(samples, &model.Sample{
+				Metric:    model.Metric(lset),
+				Value:     model.SampleValue(q.GetValue()),
+				Timestamp: timestamp,
+			})
+		}
+
+		lset := make(model.LabelSet, len(m.Label)+1)
+		for _, p := range m.Label {
+			lset[model.LabelName(p.GetName())] = model.LabelValue(p.GetValue())
+		}
+		lset[model.MetricNameLabel] = model.LabelValue(f.GetName() + "_sum")
+
+		samples = append(samples, &model.Sample{
+			Metric:    model.Metric(lset),
+			Value:     model.SampleValue(m.Summary.GetSampleSum()),
+			Timestamp: timestamp,
+		})
+
+		lset = make(model.LabelSet, len(m.Label)+1)
+		for _, p := range m.Label {
+			lset[model.LabelName(p.GetName())] = model.LabelValue(p.GetValue())
+		}
+		lset[model.MetricNameLabel] = model.LabelValue(f.GetName() + "_count")
+
+		samples = append(samples, &model.Sample{
+			Metric:    model.Metric(lset),
+			Value:     model.SampleValue(m.Summary.GetSampleCount()),
+			Timestamp: timestamp,
+		})
+	}
+
+	return samples
+}
+
+func extractHistogram(o *DecodeOptions, f *dto.MetricFamily) model.Vector {
+	samples := make(model.Vector, 0, len(f.Metric))
+
+	for _, m := range f.Metric {
+		if m.Histogram == nil {
+			continue
+		}
+
+		timestamp := o.Timestamp
+		if m.TimestampMs != nil {
+			timestamp = model.TimeFromUnixNano(*m.TimestampMs * 1000000)
+		}
+
+		infSeen := false
+
+		for _, q := range m.Histogram.Bucket {
+			lset := make(model.LabelSet, len(m.Label)+2)
+			for _, p := range m.Label {
+				lset[model.LabelName(p.GetName())] = model.LabelValue(p.GetValue())
+			}
+			lset[model.LabelName(model.BucketLabel)] = model.LabelValue(fmt.Sprint(q.GetUpperBound()))
+			lset[model.MetricNameLabel] = model.LabelValue(f.GetName() + "_bucket")
+
+			if math.IsInf(q.GetUpperBound(), +1) {
+				infSeen = true
+			}
+
+			samples = append(samples, &model.Sample{
+				Metric:    model.Metric(lset),
+				Value:     model.SampleValue(q.GetCumulativeCount()),
+				Timestamp: timestamp,
+			})
+		}
+
+		lset := make(model.LabelSet, len(m.Label)+1)
+		for _, p := range m.Label {
+			lset[model.LabelName(p.GetName())] = model.LabelValue(p.GetValue())
+		}
+		lset[model.MetricNameLabel] = model.LabelValue(f.GetName() + "_sum")
+
+		samples = append(samples, &model.Sample{
+			Metric:    model.Metric(lset),
+			Value:     model.SampleValue(m.Histogram.GetSampleSum()),
+			Timestamp: timestamp,
+		})
+
+		lset = make(model.LabelSet, len(m.Label)+1)
+		for _, p := range m.Label {
+			lset[model.LabelName(p.GetName())] = model.LabelValue(p.GetValue())
+		}
+		lset[model.MetricNameLabel] = model.LabelValue(f.GetName() + "_count")
+
+		count := &model.Sample{
+			Metric:    model.Metric(lset),
+			Value:     model.SampleValue(m.Histogram.GetSampleCount()),
+			Timestamp: timestamp,
+		}
+		samples = append(samples, count)
+
+		if !infSeen {
+			// Append an infinity bucket sample.
+			lset := make(model.LabelSet, len(m.Label)+2)
+			for _, p := range m.Label {
+				lset[model.LabelName(p.GetName())] = model.LabelValue(p.GetValue())
+			}
+			lset[model.LabelName(model.BucketLabel)] = model.LabelValue("+Inf")
+			lset[model.MetricNameLabel] = model.LabelValue(f.GetName() + "_bucket")
+
+			samples = append(samples, &model.Sample{
+				Metric:    model.Metric(lset),
+				Value:     count.Value,
+				Timestamp: timestamp,
+			})
+		}
+	}
+
+	return samples
+}

--- a/vendor/github.com/prometheus/common/expfmt/encode.go
+++ b/vendor/github.com/prometheus/common/expfmt/encode.go
@@ -1,0 +1,88 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package expfmt
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/matttproud/golang_protobuf_extensions/pbutil"
+	"github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg"
+
+	dto "github.com/prometheus/client_model/go"
+)
+
+// Encoder types encode metric families into an underlying wire protocol.
+type Encoder interface {
+	Encode(*dto.MetricFamily) error
+}
+
+type encoder func(*dto.MetricFamily) error
+
+func (e encoder) Encode(v *dto.MetricFamily) error {
+	return e(v)
+}
+
+// Negotiate returns the Content-Type based on the given Accept header.
+// If no appropriate accepted type is found, FmtText is returned.
+func Negotiate(h http.Header) Format {
+	for _, ac := range goautoneg.ParseAccept(h.Get(hdrAccept)) {
+		// Check for protocol buffer
+		if ac.Type+"/"+ac.SubType == ProtoType && ac.Params["proto"] == ProtoProtocol {
+			switch ac.Params["encoding"] {
+			case "delimited":
+				return FmtProtoDelim
+			case "text":
+				return FmtProtoText
+			case "compact-text":
+				return FmtProtoCompact
+			}
+		}
+		// Check for text format.
+		ver := ac.Params["version"]
+		if ac.Type == "text" && ac.SubType == "plain" && (ver == TextVersion || ver == "") {
+			return FmtText
+		}
+	}
+	return FmtText
+}
+
+// NewEncoder returns a new encoder based on content type negotiation.
+func NewEncoder(w io.Writer, format Format) Encoder {
+	switch format {
+	case FmtProtoDelim:
+		return encoder(func(v *dto.MetricFamily) error {
+			_, err := pbutil.WriteDelimited(w, v)
+			return err
+		})
+	case FmtProtoCompact:
+		return encoder(func(v *dto.MetricFamily) error {
+			_, err := fmt.Fprintln(w, v.String())
+			return err
+		})
+	case FmtProtoText:
+		return encoder(func(v *dto.MetricFamily) error {
+			_, err := fmt.Fprintln(w, proto.MarshalTextString(v))
+			return err
+		})
+	case FmtText:
+		return encoder(func(v *dto.MetricFamily) error {
+			_, err := MetricFamilyToText(w, v)
+			return err
+		})
+	}
+	panic("expfmt.NewEncoder: unknown format")
+}

--- a/vendor/github.com/prometheus/common/expfmt/expfmt.go
+++ b/vendor/github.com/prometheus/common/expfmt/expfmt.go
@@ -1,0 +1,40 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// A package for reading and writing Prometheus metrics.
+package expfmt
+
+type Format string
+
+const (
+	TextVersion = "0.0.4"
+
+	ProtoType     = `application/vnd.google.protobuf`
+	ProtoProtocol = `io.prometheus.client.MetricFamily`
+	ProtoFmt      = ProtoType + "; proto=" + ProtoProtocol + ";"
+
+	// The Content-Type values for the different wire protocols.
+	FmtUnknown      Format = `<unknown>`
+	FmtText         Format = `text/plain; version=` + TextVersion
+	FmtProtoDelim   Format = ProtoFmt + ` encoding=delimited`
+	FmtProtoText    Format = ProtoFmt + ` encoding=text`
+	FmtProtoCompact Format = ProtoFmt + ` encoding=compact-text`
+
+	// fmtJSON2 is hidden as it is deprecated.
+	fmtJSON2 Format = `application/json; version=0.0.2`
+)
+
+const (
+	hdrContentType = "Content-Type"
+	hdrAccept      = "Accept"
+)

--- a/vendor/github.com/prometheus/common/expfmt/fuzz.go
+++ b/vendor/github.com/prometheus/common/expfmt/fuzz.go
@@ -1,0 +1,36 @@
+// Copyright 2014 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Build only when actually fuzzing
+// +build gofuzz
+
+package expfmt
+
+import "bytes"
+
+// Fuzz text metric parser with with github.com/dvyukov/go-fuzz:
+//
+//     go-fuzz-build github.com/prometheus/common/expfmt
+//     go-fuzz -bin expfmt-fuzz.zip -workdir fuzz
+//
+// Further input samples should go in the folder fuzz/corpus.
+func Fuzz(in []byte) int {
+	parser := TextParser{}
+	_, err := parser.TextToMetricFamilies(bytes.NewReader(in))
+
+	if err != nil {
+		return 0
+	}
+
+	return 1
+}

--- a/vendor/github.com/prometheus/common/expfmt/json_decode.go
+++ b/vendor/github.com/prometheus/common/expfmt/json_decode.go
@@ -1,0 +1,174 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package expfmt
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+
+	"github.com/golang/protobuf/proto"
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/prometheus/common/model"
+)
+
+type json2Decoder struct {
+	dec  *json.Decoder
+	fams []*dto.MetricFamily
+}
+
+func newJSON2Decoder(r io.Reader) Decoder {
+	return &json2Decoder{
+		dec: json.NewDecoder(r),
+	}
+}
+
+type histogram002 struct {
+	Labels model.LabelSet     `json:"labels"`
+	Values map[string]float64 `json:"value"`
+}
+
+type counter002 struct {
+	Labels model.LabelSet `json:"labels"`
+	Value  float64        `json:"value"`
+}
+
+func protoLabelSet(base, ext model.LabelSet) ([]*dto.LabelPair, error) {
+	labels := base.Clone().Merge(ext)
+	delete(labels, model.MetricNameLabel)
+
+	names := make([]string, 0, len(labels))
+	for ln := range labels {
+		names = append(names, string(ln))
+	}
+	sort.Strings(names)
+
+	pairs := make([]*dto.LabelPair, 0, len(labels))
+
+	for _, ln := range names {
+		if !model.LabelNameRE.MatchString(ln) {
+			return nil, fmt.Errorf("invalid label name %q", ln)
+		}
+		lv := labels[model.LabelName(ln)]
+
+		pairs = append(pairs, &dto.LabelPair{
+			Name:  proto.String(ln),
+			Value: proto.String(string(lv)),
+		})
+	}
+
+	return pairs, nil
+}
+
+func (d *json2Decoder) more() error {
+	var entities []struct {
+		BaseLabels model.LabelSet `json:"baseLabels"`
+		Docstring  string         `json:"docstring"`
+		Metric     struct {
+			Type   string          `json:"type"`
+			Values json.RawMessage `json:"value"`
+		} `json:"metric"`
+	}
+
+	if err := d.dec.Decode(&entities); err != nil {
+		return err
+	}
+	for _, e := range entities {
+		f := &dto.MetricFamily{
+			Name:   proto.String(string(e.BaseLabels[model.MetricNameLabel])),
+			Help:   proto.String(e.Docstring),
+			Type:   dto.MetricType_UNTYPED.Enum(),
+			Metric: []*dto.Metric{},
+		}
+
+		d.fams = append(d.fams, f)
+
+		switch e.Metric.Type {
+		case "counter", "gauge":
+			var values []counter002
+
+			if err := json.Unmarshal(e.Metric.Values, &values); err != nil {
+				return fmt.Errorf("could not extract %s value: %s", e.Metric.Type, err)
+			}
+
+			for _, ctr := range values {
+				labels, err := protoLabelSet(e.BaseLabels, ctr.Labels)
+				if err != nil {
+					return err
+				}
+				f.Metric = append(f.Metric, &dto.Metric{
+					Label: labels,
+					Untyped: &dto.Untyped{
+						Value: proto.Float64(ctr.Value),
+					},
+				})
+			}
+
+		case "histogram":
+			var values []histogram002
+
+			if err := json.Unmarshal(e.Metric.Values, &values); err != nil {
+				return fmt.Errorf("could not extract %s value: %s", e.Metric.Type, err)
+			}
+
+			for _, hist := range values {
+				quants := make([]string, 0, len(values))
+				for q := range hist.Values {
+					quants = append(quants, q)
+				}
+
+				sort.Strings(quants)
+
+				for _, q := range quants {
+					value := hist.Values[q]
+					// The correct label is "quantile" but to not break old expressions
+					// this remains "percentile"
+					hist.Labels["percentile"] = model.LabelValue(q)
+
+					labels, err := protoLabelSet(e.BaseLabels, hist.Labels)
+					if err != nil {
+						return err
+					}
+
+					f.Metric = append(f.Metric, &dto.Metric{
+						Label: labels,
+						Untyped: &dto.Untyped{
+							Value: proto.Float64(value),
+						},
+					})
+				}
+			}
+
+		default:
+			return fmt.Errorf("unknown metric type %q", e.Metric.Type)
+		}
+	}
+	return nil
+}
+
+// Decode implements the Decoder interface.
+func (d *json2Decoder) Decode(v *dto.MetricFamily) error {
+	if len(d.fams) == 0 {
+		if err := d.more(); err != nil {
+			return err
+		}
+	}
+
+	*v = *d.fams[0]
+	d.fams = d.fams[1:]
+
+	return nil
+}

--- a/vendor/github.com/prometheus/common/expfmt/text_create.go
+++ b/vendor/github.com/prometheus/common/expfmt/text_create.go
@@ -1,0 +1,305 @@
+// Copyright 2014 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package expfmt
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math"
+	"strings"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/model"
+)
+
+// MetricFamilyToText converts a MetricFamily proto message into text format and
+// writes the resulting lines to 'out'. It returns the number of bytes written
+// and any error encountered.  This function does not perform checks on the
+// content of the metric and label names, i.e. invalid metric or label names
+// will result in invalid text format output.
+// This method fulfills the type 'prometheus.encoder'.
+func MetricFamilyToText(out io.Writer, in *dto.MetricFamily) (int, error) {
+	var written int
+
+	// Fail-fast checks.
+	if len(in.Metric) == 0 {
+		return written, fmt.Errorf("MetricFamily has no metrics: %s", in)
+	}
+	name := in.GetName()
+	if name == "" {
+		return written, fmt.Errorf("MetricFamily has no name: %s", in)
+	}
+
+	// Comments, first HELP, then TYPE.
+	if in.Help != nil {
+		n, err := fmt.Fprintf(
+			out, "# HELP %s %s\n",
+			name, escapeString(*in.Help, false),
+		)
+		written += n
+		if err != nil {
+			return written, err
+		}
+	}
+	metricType := in.GetType()
+	n, err := fmt.Fprintf(
+		out, "# TYPE %s %s\n",
+		name, strings.ToLower(metricType.String()),
+	)
+	written += n
+	if err != nil {
+		return written, err
+	}
+
+	// Finally the samples, one line for each.
+	for _, metric := range in.Metric {
+		switch metricType {
+		case dto.MetricType_COUNTER:
+			if metric.Counter == nil {
+				return written, fmt.Errorf(
+					"expected counter in metric %s %s", name, metric,
+				)
+			}
+			n, err = writeSample(
+				name, metric, "", "",
+				metric.Counter.GetValue(),
+				out,
+			)
+		case dto.MetricType_GAUGE:
+			if metric.Gauge == nil {
+				return written, fmt.Errorf(
+					"expected gauge in metric %s %s", name, metric,
+				)
+			}
+			n, err = writeSample(
+				name, metric, "", "",
+				metric.Gauge.GetValue(),
+				out,
+			)
+		case dto.MetricType_UNTYPED:
+			if metric.Untyped == nil {
+				return written, fmt.Errorf(
+					"expected untyped in metric %s %s", name, metric,
+				)
+			}
+			n, err = writeSample(
+				name, metric, "", "",
+				metric.Untyped.GetValue(),
+				out,
+			)
+		case dto.MetricType_SUMMARY:
+			if metric.Summary == nil {
+				return written, fmt.Errorf(
+					"expected summary in metric %s %s", name, metric,
+				)
+			}
+			for _, q := range metric.Summary.Quantile {
+				n, err = writeSample(
+					name, metric,
+					model.QuantileLabel, fmt.Sprint(q.GetQuantile()),
+					q.GetValue(),
+					out,
+				)
+				written += n
+				if err != nil {
+					return written, err
+				}
+			}
+			n, err = writeSample(
+				name+"_sum", metric, "", "",
+				metric.Summary.GetSampleSum(),
+				out,
+			)
+			if err != nil {
+				return written, err
+			}
+			written += n
+			n, err = writeSample(
+				name+"_count", metric, "", "",
+				float64(metric.Summary.GetSampleCount()),
+				out,
+			)
+		case dto.MetricType_HISTOGRAM:
+			if metric.Histogram == nil {
+				return written, fmt.Errorf(
+					"expected histogram in metric %s %s", name, metric,
+				)
+			}
+			infSeen := false
+			for _, q := range metric.Histogram.Bucket {
+				n, err = writeSample(
+					name+"_bucket", metric,
+					model.BucketLabel, fmt.Sprint(q.GetUpperBound()),
+					float64(q.GetCumulativeCount()),
+					out,
+				)
+				written += n
+				if err != nil {
+					return written, err
+				}
+				if math.IsInf(q.GetUpperBound(), +1) {
+					infSeen = true
+				}
+			}
+			if !infSeen {
+				n, err = writeSample(
+					name+"_bucket", metric,
+					model.BucketLabel, "+Inf",
+					float64(metric.Histogram.GetSampleCount()),
+					out,
+				)
+				if err != nil {
+					return written, err
+				}
+				written += n
+			}
+			n, err = writeSample(
+				name+"_sum", metric, "", "",
+				metric.Histogram.GetSampleSum(),
+				out,
+			)
+			if err != nil {
+				return written, err
+			}
+			written += n
+			n, err = writeSample(
+				name+"_count", metric, "", "",
+				float64(metric.Histogram.GetSampleCount()),
+				out,
+			)
+		default:
+			return written, fmt.Errorf(
+				"unexpected type in metric %s %s", name, metric,
+			)
+		}
+		written += n
+		if err != nil {
+			return written, err
+		}
+	}
+	return written, nil
+}
+
+// writeSample writes a single sample in text format to out, given the metric
+// name, the metric proto message itself, optionally an additional label name
+// and value (use empty strings if not required), and the value. The function
+// returns the number of bytes written and any error encountered.
+func writeSample(
+	name string,
+	metric *dto.Metric,
+	additionalLabelName, additionalLabelValue string,
+	value float64,
+	out io.Writer,
+) (int, error) {
+	var written int
+	n, err := fmt.Fprint(out, name)
+	written += n
+	if err != nil {
+		return written, err
+	}
+	n, err = labelPairsToText(
+		metric.Label,
+		additionalLabelName, additionalLabelValue,
+		out,
+	)
+	written += n
+	if err != nil {
+		return written, err
+	}
+	n, err = fmt.Fprintf(out, " %v", value)
+	written += n
+	if err != nil {
+		return written, err
+	}
+	if metric.TimestampMs != nil {
+		n, err = fmt.Fprintf(out, " %v", *metric.TimestampMs)
+		written += n
+		if err != nil {
+			return written, err
+		}
+	}
+	n, err = out.Write([]byte{'\n'})
+	written += n
+	if err != nil {
+		return written, err
+	}
+	return written, nil
+}
+
+// labelPairsToText converts a slice of LabelPair proto messages plus the
+// explicitly given additional label pair into text formatted as required by the
+// text format and writes it to 'out'. An empty slice in combination with an
+// empty string 'additionalLabelName' results in nothing being
+// written. Otherwise, the label pairs are written, escaped as required by the
+// text format, and enclosed in '{...}'. The function returns the number of
+// bytes written and any error encountered.
+func labelPairsToText(
+	in []*dto.LabelPair,
+	additionalLabelName, additionalLabelValue string,
+	out io.Writer,
+) (int, error) {
+	if len(in) == 0 && additionalLabelName == "" {
+		return 0, nil
+	}
+	var written int
+	separator := '{'
+	for _, lp := range in {
+		n, err := fmt.Fprintf(
+			out, `%c%s="%s"`,
+			separator, lp.GetName(), escapeString(lp.GetValue(), true),
+		)
+		written += n
+		if err != nil {
+			return written, err
+		}
+		separator = ','
+	}
+	if additionalLabelName != "" {
+		n, err := fmt.Fprintf(
+			out, `%c%s="%s"`,
+			separator, additionalLabelName,
+			escapeString(additionalLabelValue, true),
+		)
+		written += n
+		if err != nil {
+			return written, err
+		}
+	}
+	n, err := out.Write([]byte{'}'})
+	written += n
+	if err != nil {
+		return written, err
+	}
+	return written, nil
+}
+
+// escapeString replaces '\' by '\\', new line character by '\n', and - if
+// includeDoubleQuote is true - '"' by '\"'.
+func escapeString(v string, includeDoubleQuote bool) string {
+	result := bytes.NewBuffer(make([]byte, 0, len(v)))
+	for _, c := range v {
+		switch {
+		case c == '\\':
+			result.WriteString(`\\`)
+		case includeDoubleQuote && c == '"':
+			result.WriteString(`\"`)
+		case c == '\n':
+			result.WriteString(`\n`)
+		default:
+			result.WriteRune(c)
+		}
+	}
+	return result.String()
+}

--- a/vendor/github.com/prometheus/common/expfmt/text_parse.go
+++ b/vendor/github.com/prometheus/common/expfmt/text_parse.go
@@ -1,0 +1,753 @@
+// Copyright 2014 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package expfmt
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"math"
+	"strconv"
+	"strings"
+
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/prometheus/common/model"
+)
+
+// A stateFn is a function that represents a state in a state machine. By
+// executing it, the state is progressed to the next state. The stateFn returns
+// another stateFn, which represents the new state. The end state is represented
+// by nil.
+type stateFn func() stateFn
+
+// ParseError signals errors while parsing the simple and flat text-based
+// exchange format.
+type ParseError struct {
+	Line int
+	Msg  string
+}
+
+// Error implements the error interface.
+func (e ParseError) Error() string {
+	return fmt.Sprintf("text format parsing error in line %d: %s", e.Line, e.Msg)
+}
+
+// TextParser is used to parse the simple and flat text-based exchange format. Its
+// nil value is ready to use.
+type TextParser struct {
+	metricFamiliesByName map[string]*dto.MetricFamily
+	buf                  *bufio.Reader // Where the parsed input is read through.
+	err                  error         // Most recent error.
+	lineCount            int           // Tracks the line count for error messages.
+	currentByte          byte          // The most recent byte read.
+	currentToken         bytes.Buffer  // Re-used each time a token has to be gathered from multiple bytes.
+	currentMF            *dto.MetricFamily
+	currentMetric        *dto.Metric
+	currentLabelPair     *dto.LabelPair
+
+	// The remaining member variables are only used for summaries/histograms.
+	currentLabels map[string]string // All labels including '__name__' but excluding 'quantile'/'le'
+	// Summary specific.
+	summaries       map[uint64]*dto.Metric // Key is created with LabelsToSignature.
+	currentQuantile float64
+	// Histogram specific.
+	histograms    map[uint64]*dto.Metric // Key is created with LabelsToSignature.
+	currentBucket float64
+	// These tell us if the currently processed line ends on '_count' or
+	// '_sum' respectively and belong to a summary/histogram, representing the sample
+	// count and sum of that summary/histogram.
+	currentIsSummaryCount, currentIsSummarySum     bool
+	currentIsHistogramCount, currentIsHistogramSum bool
+}
+
+// TextToMetricFamilies reads 'in' as the simple and flat text-based exchange
+// format and creates MetricFamily proto messages. It returns the MetricFamily
+// proto messages in a map where the metric names are the keys, along with any
+// error encountered.
+//
+// If the input contains duplicate metrics (i.e. lines with the same metric name
+// and exactly the same label set), the resulting MetricFamily will contain
+// duplicate Metric proto messages. Similar is true for duplicate label
+// names. Checks for duplicates have to be performed separately, if required.
+// Also note that neither the metrics within each MetricFamily are sorted nor
+// the label pairs within each Metric. Sorting is not required for the most
+// frequent use of this method, which is sample ingestion in the Prometheus
+// server. However, for presentation purposes, you might want to sort the
+// metrics, and in some cases, you must sort the labels, e.g. for consumption by
+// the metric family injection hook of the Prometheus registry.
+//
+// Summaries and histograms are rather special beasts. You would probably not
+// use them in the simple text format anyway. This method can deal with
+// summaries and histograms if they are presented in exactly the way the
+// text.Create function creates them.
+//
+// This method must not be called concurrently. If you want to parse different
+// input concurrently, instantiate a separate Parser for each goroutine.
+func (p *TextParser) TextToMetricFamilies(in io.Reader) (map[string]*dto.MetricFamily, error) {
+	p.reset(in)
+	for nextState := p.startOfLine; nextState != nil; nextState = nextState() {
+		// Magic happens here...
+	}
+	// Get rid of empty metric families.
+	for k, mf := range p.metricFamiliesByName {
+		if len(mf.GetMetric()) == 0 {
+			delete(p.metricFamiliesByName, k)
+		}
+	}
+	// If p.err is io.EOF now, we have run into a premature end of the input
+	// stream. Turn this error into something nicer and more
+	// meaningful. (io.EOF is often used as a signal for the legitimate end
+	// of an input stream.)
+	if p.err == io.EOF {
+		p.parseError("unexpected end of input stream")
+	}
+	return p.metricFamiliesByName, p.err
+}
+
+func (p *TextParser) reset(in io.Reader) {
+	p.metricFamiliesByName = map[string]*dto.MetricFamily{}
+	if p.buf == nil {
+		p.buf = bufio.NewReader(in)
+	} else {
+		p.buf.Reset(in)
+	}
+	p.err = nil
+	p.lineCount = 0
+	if p.summaries == nil || len(p.summaries) > 0 {
+		p.summaries = map[uint64]*dto.Metric{}
+	}
+	if p.histograms == nil || len(p.histograms) > 0 {
+		p.histograms = map[uint64]*dto.Metric{}
+	}
+	p.currentQuantile = math.NaN()
+	p.currentBucket = math.NaN()
+}
+
+// startOfLine represents the state where the next byte read from p.buf is the
+// start of a line (or whitespace leading up to it).
+func (p *TextParser) startOfLine() stateFn {
+	p.lineCount++
+	if p.skipBlankTab(); p.err != nil {
+		// End of input reached. This is the only case where
+		// that is not an error but a signal that we are done.
+		p.err = nil
+		return nil
+	}
+	switch p.currentByte {
+	case '#':
+		return p.startComment
+	case '\n':
+		return p.startOfLine // Empty line, start the next one.
+	}
+	return p.readingMetricName
+}
+
+// startComment represents the state where the next byte read from p.buf is the
+// start of a comment (or whitespace leading up to it).
+func (p *TextParser) startComment() stateFn {
+	if p.skipBlankTab(); p.err != nil {
+		return nil // Unexpected end of input.
+	}
+	if p.currentByte == '\n' {
+		return p.startOfLine
+	}
+	if p.readTokenUntilWhitespace(); p.err != nil {
+		return nil // Unexpected end of input.
+	}
+	// If we have hit the end of line already, there is nothing left
+	// to do. This is not considered a syntax error.
+	if p.currentByte == '\n' {
+		return p.startOfLine
+	}
+	keyword := p.currentToken.String()
+	if keyword != "HELP" && keyword != "TYPE" {
+		// Generic comment, ignore by fast forwarding to end of line.
+		for p.currentByte != '\n' {
+			if p.currentByte, p.err = p.buf.ReadByte(); p.err != nil {
+				return nil // Unexpected end of input.
+			}
+		}
+		return p.startOfLine
+	}
+	// There is something. Next has to be a metric name.
+	if p.skipBlankTab(); p.err != nil {
+		return nil // Unexpected end of input.
+	}
+	if p.readTokenAsMetricName(); p.err != nil {
+		return nil // Unexpected end of input.
+	}
+	if p.currentByte == '\n' {
+		// At the end of the line already.
+		// Again, this is not considered a syntax error.
+		return p.startOfLine
+	}
+	if !isBlankOrTab(p.currentByte) {
+		p.parseError("invalid metric name in comment")
+		return nil
+	}
+	p.setOrCreateCurrentMF()
+	if p.skipBlankTab(); p.err != nil {
+		return nil // Unexpected end of input.
+	}
+	if p.currentByte == '\n' {
+		// At the end of the line already.
+		// Again, this is not considered a syntax error.
+		return p.startOfLine
+	}
+	switch keyword {
+	case "HELP":
+		return p.readingHelp
+	case "TYPE":
+		return p.readingType
+	}
+	panic(fmt.Sprintf("code error: unexpected keyword %q", keyword))
+}
+
+// readingMetricName represents the state where the last byte read (now in
+// p.currentByte) is the first byte of a metric name.
+func (p *TextParser) readingMetricName() stateFn {
+	if p.readTokenAsMetricName(); p.err != nil {
+		return nil
+	}
+	if p.currentToken.Len() == 0 {
+		p.parseError("invalid metric name")
+		return nil
+	}
+	p.setOrCreateCurrentMF()
+	// Now is the time to fix the type if it hasn't happened yet.
+	if p.currentMF.Type == nil {
+		p.currentMF.Type = dto.MetricType_UNTYPED.Enum()
+	}
+	p.currentMetric = &dto.Metric{}
+	// Do not append the newly created currentMetric to
+	// currentMF.Metric right now. First wait if this is a summary,
+	// and the metric exists already, which we can only know after
+	// having read all the labels.
+	if p.skipBlankTabIfCurrentBlankTab(); p.err != nil {
+		return nil // Unexpected end of input.
+	}
+	return p.readingLabels
+}
+
+// readingLabels represents the state where the last byte read (now in
+// p.currentByte) is either the first byte of the label set (i.e. a '{'), or the
+// first byte of the value (otherwise).
+func (p *TextParser) readingLabels() stateFn {
+	// Summaries/histograms are special. We have to reset the
+	// currentLabels map, currentQuantile and currentBucket before starting to
+	// read labels.
+	if p.currentMF.GetType() == dto.MetricType_SUMMARY || p.currentMF.GetType() == dto.MetricType_HISTOGRAM {
+		p.currentLabels = map[string]string{}
+		p.currentLabels[string(model.MetricNameLabel)] = p.currentMF.GetName()
+		p.currentQuantile = math.NaN()
+		p.currentBucket = math.NaN()
+	}
+	if p.currentByte != '{' {
+		return p.readingValue
+	}
+	return p.startLabelName
+}
+
+// startLabelName represents the state where the next byte read from p.buf is
+// the start of a label name (or whitespace leading up to it).
+func (p *TextParser) startLabelName() stateFn {
+	if p.skipBlankTab(); p.err != nil {
+		return nil // Unexpected end of input.
+	}
+	if p.currentByte == '}' {
+		if p.skipBlankTab(); p.err != nil {
+			return nil // Unexpected end of input.
+		}
+		return p.readingValue
+	}
+	if p.readTokenAsLabelName(); p.err != nil {
+		return nil // Unexpected end of input.
+	}
+	if p.currentToken.Len() == 0 {
+		p.parseError(fmt.Sprintf("invalid label name for metric %q", p.currentMF.GetName()))
+		return nil
+	}
+	p.currentLabelPair = &dto.LabelPair{Name: proto.String(p.currentToken.String())}
+	if p.currentLabelPair.GetName() == string(model.MetricNameLabel) {
+		p.parseError(fmt.Sprintf("label name %q is reserved", model.MetricNameLabel))
+		return nil
+	}
+	// Special summary/histogram treatment. Don't add 'quantile' and 'le'
+	// labels to 'real' labels.
+	if !(p.currentMF.GetType() == dto.MetricType_SUMMARY && p.currentLabelPair.GetName() == model.QuantileLabel) &&
+		!(p.currentMF.GetType() == dto.MetricType_HISTOGRAM && p.currentLabelPair.GetName() == model.BucketLabel) {
+		p.currentMetric.Label = append(p.currentMetric.Label, p.currentLabelPair)
+	}
+	if p.skipBlankTabIfCurrentBlankTab(); p.err != nil {
+		return nil // Unexpected end of input.
+	}
+	if p.currentByte != '=' {
+		p.parseError(fmt.Sprintf("expected '=' after label name, found %q", p.currentByte))
+		return nil
+	}
+	return p.startLabelValue
+}
+
+// startLabelValue represents the state where the next byte read from p.buf is
+// the start of a (quoted) label value (or whitespace leading up to it).
+func (p *TextParser) startLabelValue() stateFn {
+	if p.skipBlankTab(); p.err != nil {
+		return nil // Unexpected end of input.
+	}
+	if p.currentByte != '"' {
+		p.parseError(fmt.Sprintf("expected '\"' at start of label value, found %q", p.currentByte))
+		return nil
+	}
+	if p.readTokenAsLabelValue(); p.err != nil {
+		return nil
+	}
+	p.currentLabelPair.Value = proto.String(p.currentToken.String())
+	// Special treatment of summaries:
+	// - Quantile labels are special, will result in dto.Quantile later.
+	// - Other labels have to be added to currentLabels for signature calculation.
+	if p.currentMF.GetType() == dto.MetricType_SUMMARY {
+		if p.currentLabelPair.GetName() == model.QuantileLabel {
+			if p.currentQuantile, p.err = strconv.ParseFloat(p.currentLabelPair.GetValue(), 64); p.err != nil {
+				// Create a more helpful error message.
+				p.parseError(fmt.Sprintf("expected float as value for 'quantile' label, got %q", p.currentLabelPair.GetValue()))
+				return nil
+			}
+		} else {
+			p.currentLabels[p.currentLabelPair.GetName()] = p.currentLabelPair.GetValue()
+		}
+	}
+	// Similar special treatment of histograms.
+	if p.currentMF.GetType() == dto.MetricType_HISTOGRAM {
+		if p.currentLabelPair.GetName() == model.BucketLabel {
+			if p.currentBucket, p.err = strconv.ParseFloat(p.currentLabelPair.GetValue(), 64); p.err != nil {
+				// Create a more helpful error message.
+				p.parseError(fmt.Sprintf("expected float as value for 'le' label, got %q", p.currentLabelPair.GetValue()))
+				return nil
+			}
+		} else {
+			p.currentLabels[p.currentLabelPair.GetName()] = p.currentLabelPair.GetValue()
+		}
+	}
+	if p.skipBlankTab(); p.err != nil {
+		return nil // Unexpected end of input.
+	}
+	switch p.currentByte {
+	case ',':
+		return p.startLabelName
+
+	case '}':
+		if p.skipBlankTab(); p.err != nil {
+			return nil // Unexpected end of input.
+		}
+		return p.readingValue
+	default:
+		p.parseError(fmt.Sprintf("unexpected end of label value %q", p.currentLabelPair.Value))
+		return nil
+	}
+}
+
+// readingValue represents the state where the last byte read (now in
+// p.currentByte) is the first byte of the sample value (i.e. a float).
+func (p *TextParser) readingValue() stateFn {
+	// When we are here, we have read all the labels, so for the
+	// special case of a summary/histogram, we can finally find out
+	// if the metric already exists.
+	if p.currentMF.GetType() == dto.MetricType_SUMMARY {
+		signature := model.LabelsToSignature(p.currentLabels)
+		if summary := p.summaries[signature]; summary != nil {
+			p.currentMetric = summary
+		} else {
+			p.summaries[signature] = p.currentMetric
+			p.currentMF.Metric = append(p.currentMF.Metric, p.currentMetric)
+		}
+	} else if p.currentMF.GetType() == dto.MetricType_HISTOGRAM {
+		signature := model.LabelsToSignature(p.currentLabels)
+		if histogram := p.histograms[signature]; histogram != nil {
+			p.currentMetric = histogram
+		} else {
+			p.histograms[signature] = p.currentMetric
+			p.currentMF.Metric = append(p.currentMF.Metric, p.currentMetric)
+		}
+	} else {
+		p.currentMF.Metric = append(p.currentMF.Metric, p.currentMetric)
+	}
+	if p.readTokenUntilWhitespace(); p.err != nil {
+		return nil // Unexpected end of input.
+	}
+	value, err := strconv.ParseFloat(p.currentToken.String(), 64)
+	if err != nil {
+		// Create a more helpful error message.
+		p.parseError(fmt.Sprintf("expected float as value, got %q", p.currentToken.String()))
+		return nil
+	}
+	switch p.currentMF.GetType() {
+	case dto.MetricType_COUNTER:
+		p.currentMetric.Counter = &dto.Counter{Value: proto.Float64(value)}
+	case dto.MetricType_GAUGE:
+		p.currentMetric.Gauge = &dto.Gauge{Value: proto.Float64(value)}
+	case dto.MetricType_UNTYPED:
+		p.currentMetric.Untyped = &dto.Untyped{Value: proto.Float64(value)}
+	case dto.MetricType_SUMMARY:
+		// *sigh*
+		if p.currentMetric.Summary == nil {
+			p.currentMetric.Summary = &dto.Summary{}
+		}
+		switch {
+		case p.currentIsSummaryCount:
+			p.currentMetric.Summary.SampleCount = proto.Uint64(uint64(value))
+		case p.currentIsSummarySum:
+			p.currentMetric.Summary.SampleSum = proto.Float64(value)
+		case !math.IsNaN(p.currentQuantile):
+			p.currentMetric.Summary.Quantile = append(
+				p.currentMetric.Summary.Quantile,
+				&dto.Quantile{
+					Quantile: proto.Float64(p.currentQuantile),
+					Value:    proto.Float64(value),
+				},
+			)
+		}
+	case dto.MetricType_HISTOGRAM:
+		// *sigh*
+		if p.currentMetric.Histogram == nil {
+			p.currentMetric.Histogram = &dto.Histogram{}
+		}
+		switch {
+		case p.currentIsHistogramCount:
+			p.currentMetric.Histogram.SampleCount = proto.Uint64(uint64(value))
+		case p.currentIsHistogramSum:
+			p.currentMetric.Histogram.SampleSum = proto.Float64(value)
+		case !math.IsNaN(p.currentBucket):
+			p.currentMetric.Histogram.Bucket = append(
+				p.currentMetric.Histogram.Bucket,
+				&dto.Bucket{
+					UpperBound:      proto.Float64(p.currentBucket),
+					CumulativeCount: proto.Uint64(uint64(value)),
+				},
+			)
+		}
+	default:
+		p.err = fmt.Errorf("unexpected type for metric name %q", p.currentMF.GetName())
+	}
+	if p.currentByte == '\n' {
+		return p.startOfLine
+	}
+	return p.startTimestamp
+}
+
+// startTimestamp represents the state where the next byte read from p.buf is
+// the start of the timestamp (or whitespace leading up to it).
+func (p *TextParser) startTimestamp() stateFn {
+	if p.skipBlankTab(); p.err != nil {
+		return nil // Unexpected end of input.
+	}
+	if p.readTokenUntilWhitespace(); p.err != nil {
+		return nil // Unexpected end of input.
+	}
+	timestamp, err := strconv.ParseInt(p.currentToken.String(), 10, 64)
+	if err != nil {
+		// Create a more helpful error message.
+		p.parseError(fmt.Sprintf("expected integer as timestamp, got %q", p.currentToken.String()))
+		return nil
+	}
+	p.currentMetric.TimestampMs = proto.Int64(timestamp)
+	if p.readTokenUntilNewline(false); p.err != nil {
+		return nil // Unexpected end of input.
+	}
+	if p.currentToken.Len() > 0 {
+		p.parseError(fmt.Sprintf("spurious string after timestamp: %q", p.currentToken.String()))
+		return nil
+	}
+	return p.startOfLine
+}
+
+// readingHelp represents the state where the last byte read (now in
+// p.currentByte) is the first byte of the docstring after 'HELP'.
+func (p *TextParser) readingHelp() stateFn {
+	if p.currentMF.Help != nil {
+		p.parseError(fmt.Sprintf("second HELP line for metric name %q", p.currentMF.GetName()))
+		return nil
+	}
+	// Rest of line is the docstring.
+	if p.readTokenUntilNewline(true); p.err != nil {
+		return nil // Unexpected end of input.
+	}
+	p.currentMF.Help = proto.String(p.currentToken.String())
+	return p.startOfLine
+}
+
+// readingType represents the state where the last byte read (now in
+// p.currentByte) is the first byte of the type hint after 'HELP'.
+func (p *TextParser) readingType() stateFn {
+	if p.currentMF.Type != nil {
+		p.parseError(fmt.Sprintf("second TYPE line for metric name %q, or TYPE reported after samples", p.currentMF.GetName()))
+		return nil
+	}
+	// Rest of line is the type.
+	if p.readTokenUntilNewline(false); p.err != nil {
+		return nil // Unexpected end of input.
+	}
+	metricType, ok := dto.MetricType_value[strings.ToUpper(p.currentToken.String())]
+	if !ok {
+		p.parseError(fmt.Sprintf("unknown metric type %q", p.currentToken.String()))
+		return nil
+	}
+	p.currentMF.Type = dto.MetricType(metricType).Enum()
+	return p.startOfLine
+}
+
+// parseError sets p.err to a ParseError at the current line with the given
+// message.
+func (p *TextParser) parseError(msg string) {
+	p.err = ParseError{
+		Line: p.lineCount,
+		Msg:  msg,
+	}
+}
+
+// skipBlankTab reads (and discards) bytes from p.buf until it encounters a byte
+// that is neither ' ' nor '\t'. That byte is left in p.currentByte.
+func (p *TextParser) skipBlankTab() {
+	for {
+		if p.currentByte, p.err = p.buf.ReadByte(); p.err != nil || !isBlankOrTab(p.currentByte) {
+			return
+		}
+	}
+}
+
+// skipBlankTabIfCurrentBlankTab works exactly as skipBlankTab but doesn't do
+// anything if p.currentByte is neither ' ' nor '\t'.
+func (p *TextParser) skipBlankTabIfCurrentBlankTab() {
+	if isBlankOrTab(p.currentByte) {
+		p.skipBlankTab()
+	}
+}
+
+// readTokenUntilWhitespace copies bytes from p.buf into p.currentToken.  The
+// first byte considered is the byte already read (now in p.currentByte).  The
+// first whitespace byte encountered is still copied into p.currentByte, but not
+// into p.currentToken.
+func (p *TextParser) readTokenUntilWhitespace() {
+	p.currentToken.Reset()
+	for p.err == nil && !isBlankOrTab(p.currentByte) && p.currentByte != '\n' {
+		p.currentToken.WriteByte(p.currentByte)
+		p.currentByte, p.err = p.buf.ReadByte()
+	}
+}
+
+// readTokenUntilNewline copies bytes from p.buf into p.currentToken.  The first
+// byte considered is the byte already read (now in p.currentByte).  The first
+// newline byte encountered is still copied into p.currentByte, but not into
+// p.currentToken. If recognizeEscapeSequence is true, two escape sequences are
+// recognized: '\\' tranlates into '\', and '\n' into a line-feed character. All
+// other escape sequences are invalid and cause an error.
+func (p *TextParser) readTokenUntilNewline(recognizeEscapeSequence bool) {
+	p.currentToken.Reset()
+	escaped := false
+	for p.err == nil {
+		if recognizeEscapeSequence && escaped {
+			switch p.currentByte {
+			case '\\':
+				p.currentToken.WriteByte(p.currentByte)
+			case 'n':
+				p.currentToken.WriteByte('\n')
+			default:
+				p.parseError(fmt.Sprintf("invalid escape sequence '\\%c'", p.currentByte))
+				return
+			}
+			escaped = false
+		} else {
+			switch p.currentByte {
+			case '\n':
+				return
+			case '\\':
+				escaped = true
+			default:
+				p.currentToken.WriteByte(p.currentByte)
+			}
+		}
+		p.currentByte, p.err = p.buf.ReadByte()
+	}
+}
+
+// readTokenAsMetricName copies a metric name from p.buf into p.currentToken.
+// The first byte considered is the byte already read (now in p.currentByte).
+// The first byte not part of a metric name is still copied into p.currentByte,
+// but not into p.currentToken.
+func (p *TextParser) readTokenAsMetricName() {
+	p.currentToken.Reset()
+	if !isValidMetricNameStart(p.currentByte) {
+		return
+	}
+	for {
+		p.currentToken.WriteByte(p.currentByte)
+		p.currentByte, p.err = p.buf.ReadByte()
+		if p.err != nil || !isValidMetricNameContinuation(p.currentByte) {
+			return
+		}
+	}
+}
+
+// readTokenAsLabelName copies a label name from p.buf into p.currentToken.
+// The first byte considered is the byte already read (now in p.currentByte).
+// The first byte not part of a label name is still copied into p.currentByte,
+// but not into p.currentToken.
+func (p *TextParser) readTokenAsLabelName() {
+	p.currentToken.Reset()
+	if !isValidLabelNameStart(p.currentByte) {
+		return
+	}
+	for {
+		p.currentToken.WriteByte(p.currentByte)
+		p.currentByte, p.err = p.buf.ReadByte()
+		if p.err != nil || !isValidLabelNameContinuation(p.currentByte) {
+			return
+		}
+	}
+}
+
+// readTokenAsLabelValue copies a label value from p.buf into p.currentToken.
+// In contrast to the other 'readTokenAs...' functions, which start with the
+// last read byte in p.currentByte, this method ignores p.currentByte and starts
+// with reading a new byte from p.buf. The first byte not part of a label value
+// is still copied into p.currentByte, but not into p.currentToken.
+func (p *TextParser) readTokenAsLabelValue() {
+	p.currentToken.Reset()
+	escaped := false
+	for {
+		if p.currentByte, p.err = p.buf.ReadByte(); p.err != nil {
+			return
+		}
+		if escaped {
+			switch p.currentByte {
+			case '"', '\\':
+				p.currentToken.WriteByte(p.currentByte)
+			case 'n':
+				p.currentToken.WriteByte('\n')
+			default:
+				p.parseError(fmt.Sprintf("invalid escape sequence '\\%c'", p.currentByte))
+				return
+			}
+			escaped = false
+			continue
+		}
+		switch p.currentByte {
+		case '"':
+			return
+		case '\n':
+			p.parseError(fmt.Sprintf("label value %q contains unescaped new-line", p.currentToken.String()))
+			return
+		case '\\':
+			escaped = true
+		default:
+			p.currentToken.WriteByte(p.currentByte)
+		}
+	}
+}
+
+func (p *TextParser) setOrCreateCurrentMF() {
+	p.currentIsSummaryCount = false
+	p.currentIsSummarySum = false
+	p.currentIsHistogramCount = false
+	p.currentIsHistogramSum = false
+	name := p.currentToken.String()
+	if p.currentMF = p.metricFamiliesByName[name]; p.currentMF != nil {
+		return
+	}
+	// Try out if this is a _sum or _count for a summary/histogram.
+	summaryName := summaryMetricName(name)
+	if p.currentMF = p.metricFamiliesByName[summaryName]; p.currentMF != nil {
+		if p.currentMF.GetType() == dto.MetricType_SUMMARY {
+			if isCount(name) {
+				p.currentIsSummaryCount = true
+			}
+			if isSum(name) {
+				p.currentIsSummarySum = true
+			}
+			return
+		}
+	}
+	histogramName := histogramMetricName(name)
+	if p.currentMF = p.metricFamiliesByName[histogramName]; p.currentMF != nil {
+		if p.currentMF.GetType() == dto.MetricType_HISTOGRAM {
+			if isCount(name) {
+				p.currentIsHistogramCount = true
+			}
+			if isSum(name) {
+				p.currentIsHistogramSum = true
+			}
+			return
+		}
+	}
+	p.currentMF = &dto.MetricFamily{Name: proto.String(name)}
+	p.metricFamiliesByName[name] = p.currentMF
+}
+
+func isValidLabelNameStart(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || b == '_'
+}
+
+func isValidLabelNameContinuation(b byte) bool {
+	return isValidLabelNameStart(b) || (b >= '0' && b <= '9')
+}
+
+func isValidMetricNameStart(b byte) bool {
+	return isValidLabelNameStart(b) || b == ':'
+}
+
+func isValidMetricNameContinuation(b byte) bool {
+	return isValidLabelNameContinuation(b) || b == ':'
+}
+
+func isBlankOrTab(b byte) bool {
+	return b == ' ' || b == '\t'
+}
+
+func isCount(name string) bool {
+	return len(name) > 6 && name[len(name)-6:] == "_count"
+}
+
+func isSum(name string) bool {
+	return len(name) > 4 && name[len(name)-4:] == "_sum"
+}
+
+func isBucket(name string) bool {
+	return len(name) > 7 && name[len(name)-7:] == "_bucket"
+}
+
+func summaryMetricName(name string) string {
+	switch {
+	case isCount(name):
+		return name[:len(name)-6]
+	case isSum(name):
+		return name[:len(name)-4]
+	default:
+		return name
+	}
+}
+
+func histogramMetricName(name string) string {
+	switch {
+	case isCount(name):
+		return name[:len(name)-6]
+	case isSum(name):
+		return name[:len(name)-4]
+	case isBucket(name):
+		return name[:len(name)-7]
+	default:
+		return name
+	}
+}

--- a/vendor/github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg/README.txt
+++ b/vendor/github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg/README.txt
@@ -1,0 +1,67 @@
+PACKAGE
+
+package goautoneg
+import "bitbucket.org/ww/goautoneg"
+
+HTTP Content-Type Autonegotiation.
+
+The functions in this package implement the behaviour specified in
+http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html
+
+Copyright (c) 2011, Open Knowledge Foundation Ltd.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+    Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in
+    the documentation and/or other materials provided with the
+    distribution.
+
+    Neither the name of the Open Knowledge Foundation Ltd. nor the
+    names of its contributors may be used to endorse or promote
+    products derived from this software without specific prior written
+    permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+FUNCTIONS
+
+func Negotiate(header string, alternatives []string) (content_type string)
+Negotiate the most appropriate content_type given the accept header
+and a list of alternatives.
+
+func ParseAccept(header string) (accept []Accept)
+Parse an Accept Header string returning a sorted list
+of clauses
+
+
+TYPES
+
+type Accept struct {
+    Type, SubType string
+    Q             float32
+    Params        map[string]string
+}
+Structure to represent a clause in an HTTP Accept Header
+
+
+SUBDIRECTORIES
+
+	.hg

--- a/vendor/github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg/autoneg.go
+++ b/vendor/github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg/autoneg.go
@@ -1,0 +1,162 @@
+/*
+HTTP Content-Type Autonegotiation.
+
+The functions in this package implement the behaviour specified in
+http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html
+
+Copyright (c) 2011, Open Knowledge Foundation Ltd.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+    Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in
+    the documentation and/or other materials provided with the
+    distribution.
+
+    Neither the name of the Open Knowledge Foundation Ltd. nor the
+    names of its contributors may be used to endorse or promote
+    products derived from this software without specific prior written
+    permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+*/
+package goautoneg
+
+import (
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Structure to represent a clause in an HTTP Accept Header
+type Accept struct {
+	Type, SubType string
+	Q             float64
+	Params        map[string]string
+}
+
+// For internal use, so that we can use the sort interface
+type accept_slice []Accept
+
+func (accept accept_slice) Len() int {
+	slice := []Accept(accept)
+	return len(slice)
+}
+
+func (accept accept_slice) Less(i, j int) bool {
+	slice := []Accept(accept)
+	ai, aj := slice[i], slice[j]
+	if ai.Q > aj.Q {
+		return true
+	}
+	if ai.Type != "*" && aj.Type == "*" {
+		return true
+	}
+	if ai.SubType != "*" && aj.SubType == "*" {
+		return true
+	}
+	return false
+}
+
+func (accept accept_slice) Swap(i, j int) {
+	slice := []Accept(accept)
+	slice[i], slice[j] = slice[j], slice[i]
+}
+
+// Parse an Accept Header string returning a sorted list
+// of clauses
+func ParseAccept(header string) (accept []Accept) {
+	parts := strings.Split(header, ",")
+	accept = make([]Accept, 0, len(parts))
+	for _, part := range parts {
+		part := strings.Trim(part, " ")
+
+		a := Accept{}
+		a.Params = make(map[string]string)
+		a.Q = 1.0
+
+		mrp := strings.Split(part, ";")
+
+		media_range := mrp[0]
+		sp := strings.Split(media_range, "/")
+		a.Type = strings.Trim(sp[0], " ")
+
+		switch {
+		case len(sp) == 1 && a.Type == "*":
+			a.SubType = "*"
+		case len(sp) == 2:
+			a.SubType = strings.Trim(sp[1], " ")
+		default:
+			continue
+		}
+
+		if len(mrp) == 1 {
+			accept = append(accept, a)
+			continue
+		}
+
+		for _, param := range mrp[1:] {
+			sp := strings.SplitN(param, "=", 2)
+			if len(sp) != 2 {
+				continue
+			}
+			token := strings.Trim(sp[0], " ")
+			if token == "q" {
+				a.Q, _ = strconv.ParseFloat(sp[1], 32)
+			} else {
+				a.Params[token] = strings.Trim(sp[1], " ")
+			}
+		}
+
+		accept = append(accept, a)
+	}
+
+	slice := accept_slice(accept)
+	sort.Sort(slice)
+
+	return
+}
+
+// Negotiate the most appropriate content_type given the accept header
+// and a list of alternatives.
+func Negotiate(header string, alternatives []string) (content_type string) {
+	asp := make([][]string, 0, len(alternatives))
+	for _, ctype := range alternatives {
+		asp = append(asp, strings.SplitN(ctype, "/", 2))
+	}
+	for _, clause := range ParseAccept(header) {
+		for i, ctsp := range asp {
+			if clause.Type == ctsp[0] && clause.SubType == ctsp[1] {
+				content_type = alternatives[i]
+				return
+			}
+			if clause.Type == ctsp[0] && clause.SubType == "*" {
+				content_type = alternatives[i]
+				return
+			}
+			if clause.Type == "*" && clause.SubType == "*" {
+				content_type = alternatives[i]
+				return
+			}
+		}
+	}
+	return
+}

--- a/vendor/github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg/autoneg_test.go
+++ b/vendor/github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg/autoneg_test.go
@@ -1,0 +1,33 @@
+package goautoneg
+
+import (
+	"testing"
+)
+
+var chrome = "application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5"
+
+func TestParseAccept(t *testing.T) {
+	alternatives := []string{"text/html", "image/png"}
+	content_type := Negotiate(chrome, alternatives)
+	if content_type != "image/png" {
+		t.Errorf("got %s expected image/png", content_type)
+	}
+
+	alternatives = []string{"text/html", "text/plain", "text/n3"}
+	content_type = Negotiate(chrome, alternatives)
+	if content_type != "text/html" {
+		t.Errorf("got %s expected text/html", content_type)
+	}
+
+	alternatives = []string{"text/n3", "text/plain"}
+	content_type = Negotiate(chrome, alternatives)
+	if content_type != "text/plain" {
+		t.Errorf("got %s expected text/plain", content_type)
+	}
+
+	alternatives = []string{"text/n3", "application/rdf+xml"}
+	content_type = Negotiate(chrome, alternatives)
+	if content_type != "text/n3" {
+		t.Errorf("got %s expected text/n3", content_type)
+	}
+}

--- a/vendor/github.com/prometheus/common/model/alert.go
+++ b/vendor/github.com/prometheus/common/model/alert.go
@@ -1,0 +1,136 @@
+// Copyright 2013 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"fmt"
+	"time"
+)
+
+type AlertStatus string
+
+const (
+	AlertFiring   AlertStatus = "firing"
+	AlertResolved AlertStatus = "resolved"
+)
+
+// Alert is a generic representation of an alert in the Prometheus eco-system.
+type Alert struct {
+	// Label value pairs for purpose of aggregation, matching, and disposition
+	// dispatching. This must minimally include an "alertname" label.
+	Labels LabelSet `json:"labels"`
+
+	// Extra key/value information which does not define alert identity.
+	Annotations LabelSet `json:"annotations"`
+
+	// The known time range for this alert. Both ends are optional.
+	StartsAt     time.Time `json:"startsAt,omitempty"`
+	EndsAt       time.Time `json:"endsAt,omitempty"`
+	GeneratorURL string    `json:"generatorURL"`
+}
+
+// Name returns the name of the alert. It is equivalent to the "alertname" label.
+func (a *Alert) Name() string {
+	return string(a.Labels[AlertNameLabel])
+}
+
+// Fingerprint returns a unique hash for the alert. It is equivalent to
+// the fingerprint of the alert's label set.
+func (a *Alert) Fingerprint() Fingerprint {
+	return a.Labels.Fingerprint()
+}
+
+func (a *Alert) String() string {
+	s := fmt.Sprintf("%s[%s]", a.Name(), a.Fingerprint().String()[:7])
+	if a.Resolved() {
+		return s + "[resolved]"
+	}
+	return s + "[active]"
+}
+
+// Resolved returns true iff the activity interval ended in the past.
+func (a *Alert) Resolved() bool {
+	return a.ResolvedAt(time.Now())
+}
+
+// ResolvedAt returns true off the activity interval ended before
+// the given timestamp.
+func (a *Alert) ResolvedAt(ts time.Time) bool {
+	if a.EndsAt.IsZero() {
+		return false
+	}
+	return !a.EndsAt.After(ts)
+}
+
+// Status returns the status of the alert.
+func (a *Alert) Status() AlertStatus {
+	if a.Resolved() {
+		return AlertResolved
+	}
+	return AlertFiring
+}
+
+// Validate checks whether the alert data is inconsistent.
+func (a *Alert) Validate() error {
+	if a.StartsAt.IsZero() {
+		return fmt.Errorf("start time missing")
+	}
+	if !a.EndsAt.IsZero() && a.EndsAt.Before(a.StartsAt) {
+		return fmt.Errorf("start time must be before end time")
+	}
+	if err := a.Labels.Validate(); err != nil {
+		return fmt.Errorf("invalid label set: %s", err)
+	}
+	if len(a.Labels) == 0 {
+		return fmt.Errorf("at least one label pair required")
+	}
+	if err := a.Annotations.Validate(); err != nil {
+		return fmt.Errorf("invalid annotations: %s", err)
+	}
+	return nil
+}
+
+// Alert is a list of alerts that can be sorted in chronological order.
+type Alerts []*Alert
+
+func (as Alerts) Len() int      { return len(as) }
+func (as Alerts) Swap(i, j int) { as[i], as[j] = as[j], as[i] }
+
+func (as Alerts) Less(i, j int) bool {
+	if as[i].StartsAt.Before(as[j].StartsAt) {
+		return true
+	}
+	if as[i].EndsAt.Before(as[j].EndsAt) {
+		return true
+	}
+	return as[i].Fingerprint() < as[j].Fingerprint()
+}
+
+// HasFiring returns true iff one of the alerts is not resolved.
+func (as Alerts) HasFiring() bool {
+	for _, a := range as {
+		if !a.Resolved() {
+			return true
+		}
+	}
+	return false
+}
+
+// Status returns StatusFiring iff at least one of the alerts is firing.
+func (as Alerts) Status() AlertStatus {
+	if as.HasFiring() {
+		return AlertFiring
+	}
+	return AlertResolved
+}

--- a/vendor/github.com/prometheus/common/model/fingerprinting.go
+++ b/vendor/github.com/prometheus/common/model/fingerprinting.go
@@ -1,0 +1,105 @@
+// Copyright 2013 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// Fingerprint provides a hash-capable representation of a Metric.
+// For our purposes, FNV-1A 64-bit is used.
+type Fingerprint uint64
+
+// FingerprintFromString transforms a string representation into a Fingerprint.
+func FingerprintFromString(s string) (Fingerprint, error) {
+	num, err := strconv.ParseUint(s, 16, 64)
+	return Fingerprint(num), err
+}
+
+// ParseFingerprint parses the input string into a fingerprint.
+func ParseFingerprint(s string) (Fingerprint, error) {
+	num, err := strconv.ParseUint(s, 16, 64)
+	if err != nil {
+		return 0, err
+	}
+	return Fingerprint(num), nil
+}
+
+func (f Fingerprint) String() string {
+	return fmt.Sprintf("%016x", uint64(f))
+}
+
+// Fingerprints represents a collection of Fingerprint subject to a given
+// natural sorting scheme. It implements sort.Interface.
+type Fingerprints []Fingerprint
+
+// Len implements sort.Interface.
+func (f Fingerprints) Len() int {
+	return len(f)
+}
+
+// Less implements sort.Interface.
+func (f Fingerprints) Less(i, j int) bool {
+	return f[i] < f[j]
+}
+
+// Swap implements sort.Interface.
+func (f Fingerprints) Swap(i, j int) {
+	f[i], f[j] = f[j], f[i]
+}
+
+// FingerprintSet is a set of Fingerprints.
+type FingerprintSet map[Fingerprint]struct{}
+
+// Equal returns true if both sets contain the same elements (and not more).
+func (s FingerprintSet) Equal(o FingerprintSet) bool {
+	if len(s) != len(o) {
+		return false
+	}
+
+	for k := range s {
+		if _, ok := o[k]; !ok {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Intersection returns the elements contained in both sets.
+func (s FingerprintSet) Intersection(o FingerprintSet) FingerprintSet {
+	myLength, otherLength := len(s), len(o)
+	if myLength == 0 || otherLength == 0 {
+		return FingerprintSet{}
+	}
+
+	subSet := s
+	superSet := o
+
+	if otherLength < myLength {
+		subSet = o
+		superSet = s
+	}
+
+	out := FingerprintSet{}
+
+	for k := range subSet {
+		if _, ok := superSet[k]; ok {
+			out[k] = struct{}{}
+		}
+	}
+
+	return out
+}

--- a/vendor/github.com/prometheus/common/model/fnv.go
+++ b/vendor/github.com/prometheus/common/model/fnv.go
@@ -1,0 +1,42 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+// Inline and byte-free variant of hash/fnv's fnv64a.
+
+const (
+	offset64 = 14695981039346656037
+	prime64  = 1099511628211
+)
+
+// hashNew initializies a new fnv64a hash value.
+func hashNew() uint64 {
+	return offset64
+}
+
+// hashAdd adds a string to a fnv64a hash value, returning the updated hash.
+func hashAdd(h uint64, s string) uint64 {
+	for i := 0; i < len(s); i++ {
+		h ^= uint64(s[i])
+		h *= prime64
+	}
+	return h
+}
+
+// hashAddByte adds a byte to a fnv64a hash value, returning the updated hash.
+func hashAddByte(h uint64, b byte) uint64 {
+	h ^= uint64(b)
+	h *= prime64
+	return h
+}

--- a/vendor/github.com/prometheus/common/model/labels.go
+++ b/vendor/github.com/prometheus/common/model/labels.go
@@ -1,0 +1,206 @@
+// Copyright 2013 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+	"unicode/utf8"
+)
+
+const (
+	// AlertNameLabel is the name of the label containing the an alert's name.
+	AlertNameLabel = "alertname"
+
+	// ExportedLabelPrefix is the prefix to prepend to the label names present in
+	// exported metrics if a label of the same name is added by the server.
+	ExportedLabelPrefix = "exported_"
+
+	// MetricNameLabel is the label name indicating the metric name of a
+	// timeseries.
+	MetricNameLabel = "__name__"
+
+	// SchemeLabel is the name of the label that holds the scheme on which to
+	// scrape a target.
+	SchemeLabel = "__scheme__"
+
+	// AddressLabel is the name of the label that holds the address of
+	// a scrape target.
+	AddressLabel = "__address__"
+
+	// MetricsPathLabel is the name of the label that holds the path on which to
+	// scrape a target.
+	MetricsPathLabel = "__metrics_path__"
+
+	// ReservedLabelPrefix is a prefix which is not legal in user-supplied
+	// label names.
+	ReservedLabelPrefix = "__"
+
+	// MetaLabelPrefix is a prefix for labels that provide meta information.
+	// Labels with this prefix are used for intermediate label processing and
+	// will not be attached to time series.
+	MetaLabelPrefix = "__meta_"
+
+	// TmpLabelPrefix is a prefix for temporary labels as part of relabelling.
+	// Labels with this prefix are used for intermediate label processing and
+	// will not be attached to time series. This is reserved for use in
+	// Prometheus configuration files by users.
+	TmpLabelPrefix = "__tmp_"
+
+	// ParamLabelPrefix is a prefix for labels that provide URL parameters
+	// used to scrape a target.
+	ParamLabelPrefix = "__param_"
+
+	// JobLabel is the label name indicating the job from which a timeseries
+	// was scraped.
+	JobLabel = "job"
+
+	// InstanceLabel is the label name used for the instance label.
+	InstanceLabel = "instance"
+
+	// BucketLabel is used for the label that defines the upper bound of a
+	// bucket of a histogram ("le" -> "less or equal").
+	BucketLabel = "le"
+
+	// QuantileLabel is used for the label that defines the quantile in a
+	// summary.
+	QuantileLabel = "quantile"
+)
+
+// LabelNameRE is a regular expression matching valid label names.
+var LabelNameRE = regexp.MustCompile("^[a-zA-Z_][a-zA-Z0-9_]*$")
+
+// A LabelName is a key for a LabelSet or Metric.  It has a value associated
+// therewith.
+type LabelName string
+
+// IsValid is true iff the label name matches the pattern of LabelNameRE.
+func (ln LabelName) IsValid() bool {
+	if len(ln) == 0 {
+		return false
+	}
+	for i, b := range ln {
+		if !((b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || b == '_' || (b >= '0' && b <= '9' && i > 0)) {
+			return false
+		}
+	}
+	return true
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (ln *LabelName) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var s string
+	if err := unmarshal(&s); err != nil {
+		return err
+	}
+	if !LabelNameRE.MatchString(s) {
+		return fmt.Errorf("%q is not a valid label name", s)
+	}
+	*ln = LabelName(s)
+	return nil
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (ln *LabelName) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	if !LabelNameRE.MatchString(s) {
+		return fmt.Errorf("%q is not a valid label name", s)
+	}
+	*ln = LabelName(s)
+	return nil
+}
+
+// LabelNames is a sortable LabelName slice. In implements sort.Interface.
+type LabelNames []LabelName
+
+func (l LabelNames) Len() int {
+	return len(l)
+}
+
+func (l LabelNames) Less(i, j int) bool {
+	return l[i] < l[j]
+}
+
+func (l LabelNames) Swap(i, j int) {
+	l[i], l[j] = l[j], l[i]
+}
+
+func (l LabelNames) String() string {
+	labelStrings := make([]string, 0, len(l))
+	for _, label := range l {
+		labelStrings = append(labelStrings, string(label))
+	}
+	return strings.Join(labelStrings, ", ")
+}
+
+// A LabelValue is an associated value for a LabelName.
+type LabelValue string
+
+// IsValid returns true iff the string is a valid UTF8.
+func (lv LabelValue) IsValid() bool {
+	return utf8.ValidString(string(lv))
+}
+
+// LabelValues is a sortable LabelValue slice. It implements sort.Interface.
+type LabelValues []LabelValue
+
+func (l LabelValues) Len() int {
+	return len(l)
+}
+
+func (l LabelValues) Less(i, j int) bool {
+	return string(l[i]) < string(l[j])
+}
+
+func (l LabelValues) Swap(i, j int) {
+	l[i], l[j] = l[j], l[i]
+}
+
+// LabelPair pairs a name with a value.
+type LabelPair struct {
+	Name  LabelName
+	Value LabelValue
+}
+
+// LabelPairs is a sortable slice of LabelPair pointers. It implements
+// sort.Interface.
+type LabelPairs []*LabelPair
+
+func (l LabelPairs) Len() int {
+	return len(l)
+}
+
+func (l LabelPairs) Less(i, j int) bool {
+	switch {
+	case l[i].Name > l[j].Name:
+		return false
+	case l[i].Name < l[j].Name:
+		return true
+	case l[i].Value > l[j].Value:
+		return false
+	case l[i].Value < l[j].Value:
+		return true
+	default:
+		return false
+	}
+}
+
+func (l LabelPairs) Swap(i, j int) {
+	l[i], l[j] = l[j], l[i]
+}

--- a/vendor/github.com/prometheus/common/model/labelset.go
+++ b/vendor/github.com/prometheus/common/model/labelset.go
@@ -1,0 +1,169 @@
+// Copyright 2013 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// A LabelSet is a collection of LabelName and LabelValue pairs.  The LabelSet
+// may be fully-qualified down to the point where it may resolve to a single
+// Metric in the data store or not.  All operations that occur within the realm
+// of a LabelSet can emit a vector of Metric entities to which the LabelSet may
+// match.
+type LabelSet map[LabelName]LabelValue
+
+// Validate checks whether all names and values in the label set
+// are valid.
+func (ls LabelSet) Validate() error {
+	for ln, lv := range ls {
+		if !ln.IsValid() {
+			return fmt.Errorf("invalid name %q", ln)
+		}
+		if !lv.IsValid() {
+			return fmt.Errorf("invalid value %q", lv)
+		}
+	}
+	return nil
+}
+
+// Equal returns true iff both label sets have exactly the same key/value pairs.
+func (ls LabelSet) Equal(o LabelSet) bool {
+	if len(ls) != len(o) {
+		return false
+	}
+	for ln, lv := range ls {
+		olv, ok := o[ln]
+		if !ok {
+			return false
+		}
+		if olv != lv {
+			return false
+		}
+	}
+	return true
+}
+
+// Before compares the metrics, using the following criteria:
+//
+// If m has fewer labels than o, it is before o. If it has more, it is not.
+//
+// If the number of labels is the same, the superset of all label names is
+// sorted alphanumerically. The first differing label pair found in that order
+// determines the outcome: If the label does not exist at all in m, then m is
+// before o, and vice versa. Otherwise the label value is compared
+// alphanumerically.
+//
+// If m and o are equal, the method returns false.
+func (ls LabelSet) Before(o LabelSet) bool {
+	if len(ls) < len(o) {
+		return true
+	}
+	if len(ls) > len(o) {
+		return false
+	}
+
+	lns := make(LabelNames, 0, len(ls)+len(o))
+	for ln := range ls {
+		lns = append(lns, ln)
+	}
+	for ln := range o {
+		lns = append(lns, ln)
+	}
+	// It's probably not worth it to de-dup lns.
+	sort.Sort(lns)
+	for _, ln := range lns {
+		mlv, ok := ls[ln]
+		if !ok {
+			return true
+		}
+		olv, ok := o[ln]
+		if !ok {
+			return false
+		}
+		if mlv < olv {
+			return true
+		}
+		if mlv > olv {
+			return false
+		}
+	}
+	return false
+}
+
+// Clone returns a copy of the label set.
+func (ls LabelSet) Clone() LabelSet {
+	lsn := make(LabelSet, len(ls))
+	for ln, lv := range ls {
+		lsn[ln] = lv
+	}
+	return lsn
+}
+
+// Merge is a helper function to non-destructively merge two label sets.
+func (l LabelSet) Merge(other LabelSet) LabelSet {
+	result := make(LabelSet, len(l))
+
+	for k, v := range l {
+		result[k] = v
+	}
+
+	for k, v := range other {
+		result[k] = v
+	}
+
+	return result
+}
+
+func (l LabelSet) String() string {
+	lstrs := make([]string, 0, len(l))
+	for l, v := range l {
+		lstrs = append(lstrs, fmt.Sprintf("%s=%q", l, v))
+	}
+
+	sort.Strings(lstrs)
+	return fmt.Sprintf("{%s}", strings.Join(lstrs, ", "))
+}
+
+// Fingerprint returns the LabelSet's fingerprint.
+func (ls LabelSet) Fingerprint() Fingerprint {
+	return labelSetToFingerprint(ls)
+}
+
+// FastFingerprint returns the LabelSet's Fingerprint calculated by a faster hashing
+// algorithm, which is, however, more susceptible to hash collisions.
+func (ls LabelSet) FastFingerprint() Fingerprint {
+	return labelSetToFastFingerprint(ls)
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (l *LabelSet) UnmarshalJSON(b []byte) error {
+	var m map[LabelName]LabelValue
+	if err := json.Unmarshal(b, &m); err != nil {
+		return err
+	}
+	// encoding/json only unmarshals maps of the form map[string]T. It treats
+	// LabelName as a string and does not call its UnmarshalJSON method.
+	// Thus, we have to replicate the behavior here.
+	for ln := range m {
+		if !LabelNameRE.MatchString(string(ln)) {
+			return fmt.Errorf("%q is not a valid label name", ln)
+		}
+	}
+	*l = LabelSet(m)
+	return nil
+}

--- a/vendor/github.com/prometheus/common/model/metric.go
+++ b/vendor/github.com/prometheus/common/model/metric.go
@@ -1,0 +1,98 @@
+// Copyright 2013 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+var (
+	separator    = []byte{0}
+	MetricNameRE = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_:]*$`)
+)
+
+// A Metric is similar to a LabelSet, but the key difference is that a Metric is
+// a singleton and refers to one and only one stream of samples.
+type Metric LabelSet
+
+// Equal compares the metrics.
+func (m Metric) Equal(o Metric) bool {
+	return LabelSet(m).Equal(LabelSet(o))
+}
+
+// Before compares the metrics' underlying label sets.
+func (m Metric) Before(o Metric) bool {
+	return LabelSet(m).Before(LabelSet(o))
+}
+
+// Clone returns a copy of the Metric.
+func (m Metric) Clone() Metric {
+	clone := Metric{}
+	for k, v := range m {
+		clone[k] = v
+	}
+	return clone
+}
+
+func (m Metric) String() string {
+	metricName, hasName := m[MetricNameLabel]
+	numLabels := len(m) - 1
+	if !hasName {
+		numLabels = len(m)
+	}
+	labelStrings := make([]string, 0, numLabels)
+	for label, value := range m {
+		if label != MetricNameLabel {
+			labelStrings = append(labelStrings, fmt.Sprintf("%s=%q", label, value))
+		}
+	}
+
+	switch numLabels {
+	case 0:
+		if hasName {
+			return string(metricName)
+		}
+		return "{}"
+	default:
+		sort.Strings(labelStrings)
+		return fmt.Sprintf("%s{%s}", metricName, strings.Join(labelStrings, ", "))
+	}
+}
+
+// Fingerprint returns a Metric's Fingerprint.
+func (m Metric) Fingerprint() Fingerprint {
+	return LabelSet(m).Fingerprint()
+}
+
+// FastFingerprint returns a Metric's Fingerprint calculated by a faster hashing
+// algorithm, which is, however, more susceptible to hash collisions.
+func (m Metric) FastFingerprint() Fingerprint {
+	return LabelSet(m).FastFingerprint()
+}
+
+// IsValidMetricName returns true iff name matches the pattern of MetricNameRE.
+func IsValidMetricName(n LabelValue) bool {
+	if len(n) == 0 {
+		return false
+	}
+	for i, b := range n {
+		if !((b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || b == '_' || b == ':' || (b >= '0' && b <= '9' && i > 0)) {
+			return false
+		}
+	}
+	return true
+}

--- a/vendor/github.com/prometheus/common/model/model.go
+++ b/vendor/github.com/prometheus/common/model/model.go
@@ -1,0 +1,16 @@
+// Copyright 2013 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package model contains common data structures that are shared across
+// Prometheus componenets and libraries.
+package model

--- a/vendor/github.com/prometheus/common/model/signature.go
+++ b/vendor/github.com/prometheus/common/model/signature.go
@@ -1,0 +1,144 @@
+// Copyright 2014 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"sort"
+)
+
+// SeparatorByte is a byte that cannot occur in valid UTF-8 sequences and is
+// used to separate label names, label values, and other strings from each other
+// when calculating their combined hash value (aka signature aka fingerprint).
+const SeparatorByte byte = 255
+
+var (
+	// cache the signature of an empty label set.
+	emptyLabelSignature = hashNew()
+)
+
+// LabelsToSignature returns a quasi-unique signature (i.e., fingerprint) for a
+// given label set. (Collisions are possible but unlikely if the number of label
+// sets the function is applied to is small.)
+func LabelsToSignature(labels map[string]string) uint64 {
+	if len(labels) == 0 {
+		return emptyLabelSignature
+	}
+
+	labelNames := make([]string, 0, len(labels))
+	for labelName := range labels {
+		labelNames = append(labelNames, labelName)
+	}
+	sort.Strings(labelNames)
+
+	sum := hashNew()
+	for _, labelName := range labelNames {
+		sum = hashAdd(sum, labelName)
+		sum = hashAddByte(sum, SeparatorByte)
+		sum = hashAdd(sum, labels[labelName])
+		sum = hashAddByte(sum, SeparatorByte)
+	}
+	return sum
+}
+
+// labelSetToFingerprint works exactly as LabelsToSignature but takes a LabelSet as
+// parameter (rather than a label map) and returns a Fingerprint.
+func labelSetToFingerprint(ls LabelSet) Fingerprint {
+	if len(ls) == 0 {
+		return Fingerprint(emptyLabelSignature)
+	}
+
+	labelNames := make(LabelNames, 0, len(ls))
+	for labelName := range ls {
+		labelNames = append(labelNames, labelName)
+	}
+	sort.Sort(labelNames)
+
+	sum := hashNew()
+	for _, labelName := range labelNames {
+		sum = hashAdd(sum, string(labelName))
+		sum = hashAddByte(sum, SeparatorByte)
+		sum = hashAdd(sum, string(ls[labelName]))
+		sum = hashAddByte(sum, SeparatorByte)
+	}
+	return Fingerprint(sum)
+}
+
+// labelSetToFastFingerprint works similar to labelSetToFingerprint but uses a
+// faster and less allocation-heavy hash function, which is more susceptible to
+// create hash collisions. Therefore, collision detection should be applied.
+func labelSetToFastFingerprint(ls LabelSet) Fingerprint {
+	if len(ls) == 0 {
+		return Fingerprint(emptyLabelSignature)
+	}
+
+	var result uint64
+	for labelName, labelValue := range ls {
+		sum := hashNew()
+		sum = hashAdd(sum, string(labelName))
+		sum = hashAddByte(sum, SeparatorByte)
+		sum = hashAdd(sum, string(labelValue))
+		result ^= sum
+	}
+	return Fingerprint(result)
+}
+
+// SignatureForLabels works like LabelsToSignature but takes a Metric as
+// parameter (rather than a label map) and only includes the labels with the
+// specified LabelNames into the signature calculation. The labels passed in
+// will be sorted by this function.
+func SignatureForLabels(m Metric, labels ...LabelName) uint64 {
+	if len(labels) == 0 {
+		return emptyLabelSignature
+	}
+
+	sort.Sort(LabelNames(labels))
+
+	sum := hashNew()
+	for _, label := range labels {
+		sum = hashAdd(sum, string(label))
+		sum = hashAddByte(sum, SeparatorByte)
+		sum = hashAdd(sum, string(m[label]))
+		sum = hashAddByte(sum, SeparatorByte)
+	}
+	return sum
+}
+
+// SignatureWithoutLabels works like LabelsToSignature but takes a Metric as
+// parameter (rather than a label map) and excludes the labels with any of the
+// specified LabelNames from the signature calculation.
+func SignatureWithoutLabels(m Metric, labels map[LabelName]struct{}) uint64 {
+	if len(m) == 0 {
+		return emptyLabelSignature
+	}
+
+	labelNames := make(LabelNames, 0, len(m))
+	for labelName := range m {
+		if _, exclude := labels[labelName]; !exclude {
+			labelNames = append(labelNames, labelName)
+		}
+	}
+	if len(labelNames) == 0 {
+		return emptyLabelSignature
+	}
+	sort.Sort(labelNames)
+
+	sum := hashNew()
+	for _, labelName := range labelNames {
+		sum = hashAdd(sum, string(labelName))
+		sum = hashAddByte(sum, SeparatorByte)
+		sum = hashAdd(sum, string(m[labelName]))
+		sum = hashAddByte(sum, SeparatorByte)
+	}
+	return sum
+}

--- a/vendor/github.com/prometheus/common/model/silence.go
+++ b/vendor/github.com/prometheus/common/model/silence.go
@@ -1,0 +1,106 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"time"
+)
+
+// Matcher describes a matches the value of a given label.
+type Matcher struct {
+	Name    LabelName `json:"name"`
+	Value   string    `json:"value"`
+	IsRegex bool      `json:"isRegex"`
+}
+
+func (m *Matcher) UnmarshalJSON(b []byte) error {
+	type plain Matcher
+	if err := json.Unmarshal(b, (*plain)(m)); err != nil {
+		return err
+	}
+
+	if len(m.Name) == 0 {
+		return fmt.Errorf("label name in matcher must not be empty")
+	}
+	if m.IsRegex {
+		if _, err := regexp.Compile(m.Value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Validate returns true iff all fields of the matcher have valid values.
+func (m *Matcher) Validate() error {
+	if !m.Name.IsValid() {
+		return fmt.Errorf("invalid name %q", m.Name)
+	}
+	if m.IsRegex {
+		if _, err := regexp.Compile(m.Value); err != nil {
+			return fmt.Errorf("invalid regular expression %q", m.Value)
+		}
+	} else if !LabelValue(m.Value).IsValid() || len(m.Value) == 0 {
+		return fmt.Errorf("invalid value %q", m.Value)
+	}
+	return nil
+}
+
+// Silence defines the representation of a silence definiton
+// in the Prometheus eco-system.
+type Silence struct {
+	ID uint64 `json:"id,omitempty"`
+
+	Matchers []*Matcher `json:"matchers"`
+
+	StartsAt time.Time `json:"startsAt"`
+	EndsAt   time.Time `json:"endsAt"`
+
+	CreatedAt time.Time `json:"createdAt,omitempty"`
+	CreatedBy string    `json:"createdBy"`
+	Comment   string    `json:"comment,omitempty"`
+}
+
+// Validate returns true iff all fields of the silence have valid values.
+func (s *Silence) Validate() error {
+	if len(s.Matchers) == 0 {
+		return fmt.Errorf("at least one matcher required")
+	}
+	for _, m := range s.Matchers {
+		if err := m.Validate(); err != nil {
+			return fmt.Errorf("invalid matcher: %s", err)
+		}
+	}
+	if s.StartsAt.IsZero() {
+		return fmt.Errorf("start time missing")
+	}
+	if s.EndsAt.IsZero() {
+		return fmt.Errorf("end time missing")
+	}
+	if s.EndsAt.Before(s.StartsAt) {
+		return fmt.Errorf("start time must be before end time")
+	}
+	if s.CreatedBy == "" {
+		return fmt.Errorf("creator information missing")
+	}
+	if s.Comment == "" {
+		return fmt.Errorf("comment missing")
+	}
+	if s.CreatedAt.IsZero() {
+		return fmt.Errorf("creation timestamp missing")
+	}
+	return nil
+}

--- a/vendor/github.com/prometheus/common/model/time.go
+++ b/vendor/github.com/prometheus/common/model/time.go
@@ -1,0 +1,249 @@
+// Copyright 2013 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"fmt"
+	"math"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	// MinimumTick is the minimum supported time resolution. This has to be
+	// at least time.Second in order for the code below to work.
+	minimumTick = time.Millisecond
+	// second is the Time duration equivalent to one second.
+	second = int64(time.Second / minimumTick)
+	// The number of nanoseconds per minimum tick.
+	nanosPerTick = int64(minimumTick / time.Nanosecond)
+
+	// Earliest is the earliest Time representable. Handy for
+	// initializing a high watermark.
+	Earliest = Time(math.MinInt64)
+	// Latest is the latest Time representable. Handy for initializing
+	// a low watermark.
+	Latest = Time(math.MaxInt64)
+)
+
+// Time is the number of milliseconds since the epoch
+// (1970-01-01 00:00 UTC) excluding leap seconds.
+type Time int64
+
+// Interval describes and interval between two timestamps.
+type Interval struct {
+	Start, End Time
+}
+
+// Now returns the current time as a Time.
+func Now() Time {
+	return TimeFromUnixNano(time.Now().UnixNano())
+}
+
+// TimeFromUnix returns the Time equivalent to the Unix Time t
+// provided in seconds.
+func TimeFromUnix(t int64) Time {
+	return Time(t * second)
+}
+
+// TimeFromUnixNano returns the Time equivalent to the Unix Time
+// t provided in nanoseconds.
+func TimeFromUnixNano(t int64) Time {
+	return Time(t / nanosPerTick)
+}
+
+// Equal reports whether two Times represent the same instant.
+func (t Time) Equal(o Time) bool {
+	return t == o
+}
+
+// Before reports whether the Time t is before o.
+func (t Time) Before(o Time) bool {
+	return t < o
+}
+
+// After reports whether the Time t is after o.
+func (t Time) After(o Time) bool {
+	return t > o
+}
+
+// Add returns the Time t + d.
+func (t Time) Add(d time.Duration) Time {
+	return t + Time(d/minimumTick)
+}
+
+// Sub returns the Duration t - o.
+func (t Time) Sub(o Time) time.Duration {
+	return time.Duration(t-o) * minimumTick
+}
+
+// Time returns the time.Time representation of t.
+func (t Time) Time() time.Time {
+	return time.Unix(int64(t)/second, (int64(t)%second)*nanosPerTick)
+}
+
+// Unix returns t as a Unix time, the number of seconds elapsed
+// since January 1, 1970 UTC.
+func (t Time) Unix() int64 {
+	return int64(t) / second
+}
+
+// UnixNano returns t as a Unix time, the number of nanoseconds elapsed
+// since January 1, 1970 UTC.
+func (t Time) UnixNano() int64 {
+	return int64(t) * nanosPerTick
+}
+
+// The number of digits after the dot.
+var dotPrecision = int(math.Log10(float64(second)))
+
+// String returns a string representation of the Time.
+func (t Time) String() string {
+	return strconv.FormatFloat(float64(t)/float64(second), 'f', -1, 64)
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (t Time) MarshalJSON() ([]byte, error) {
+	return []byte(t.String()), nil
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (t *Time) UnmarshalJSON(b []byte) error {
+	p := strings.Split(string(b), ".")
+	switch len(p) {
+	case 1:
+		v, err := strconv.ParseInt(string(p[0]), 10, 64)
+		if err != nil {
+			return err
+		}
+		*t = Time(v * second)
+
+	case 2:
+		v, err := strconv.ParseInt(string(p[0]), 10, 64)
+		if err != nil {
+			return err
+		}
+		v *= second
+
+		prec := dotPrecision - len(p[1])
+		if prec < 0 {
+			p[1] = p[1][:dotPrecision]
+		} else if prec > 0 {
+			p[1] = p[1] + strings.Repeat("0", prec)
+		}
+
+		va, err := strconv.ParseInt(p[1], 10, 32)
+		if err != nil {
+			return err
+		}
+
+		*t = Time(v + va)
+
+	default:
+		return fmt.Errorf("invalid time %q", string(b))
+	}
+	return nil
+}
+
+// Duration wraps time.Duration. It is used to parse the custom duration format
+// from YAML.
+// This type should not propagate beyond the scope of input/output processing.
+type Duration time.Duration
+
+var durationRE = regexp.MustCompile("^([0-9]+)(y|w|d|h|m|s|ms)$")
+
+// StringToDuration parses a string into a time.Duration, assuming that a year
+// always has 365d, a week always has 7d, and a day always has 24h.
+func ParseDuration(durationStr string) (Duration, error) {
+	matches := durationRE.FindStringSubmatch(durationStr)
+	if len(matches) != 3 {
+		return 0, fmt.Errorf("not a valid duration string: %q", durationStr)
+	}
+	var (
+		n, _ = strconv.Atoi(matches[1])
+		dur  = time.Duration(n) * time.Millisecond
+	)
+	switch unit := matches[2]; unit {
+	case "y":
+		dur *= 1000 * 60 * 60 * 24 * 365
+	case "w":
+		dur *= 1000 * 60 * 60 * 24 * 7
+	case "d":
+		dur *= 1000 * 60 * 60 * 24
+	case "h":
+		dur *= 1000 * 60 * 60
+	case "m":
+		dur *= 1000 * 60
+	case "s":
+		dur *= 1000
+	case "ms":
+		// Value already correct
+	default:
+		return 0, fmt.Errorf("invalid time unit in duration string: %q", unit)
+	}
+	return Duration(dur), nil
+}
+
+func (d Duration) String() string {
+	var (
+		ms   = int64(time.Duration(d) / time.Millisecond)
+		unit = "ms"
+	)
+	factors := map[string]int64{
+		"y":  1000 * 60 * 60 * 24 * 365,
+		"w":  1000 * 60 * 60 * 24 * 7,
+		"d":  1000 * 60 * 60 * 24,
+		"h":  1000 * 60 * 60,
+		"m":  1000 * 60,
+		"s":  1000,
+		"ms": 1,
+	}
+
+	switch int64(0) {
+	case ms % factors["y"]:
+		unit = "y"
+	case ms % factors["w"]:
+		unit = "w"
+	case ms % factors["d"]:
+		unit = "d"
+	case ms % factors["h"]:
+		unit = "h"
+	case ms % factors["m"]:
+		unit = "m"
+	case ms % factors["s"]:
+		unit = "s"
+	}
+	return fmt.Sprintf("%v%v", ms/factors[unit], unit)
+}
+
+// MarshalYAML implements the yaml.Marshaler interface.
+func (d Duration) MarshalYAML() (interface{}, error) {
+	return d.String(), nil
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (d *Duration) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var s string
+	if err := unmarshal(&s); err != nil {
+		return err
+	}
+	dur, err := ParseDuration(s)
+	if err != nil {
+		return err
+	}
+	*d = dur
+	return nil
+}

--- a/vendor/github.com/prometheus/common/model/value.go
+++ b/vendor/github.com/prometheus/common/model/value.go
@@ -1,0 +1,403 @@
+// Copyright 2013 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// A SampleValue is a representation of a value for a given sample at a given
+// time.
+type SampleValue float64
+
+// MarshalJSON implements json.Marshaler.
+func (v SampleValue) MarshalJSON() ([]byte, error) {
+	return json.Marshal(v.String())
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (v *SampleValue) UnmarshalJSON(b []byte) error {
+	if len(b) < 2 || b[0] != '"' || b[len(b)-1] != '"' {
+		return fmt.Errorf("sample value must be a quoted string")
+	}
+	f, err := strconv.ParseFloat(string(b[1:len(b)-1]), 64)
+	if err != nil {
+		return err
+	}
+	*v = SampleValue(f)
+	return nil
+}
+
+// Equal returns true if the value of v and o is equal or if both are NaN. Note
+// that v==o is false if both are NaN. If you want the conventional float
+// behavior, use == to compare two SampleValues.
+func (v SampleValue) Equal(o SampleValue) bool {
+	if v == o {
+		return true
+	}
+	return math.IsNaN(float64(v)) && math.IsNaN(float64(o))
+}
+
+func (v SampleValue) String() string {
+	return strconv.FormatFloat(float64(v), 'f', -1, 64)
+}
+
+// SamplePair pairs a SampleValue with a Timestamp.
+type SamplePair struct {
+	Timestamp Time
+	Value     SampleValue
+}
+
+// MarshalJSON implements json.Marshaler.
+func (s SamplePair) MarshalJSON() ([]byte, error) {
+	t, err := json.Marshal(s.Timestamp)
+	if err != nil {
+		return nil, err
+	}
+	v, err := json.Marshal(s.Value)
+	if err != nil {
+		return nil, err
+	}
+	return []byte(fmt.Sprintf("[%s,%s]", t, v)), nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (s *SamplePair) UnmarshalJSON(b []byte) error {
+	v := [...]json.Unmarshaler{&s.Timestamp, &s.Value}
+	return json.Unmarshal(b, &v)
+}
+
+// Equal returns true if this SamplePair and o have equal Values and equal
+// Timestamps. The sematics of Value equality is defined by SampleValue.Equal.
+func (s *SamplePair) Equal(o *SamplePair) bool {
+	return s == o || (s.Value.Equal(o.Value) && s.Timestamp.Equal(o.Timestamp))
+}
+
+func (s SamplePair) String() string {
+	return fmt.Sprintf("%s @[%s]", s.Value, s.Timestamp)
+}
+
+// Sample is a sample pair associated with a metric.
+type Sample struct {
+	Metric    Metric      `json:"metric"`
+	Value     SampleValue `json:"value"`
+	Timestamp Time        `json:"timestamp"`
+}
+
+// Equal compares first the metrics, then the timestamp, then the value. The
+// sematics of value equality is defined by SampleValue.Equal.
+func (s *Sample) Equal(o *Sample) bool {
+	if s == o {
+		return true
+	}
+
+	if !s.Metric.Equal(o.Metric) {
+		return false
+	}
+	if !s.Timestamp.Equal(o.Timestamp) {
+		return false
+	}
+	if s.Value.Equal(o.Value) {
+		return false
+	}
+
+	return true
+}
+
+func (s Sample) String() string {
+	return fmt.Sprintf("%s => %s", s.Metric, SamplePair{
+		Timestamp: s.Timestamp,
+		Value:     s.Value,
+	})
+}
+
+// MarshalJSON implements json.Marshaler.
+func (s Sample) MarshalJSON() ([]byte, error) {
+	v := struct {
+		Metric Metric     `json:"metric"`
+		Value  SamplePair `json:"value"`
+	}{
+		Metric: s.Metric,
+		Value: SamplePair{
+			Timestamp: s.Timestamp,
+			Value:     s.Value,
+		},
+	}
+
+	return json.Marshal(&v)
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (s *Sample) UnmarshalJSON(b []byte) error {
+	v := struct {
+		Metric Metric     `json:"metric"`
+		Value  SamplePair `json:"value"`
+	}{
+		Metric: s.Metric,
+		Value: SamplePair{
+			Timestamp: s.Timestamp,
+			Value:     s.Value,
+		},
+	}
+
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+
+	s.Metric = v.Metric
+	s.Timestamp = v.Value.Timestamp
+	s.Value = v.Value.Value
+
+	return nil
+}
+
+// Samples is a sortable Sample slice. It implements sort.Interface.
+type Samples []*Sample
+
+func (s Samples) Len() int {
+	return len(s)
+}
+
+// Less compares first the metrics, then the timestamp.
+func (s Samples) Less(i, j int) bool {
+	switch {
+	case s[i].Metric.Before(s[j].Metric):
+		return true
+	case s[j].Metric.Before(s[i].Metric):
+		return false
+	case s[i].Timestamp.Before(s[j].Timestamp):
+		return true
+	default:
+		return false
+	}
+}
+
+func (s Samples) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+// Equal compares two sets of samples and returns true if they are equal.
+func (s Samples) Equal(o Samples) bool {
+	if len(s) != len(o) {
+		return false
+	}
+
+	for i, sample := range s {
+		if !sample.Equal(o[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// SampleStream is a stream of Values belonging to an attached COWMetric.
+type SampleStream struct {
+	Metric Metric       `json:"metric"`
+	Values []SamplePair `json:"values"`
+}
+
+func (ss SampleStream) String() string {
+	vals := make([]string, len(ss.Values))
+	for i, v := range ss.Values {
+		vals[i] = v.String()
+	}
+	return fmt.Sprintf("%s =>\n%s", ss.Metric, strings.Join(vals, "\n"))
+}
+
+// Value is a generic interface for values resulting from a query evaluation.
+type Value interface {
+	Type() ValueType
+	String() string
+}
+
+func (Matrix) Type() ValueType  { return ValMatrix }
+func (Vector) Type() ValueType  { return ValVector }
+func (*Scalar) Type() ValueType { return ValScalar }
+func (*String) Type() ValueType { return ValString }
+
+type ValueType int
+
+const (
+	ValNone ValueType = iota
+	ValScalar
+	ValVector
+	ValMatrix
+	ValString
+)
+
+// MarshalJSON implements json.Marshaler.
+func (et ValueType) MarshalJSON() ([]byte, error) {
+	return json.Marshal(et.String())
+}
+
+func (et *ValueType) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	switch s {
+	case "<ValNone>":
+		*et = ValNone
+	case "scalar":
+		*et = ValScalar
+	case "vector":
+		*et = ValVector
+	case "matrix":
+		*et = ValMatrix
+	case "string":
+		*et = ValString
+	default:
+		return fmt.Errorf("unknown value type %q", s)
+	}
+	return nil
+}
+
+func (e ValueType) String() string {
+	switch e {
+	case ValNone:
+		return "<ValNone>"
+	case ValScalar:
+		return "scalar"
+	case ValVector:
+		return "vector"
+	case ValMatrix:
+		return "matrix"
+	case ValString:
+		return "string"
+	}
+	panic("ValueType.String: unhandled value type")
+}
+
+// Scalar is a scalar value evaluated at the set timestamp.
+type Scalar struct {
+	Value     SampleValue `json:"value"`
+	Timestamp Time        `json:"timestamp"`
+}
+
+func (s Scalar) String() string {
+	return fmt.Sprintf("scalar: %v @[%v]", s.Value, s.Timestamp)
+}
+
+// MarshalJSON implements json.Marshaler.
+func (s Scalar) MarshalJSON() ([]byte, error) {
+	v := strconv.FormatFloat(float64(s.Value), 'f', -1, 64)
+	return json.Marshal([...]interface{}{s.Timestamp, string(v)})
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (s *Scalar) UnmarshalJSON(b []byte) error {
+	var f string
+	v := [...]interface{}{&s.Timestamp, &f}
+
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+
+	value, err := strconv.ParseFloat(f, 64)
+	if err != nil {
+		return fmt.Errorf("error parsing sample value: %s", err)
+	}
+	s.Value = SampleValue(value)
+	return nil
+}
+
+// String is a string value evaluated at the set timestamp.
+type String struct {
+	Value     string `json:"value"`
+	Timestamp Time   `json:"timestamp"`
+}
+
+func (s *String) String() string {
+	return s.Value
+}
+
+// MarshalJSON implements json.Marshaler.
+func (s String) MarshalJSON() ([]byte, error) {
+	return json.Marshal([]interface{}{s.Timestamp, s.Value})
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (s *String) UnmarshalJSON(b []byte) error {
+	v := [...]interface{}{&s.Timestamp, &s.Value}
+	return json.Unmarshal(b, &v)
+}
+
+// Vector is basically only an alias for Samples, but the
+// contract is that in a Vector, all Samples have the same timestamp.
+type Vector []*Sample
+
+func (vec Vector) String() string {
+	entries := make([]string, len(vec))
+	for i, s := range vec {
+		entries[i] = s.String()
+	}
+	return strings.Join(entries, "\n")
+}
+
+func (vec Vector) Len() int      { return len(vec) }
+func (vec Vector) Swap(i, j int) { vec[i], vec[j] = vec[j], vec[i] }
+
+// Less compares first the metrics, then the timestamp.
+func (vec Vector) Less(i, j int) bool {
+	switch {
+	case vec[i].Metric.Before(vec[j].Metric):
+		return true
+	case vec[j].Metric.Before(vec[i].Metric):
+		return false
+	case vec[i].Timestamp.Before(vec[j].Timestamp):
+		return true
+	default:
+		return false
+	}
+}
+
+// Equal compares two sets of samples and returns true if they are equal.
+func (vec Vector) Equal(o Vector) bool {
+	if len(vec) != len(o) {
+		return false
+	}
+
+	for i, sample := range vec {
+		if !sample.Equal(o[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// Matrix is a list of time series.
+type Matrix []*SampleStream
+
+func (m Matrix) Len() int           { return len(m) }
+func (m Matrix) Less(i, j int) bool { return m[i].Metric.Before(m[j].Metric) }
+func (m Matrix) Swap(i, j int)      { m[i], m[j] = m[j], m[i] }
+
+func (mat Matrix) String() string {
+	matCp := make(Matrix, len(mat))
+	copy(matCp, mat)
+	sort.Sort(matCp)
+
+	strs := make([]string, len(matCp))
+
+	for i, ss := range matCp {
+		strs[i] = ss.String()
+	}
+
+	return strings.Join(strs, "\n")
+}


### PR DESCRIPTION
This introduces an initial implementation of push metrics (as proposed in #1129).  It supports both the Prometheus format with both text and protobuf format.  It works as such:

All metrics, when pushed, are prefixed by "custom/$USERNAME".  Metrics are stored in-memory on a per-source basis until the next scrape, at while point the in-memory store is cleared.  Multiple pushes from the same source are merged as such:
- If there is no overlap, new entries are simply inserted
- For times and labels, newer values overwrite older values
- For metric values, cumulative metrics overwrite existing cumulative metrics, while gauge metrics take the average (using a running average)
- For labeled metrics, new metrics are simply appended

When performing the final merge before scrape, the different sources' data batches are merged with no overwriting.

This also introduces merging at the source level, and the concept of "canonical" sources.  When Heapster goes to scrape different sources (which was not supported prior to this), "canonical" sources (e.g. the "kubernetes" source) overwrite data from non-canonical sources (e.g. push metrics).  This prevents push metrics from changing known labels from built-in sources.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/heapster/1217)

<!-- Reviewable:end -->
