### PR TITLE
Add missing returns to the Historical API handlers

### DIFF
--- a/metrics/api/v1/historical_handlers.go
+++ b/metrics/api/v1/historical_handlers.go
@@ -566,6 +566,7 @@ func (a *HistoricalApi) podListAggregations(request *restful.Request, response *
 	aggregations, err := getAggregations(request)
 	if err != nil {
 		response.WriteError(http.StatusBadRequest, err)
+		return
 	}
 	labels, err := getLabels(request)
 	if err != nil {
@@ -601,6 +602,7 @@ func (a *HistoricalApi) podListAggregations(request *restful.Request, response *
 	}
 	if err != nil {
 		response.WriteError(http.StatusInternalServerError, err)
+		return
 	}
 
 	result := types.MetricAggregationResultList{
@@ -667,6 +669,7 @@ func (a *HistoricalApi) processAggregationRequest(key core.HistoricalKey, reques
 	aggregations, err := getAggregations(request)
 	if err != nil {
 		response.WriteError(http.StatusBadRequest, err)
+		return
 	}
 	labels, err := getLabels(request)
 	if err != nil {


### PR DESCRIPTION
The historical API handlers were missing return statements after
`response.WriteError` calls in a couple of places.  This does not
prevent it from functioning currently, but with #1252, it causes
issues.
