### PR TITLE
fix monasca test

### DIFF
--- a/metrics/sinks/monasca/monasca_client_test.go
+++ b/metrics/sinks/monasca/monasca_client_test.go
@@ -102,12 +102,11 @@ func TestMonascaHealthy(t *testing.T) {
 }
 
 func TestMonascaUnhealthy(t *testing.T) {
-	// TODO: reenable once #1232 is fixed
-	t.Skip("skipping test due to #1232")
+
 	// setup
 	ksClientMock := new(keystoneClientMock)
-	monURL, _ := url.Parse("http://unexisting.monasca.com")
-	sut := &ClientImpl{ksClient: ksClientMock, monascaURL: monURL}
+	nonReachableMonURL, _ := url.Parse("http://127.0.0.1:9")
+	sut := &ClientImpl{ksClient: ksClientMock, monascaURL: nonReachableMonURL}
 	ksClientMock.On("GetToken").Return(testToken, nil).Once()
 
 	// do


### PR DESCRIPTION
Fixes failing Monasca test #1232. Monasca is the OpenStack monitoring component.

The URL unexisting.monasca.com has been resigtered :)) so the test is not failing anymore. Use localhost to make the test more stable in the future. 

(BTW port 9 is reserved for discard service. A service to test connection failures)

@taimir can you review?

fix #1232

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/heapster/1292)

<!-- Reviewable:end -->
