### PR TITLE
reduce make build time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,10 @@ SUPPORTED_KUBE_VERSIONS = "1.2.4"
 TEST_NAMESPACE = heapster-e2e-tests
 
 deps:
-	go get github.com/tools/godep
+	which godep || go get github.com/tools/godep
 
 build: clean deps
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 godep go build ./...
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 godep go install ./...
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 godep go build -o heapster k8s.io/heapster/metrics
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 godep go build -o eventer k8s.io/heapster/events
 


### PR DESCRIPTION
* change `go build` to `go install` to pre-compile all dependencies
* check whether `godep` is already installed. If so, bypass `go get github.com/tools/godep`

For more info see #1256

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/heapster/1257)
<!-- Reviewable:end -->
