### PR TITLE
Reduce when some of our messages get logged.

### DIFF
--- a/metrics/processors/node_aggregator.go
+++ b/metrics/processors/node_aggregator.go
@@ -41,7 +41,7 @@ func (this *NodeAggregator) Process(batch *core.DataBatch) (*core.DataBatch, err
 				nodeKey := core.NodeKey(nodeName)
 				node, found := batch.MetricSets[nodeKey]
 				if !found {
-					glog.Warningf("Failed to find node: %s", nodeKey)
+					glog.V(1).Info("No metric for node %s, cannot perform node level aggregation.")
 				} else if err := aggregate(metricSet, node, this.MetricsToAggregate); err != nil {
 					return nil, err
 				}

--- a/metrics/sources/manager.go
+++ b/metrics/sources/manager.go
@@ -76,7 +76,7 @@ func (this *sourceManager) Name() string {
 }
 
 func (this *sourceManager) ScrapeMetrics(start, end time.Time) *DataBatch {
-	glog.Infof("Scraping metrics start: %s, end: %s", start, end)
+	glog.V(1).Infof("Scraping metrics start: %s, end: %s", start, end)
 	sources := this.metricsSourceProvider.GetMetricsSources()
 
 	responseChannel := make(chan *DataBatch)
@@ -149,7 +149,7 @@ responseloop:
 		}
 	}
 
-	glog.Infof("ScrapeMetrics: time: %s size: %d", time.Since(startTime), len(response.MetricSets))
+	glog.V(1).Infof("ScrapeMetrics: time: %s size: %d", time.Since(startTime), len(response.MetricSets))
 	for i, value := range latencies {
 		glog.V(1).Infof("   scrape  bucket %d: %d", i, value)
 	}


### PR DESCRIPTION
There are a bunch of messages that we are currently logging which could be moved to not being logged by default. This will prevent the logs from growing too much in size and will allow people to more easily parse through the logs to determine if something went wrong.

The logs about how many metrics were gathered have been moved to V(1) level instead of the default logging level.

If we don't have node level metrics, we shouldn't be filling up the logs with warning messages that we can't aggregate metrics for the non-existent metric. This has also been moved to V(1).