### PR TITLE
Use Kubernetes' GenericAPIServer conventions for the commandline flag handling.

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1108,6 +1108,11 @@
 			"Rev": "a0a9a282b431f437b048932eaf01631408b5bae0"
 		},
 		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/flag",
+			"Comment": "v1.4.0-beta.3",
+			"Rev": "a0a9a282b431f437b048932eaf01631408b5bae0"
+		},
+		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/flowcontrol",
 			"Comment": "v1.4.0-beta.3",
 			"Rev": "a0a9a282b431f437b048932eaf01631408b5bae0"
@@ -1144,6 +1149,11 @@
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util/labels",
+			"Comment": "v1.4.0-beta.3",
+			"Rev": "a0a9a282b431f437b048932eaf01631408b5bae0"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/logs",
 			"Comment": "v1.4.0-beta.3",
 			"Rev": "a0a9a282b431f437b048932eaf01631408b5bae0"
 		},
@@ -1209,6 +1219,11 @@
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/version",
+			"Comment": "v1.4.0-beta.3",
+			"Rev": "a0a9a282b431f437b048932eaf01631408b5bae0"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/version/verflag",
 			"Comment": "v1.4.0-beta.3",
 			"Rev": "a0a9a282b431f437b048932eaf01631408b5bae0"
 		},

--- a/common/flags/flags.go
+++ b/common/flags/flags.go
@@ -75,3 +75,7 @@ func (us *Uris) Set(value string) error {
 	*us = append(*us, u)
 	return nil
 }
+
+func (us *Uris) Type() string {
+	return fmt.Sprintf("%T", us)
+}

--- a/metrics/auth.go
+++ b/metrics/auth.go
@@ -21,19 +21,20 @@ import (
 	"net/http"
 	"strings"
 
+	"k8s.io/heapster/metrics/options"
 	"k8s.io/kubernetes/pkg/auth/authenticator"
 	"k8s.io/kubernetes/pkg/auth/user"
 	x509request "k8s.io/kubernetes/plugin/pkg/auth/authenticator/request/x509"
 )
 
-func newAuthHandler(handler http.Handler) (http.Handler, error) {
+func newAuthHandler(opt *options.HeapsterRunOptions, handler http.Handler) (http.Handler, error) {
 	// Authn/Authz setup
-	authn, err := newAuthenticatorFromClientCAFile(*argTLSClientCAFile)
+	authn, err := newAuthenticatorFromClientCAFile(opt.TLSClientCAFile)
 	if err != nil {
 		return nil, err
 	}
 
-	authz, err := newAuthorizerFromUserList(strings.Split(*argAllowedUsers, ",")...)
+	authz, err := newAuthorizerFromUserList(strings.Split(opt.AllowedUsers, ",")...)
 	if err != nil {
 		return nil, err
 	}

--- a/metrics/options/options.go
+++ b/metrics/options/options.go
@@ -1,0 +1,54 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package options
+
+import (
+	"time"
+
+	"github.com/spf13/pflag"
+	"k8s.io/heapster/common/flags"
+)
+
+type HeapsterRunOptions struct {
+	MetricResolution time.Duration
+	Port             int
+	Ip               string
+	MaxProcs         int
+	TLSCertFile      string
+	TLSKeyFile       string
+	TLSClientCAFile  string
+	AllowedUsers     string
+	Sources          flags.Uris
+	Sinks            flags.Uris
+	HistoricalSource string
+}
+
+func NewHeapsterRunOptions() *HeapsterRunOptions {
+	return &HeapsterRunOptions{}
+}
+
+func (h *HeapsterRunOptions) AddFlags(fs *pflag.FlagSet) {
+	fs.Var(&h.Sources, "source", "source(s) to watch")
+	fs.Var(&h.Sinks, "sink", "external sink(s) that receive data")
+	fs.DurationVar(&h.MetricResolution, "metric_resolution", 60*time.Second, "The resolution at which heapster will retain metrics.")
+	fs.IntVar(&h.Port, "port", 8082, "port to listen to")
+	fs.StringVar(&h.Ip, "listen_ip", "", "IP to listen on, defaults to all IPs")
+	fs.IntVar(&h.MaxProcs, "max_procs", 0, "max number of CPUs that can be used simultaneously. Less than 1 for default (number of cores)")
+	fs.StringVar(&h.TLSCertFile, "tls_cert", "", "file containing TLS certificate")
+	fs.StringVar(&h.TLSKeyFile, "tls_key", "", "file containing TLS key")
+	fs.StringVar(&h.TLSClientCAFile, "tls_client_ca", "", "file containing TLS client CA for client cert validation")
+	fs.StringVar(&h.AllowedUsers, "allowed_users", "", "comma-separated list of allowed users")
+	fs.StringVar(&h.HistoricalSource, "historical_source", "", "which source type to use for the historical API (should be exactly the same as one of the sink URIs), or empty to disable the historical API")
+}

--- a/vendor/k8s.io/kubernetes/pkg/util/flag/flags.go
+++ b/vendor/k8s.io/kubernetes/pkg/util/flag/flags.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flag
+
+import (
+	goflag "flag"
+	"strings"
+
+	"github.com/golang/glog"
+	"github.com/spf13/pflag"
+)
+
+// WordSepNormalizeFunc changes all flags that contain "_" separators
+func WordSepNormalizeFunc(f *pflag.FlagSet, name string) pflag.NormalizedName {
+	if strings.Contains(name, "_") {
+		return pflag.NormalizedName(strings.Replace(name, "_", "-", -1))
+	}
+	return pflag.NormalizedName(name)
+}
+
+// WarnWordSepNormalizeFunc changes and warns for flags that contain "_" separators
+func WarnWordSepNormalizeFunc(f *pflag.FlagSet, name string) pflag.NormalizedName {
+	if strings.Contains(name, "_") {
+		nname := strings.Replace(name, "_", "-", -1)
+		glog.Warningf("%s is DEPRECATED and will be removed in a future version. Use %s instead.", name, nname)
+
+		return pflag.NormalizedName(nname)
+	}
+	return pflag.NormalizedName(name)
+}
+
+// InitFlags normalizes and parses the command line flags
+func InitFlags() {
+	pflag.CommandLine.SetNormalizeFunc(WordSepNormalizeFunc)
+	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
+	pflag.Parse()
+}

--- a/vendor/k8s.io/kubernetes/pkg/util/flag/tristate.go
+++ b/vendor/k8s.io/kubernetes/pkg/util/flag/tristate.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flag
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// Tristate is a flag compatible with flags and pflags that
+// keeps track of whether it had a value supplied or not.
+type Tristate int
+
+const (
+	Unset Tristate = iota // 0
+	True
+	False
+)
+
+func (f *Tristate) Default(value bool) {
+	*f = triFromBool(value)
+}
+
+func (f Tristate) String() string {
+	b := boolFromTri(f)
+	return fmt.Sprintf("%t", b)
+}
+
+func (f Tristate) Value() bool {
+	b := boolFromTri(f)
+	return b
+}
+
+func (f *Tristate) Set(value string) error {
+	boolVal, err := strconv.ParseBool(value)
+	if err != nil {
+		return err
+	}
+
+	*f = triFromBool(boolVal)
+	return nil
+}
+
+func (f Tristate) Provided() bool {
+	if f != Unset {
+		return true
+	}
+	return false
+}
+
+func (f *Tristate) Type() string {
+	return "tristate"
+}
+
+func boolFromTri(t Tristate) bool {
+	if t == True {
+		return true
+	} else {
+		return false
+	}
+}
+
+func triFromBool(b bool) Tristate {
+	if b {
+		return True
+	} else {
+		return False
+	}
+}

--- a/vendor/k8s.io/kubernetes/pkg/util/logs/logs.go
+++ b/vendor/k8s.io/kubernetes/pkg/util/logs/logs.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logs
+
+import (
+	"flag"
+	"log"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/spf13/pflag"
+	"k8s.io/kubernetes/pkg/util/wait"
+)
+
+var logFlushFreq = pflag.Duration("log-flush-frequency", 5*time.Second, "Maximum number of seconds between log flushes")
+
+// TODO(thockin): This is temporary until we agree on log dirs and put those into each cmd.
+func init() {
+	flag.Set("logtostderr", "true")
+}
+
+// GlogWriter serves as a bridge between the standard log package and the glog package.
+type GlogWriter struct{}
+
+// Write implements the io.Writer interface.
+func (writer GlogWriter) Write(data []byte) (n int, err error) {
+	glog.Info(string(data))
+	return len(data), nil
+}
+
+// InitLogs initializes logs the way we want for kubernetes.
+func InitLogs() {
+	log.SetOutput(GlogWriter{})
+	log.SetFlags(0)
+	// The default glog flush interval is 30 seconds, which is frighteningly long.
+	go wait.Until(glog.Flush, *logFlushFreq, wait.NeverStop)
+}
+
+// FlushLogs flushes logs immediately.
+func FlushLogs() {
+	glog.Flush()
+}
+
+// NewLogger creates a new log.Logger which sends logs to glog.Info.
+func NewLogger(prefix string) *log.Logger {
+	return log.New(GlogWriter{}, prefix, 0)
+}

--- a/vendor/k8s.io/kubernetes/pkg/version/verflag/verflag.go
+++ b/vendor/k8s.io/kubernetes/pkg/version/verflag/verflag.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package verflag defines utility functions to handle command line flags
+// related to version of Kubernetes.
+package verflag
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	flag "github.com/spf13/pflag"
+	"k8s.io/kubernetes/pkg/version"
+)
+
+type versionValue int
+
+const (
+	VersionFalse versionValue = 0
+	VersionTrue  versionValue = 1
+	VersionRaw   versionValue = 2
+)
+
+const strRawVersion string = "raw"
+
+func (v *versionValue) IsBoolFlag() bool {
+	return true
+}
+
+func (v *versionValue) Get() interface{} {
+	return versionValue(*v)
+}
+
+func (v *versionValue) Set(s string) error {
+	if s == strRawVersion {
+		*v = VersionRaw
+		return nil
+	}
+	boolVal, err := strconv.ParseBool(s)
+	if boolVal {
+		*v = VersionTrue
+	} else {
+		*v = VersionFalse
+	}
+	return err
+}
+
+func (v *versionValue) String() string {
+	if *v == VersionRaw {
+		return strRawVersion
+	}
+	return fmt.Sprintf("%v", bool(*v == VersionTrue))
+}
+
+// The type of the flag as required by the pflag.Value interface
+func (v *versionValue) Type() string {
+	return "version"
+}
+
+func VersionVar(p *versionValue, name string, value versionValue, usage string) {
+	*p = value
+	flag.Var(p, name, usage)
+	// "--version" will be treated as "--version=true"
+	flag.Lookup(name).NoOptDefVal = "true"
+}
+
+func Version(name string, value versionValue, usage string) *versionValue {
+	p := new(versionValue)
+	VersionVar(p, name, value, usage)
+	return p
+}
+
+var (
+	versionFlag = Version("version", VersionFalse, "Print version information and quit")
+)
+
+// PrintAndExitIfRequested will check if the -version flag was passed
+// and, if so, print the version and exit.
+func PrintAndExitIfRequested() {
+	if *versionFlag == VersionRaw {
+		fmt.Printf("%#v\n", version.Get())
+		os.Exit(0)
+	} else if *versionFlag == VersionTrue {
+		fmt.Printf("Kubernetes %s\n", version.Get())
+		os.Exit(0)
+	}
+}


### PR DESCRIPTION
This brings Heapster inline with the conventions used by Kubernetes' GenericAPIServer.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/heapster/1286)

<!-- Reviewable:end -->
