### PR TITLE
Update README with correct Openshift instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To run Heapster on a Kubernetes cluster with,
 
 ### Running Heapster on OpenShift
 
-Using Heapster to monitor an OpenShift cluster requires some additional changes to the Kubernetes instructions to allow communication between the Heapster instance and OpenShift's secured endpoints. To run a combination of Heapster and Hawkular-Metrics, follow [this guide](https://github.com/hawkular/hawkular-metrics/blob/master/containers/README.adoc).
+Using Heapster to monitor an OpenShift cluster requires some additional changes to the Kubernetes instructions to allow communication between the Heapster instance and OpenShift's secured endpoints. To run standalone Heapster or a combination of Heapster and Hawkular-Metrics in OpenShift, follow [this guide](https://github.com/openshift/origin-metrics).
 
 #### Troubleshooting guide [here](docs/debugging.md)
 


### PR DESCRIPTION
Openshift repository includes instructions on how to run standalone Heapster or Heapster with Hawkular-Metrics combination on Openshift (with deployment scripts).