### PR TITLE
InfluxDB Historical: Fix panic on missing pods in GetAggregation

### DIFF
--- a/common/influxdb/dummy_influxdb.go
+++ b/common/influxdb/dummy_influxdb.go
@@ -15,6 +15,7 @@
 package influxdb
 
 import (
+	"strings"
 	"time"
 
 	influxdb "github.com/influxdata/influxdb/client"
@@ -39,8 +40,13 @@ func (client *FakeInfluxDBClient) Write(bps influxdb.BatchPoints) (*influxdb.Res
 	return nil, nil
 }
 
-func (client *FakeInfluxDBClient) Query(influxdb.Query) (*influxdb.Response, error) {
-	return nil, nil
+func (client *FakeInfluxDBClient) Query(q influxdb.Query) (*influxdb.Response, error) {
+	numQueries := strings.Count(q.Command, ";")
+
+	// return an empty result for each separate query
+	return &influxdb.Response{
+		Results: make([]influxdb.Result, numQueries),
+	}, nil
 }
 
 func (client *FakeInfluxDBClient) Ping() (time.Duration, string, error) {

--- a/metrics/sinks/influxdb/influxdb.go
+++ b/metrics/sinks/influxdb/influxdb.go
@@ -177,13 +177,21 @@ func (sink *influxdbSink) Stop() {
 	// nothing needs to be done.
 }
 
-func (sink *influxdbSink) createDatabase() error {
+func (sink *influxdbSink) ensureClient() error {
 	if sink.client == nil {
 		client, err := influxdb_common.NewClient(sink.c)
 		if err != nil {
 			return err
 		}
 		sink.client = client
+	}
+
+	return nil
+}
+
+func (sink *influxdbSink) createDatabase() error {
+	if err := sink.ensureClient(); err != nil {
+		return err
 	}
 
 	if sink.dbExists {

--- a/metrics/sinks/influxdb/influxdb_historical.go
+++ b/metrics/sinks/influxdb/influxdb_historical.go
@@ -610,6 +610,9 @@ func (sink *influxdbSink) GetSystemContainersFromNode(node string) ([]string, er
 
 // stringListQueryCol runs the given query, and returns all results from the given column as a string list
 func (sink *influxdbSink) stringListQueryCol(q, colName string, errStr string) ([]string, error) {
+	sink.RLock()
+	defer sink.RUnlock()
+
 	resp, err := sink.runQuery(q)
 	if err != nil {
 		return nil, fmt.Errorf(errStr)
@@ -641,6 +644,9 @@ func (sink *influxdbSink) stringListQueryCol(q, colName string, errStr string) (
 
 // stringListQuery runs the given query, and returns all results from the first column as a string list
 func (sink *influxdbSink) stringListQuery(q string, errStr string) ([]string, error) {
+	sink.RLock()
+	defer sink.RUnlock()
+
 	resp, err := sink.runQuery(q)
 	if err != nil {
 		return nil, fmt.Errorf(errStr)
@@ -658,7 +664,14 @@ func (sink *influxdbSink) stringListQuery(q string, errStr string) ([]string, er
 }
 
 // runQuery executes the given query against InfluxDB (using the default database for this sink)
+// The caller is responsible for locking the sink before use.
 func (sink *influxdbSink) runQuery(queryStr string) ([]influxdb.Result, error) {
+	// ensure we have a valid client handle before attempting to use it
+	if err := sink.ensureClient(); err != nil {
+		glog.Errorf("Unable to ensure InfluxDB client is present: %v", err)
+		return nil, fmt.Errorf("unable to run query: unable to connect to database")
+	}
+
 	q := influxdb.Query{
 		Command:  queryStr,
 		Database: sink.c.DbName,

--- a/metrics/sinks/influxdb/influxdb_historical.go
+++ b/metrics/sinks/influxdb/influxdb_historical.go
@@ -454,6 +454,10 @@ func (sink *influxdbSink) GetAggregation(metricName string, aggregations []core.
 	//       instead of returning an error.  We should detect this case and return an error ourselves (or maybe just require a start time at the API level)
 	res := make(map[core.HistoricalKey][]core.TimestampedAggregationValue, len(metricKeys))
 	for i, key := range metricKeys {
+		if len(resp[i].Series) < 1 {
+			return nil, fmt.Errorf("No results for metric %q describing %q", metricName, key.String())
+		}
+
 		vals, err := sink.parseAggregateQueryRow(resp[i].Series[0], aggregationLookup, bucketSize)
 		if err != nil {
 			return nil, err
@@ -501,6 +505,10 @@ func (sink *influxdbSink) GetLabeledAggregation(metricName string, labels map[st
 	//       instead of returning an error.  We should detect this case and return an error ourselves (or maybe just require a start time at the API level)
 	res := make(map[core.HistoricalKey][]core.TimestampedAggregationValue, len(metricKeys))
 	for i, key := range metricKeys {
+		if len(resp[i].Series) < 1 {
+			return nil, fmt.Errorf("No results for metric %q describing %q", metricName, key.String())
+		}
+
 		vals, err := sink.parseAggregateQueryRow(resp[i].Series[0], aggregationLookup, bucketSize)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
`GetAggregation` and `GetLabeledAggregation` were missing one of the checks for missing data, and thus would panic when invalid pods were requested.  This fixes that.

Fixes #1249 