### PR TITLE
Remove service-cluster-ip-range flag from configs not using apiserver

### DIFF
--- a/deploy/kube-config/google/heapster-controller.yaml
+++ b/deploy/kube-config/google/heapster-controller.yaml
@@ -29,7 +29,6 @@ spec:
         - --sink=gcl
         - --poll_duration=2m
         - --stats_resolution=1m
-        - --service-cluster-ip-range=10.10.0.0/24
         volumeMounts:
         - mountPath: /etc/ssl/certs
           name: ssl-certs

--- a/deploy/kube-config/influxdb/heapster-controller.yaml
+++ b/deploy/kube-config/influxdb/heapster-controller.yaml
@@ -26,4 +26,3 @@ spec:
         - /heapster
         - --source=kubernetes:https://kubernetes.default
         - --sink=influxdb:http://monitoring-influxdb:8086
-        - --service-cluster-ip-range=10.10.0.0/24

--- a/deploy/kube-config/kafka/heapster-controller.yaml
+++ b/deploy/kube-config/kafka/heapster-controller.yaml
@@ -26,4 +26,3 @@ spec:
         - /heapster
         - --source=kubernetes:https://kubernetes.default
         - --sink=kafka:?brokers=monitoring-kafka:9092&timeseriestopic=timeseries&eventstopic=events
-        - --service-cluster-ip-range=10.10.0.0/24

--- a/deploy/kube-config/standalone-test/heapster-controller.yaml
+++ b/deploy/kube-config/standalone-test/heapster-controller.yaml
@@ -23,7 +23,6 @@ spec:
         - /heapster
         - --source=kubernetes.summary_api:''
         - --sink=log
-        - --service-cluster-ip-range=10.10.0.0/24
         volumeMounts:
         - name: ssl-certs
           mountPath: /etc/ssl/certs

--- a/deploy/kube-config/standalone-test/heapster-summary-controller.yaml
+++ b/deploy/kube-config/standalone-test/heapster-summary-controller.yaml
@@ -23,7 +23,6 @@ spec:
         - /heapster
         - --source=kubernetes.summary_api:https://kubernetes.default
         - --sink=log
-        - --service-cluster-ip-range=10.10.0.0/24
         volumeMounts:
         - name: ssl-certs
           mountPath: /etc/ssl/certs

--- a/deploy/kube-config/standalone/heapster-controller.yaml
+++ b/deploy/kube-config/standalone/heapster-controller.yaml
@@ -25,7 +25,6 @@ spec:
         command:
         - /heapster
         - --source=kubernetes:https://kubernetes.default
-        - --service-cluster-ip-range=10.10.0.0/24
         volumeMounts:
         - name: ssl-certs
           mountPath: /etc/ssl/certs


### PR DESCRIPTION
This flag was needed before the "api-server" flag was introduced. Now it's only obligatory if the API server is enabled.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/heapster/1318)

<!-- Reviewable:end -->
