### PR TITLE
Add support for scoped tokens in Monasca Sink

### DIFF
--- a/docs/sink-configuration.md
+++ b/docs/sink-configuration.md
@@ -105,7 +105,7 @@ To use the Monasca sink add the following flag:
 	--sink=monasca:[?<OPTIONS>]
 
 The available options are listed below, and some of them are mandatory. You need to provide access to the Identity service of OpenStack (keystone).
-Currently, only authorization through `username` / `userID` + `password` / `APIKey` is supported.
+Currently, only authorization through `username` / `userID` + `password` / `APIKey` is supported. If the agent access (for sending metrics) to Monasca is restricted to a role, please specify the corresponding `tenant-id` for automatic scoped authorization.
 
 The Monasca sink is then created with either the provided Monasca API Server URL, or the URL is discovered automatically if none is provided by the user.
 

--- a/metrics/sinks/monasca/driver_test.go
+++ b/metrics/sinks/monasca/driver_test.go
@@ -104,7 +104,7 @@ func TestWrongMonascaURLError(t *testing.T) {
 	assert.Error(t, err)
 }
 
-// test the successful creation of the monasca
+// test the successful creation of the monasca sink
 func TestMonascaSinkCreation(t *testing.T) {
 	// setup
 	uri, _ := url.Parse("monasca:?keystone-url=" + testConfig.IdentityEndpoint + "&password=" +

--- a/metrics/sinks/monasca/keystone_client.go
+++ b/metrics/sinks/monasca/keystone_client.go
@@ -123,7 +123,16 @@ func (ksClient *KeystoneClientImpl) GetToken() (string, error) {
 
 // generates a brand new Keystone token
 func (ksClient *KeystoneClientImpl) newToken() (string, error) {
-	token, err := tokens.Create(ksClient.client, ksClient.opts, nil).Extract()
+	opts := ksClient.opts
+	var scope *tokens.Scope
+	if opts.TenantID != "" {
+		scope = &tokens.Scope{
+			ProjectID: opts.TenantID,
+		}
+		opts.TenantID = ""
+		opts.TenantName = ""
+	}
+	token, err := tokens.Create(ksClient.client, opts, scope).Extract()
 	if err != nil {
 		return "", err
 	}

--- a/metrics/sinks/monasca/keystone_client_test.go
+++ b/metrics/sinks/monasca/keystone_client_test.go
@@ -34,7 +34,7 @@ func TestMonascaURLDiscovery(t *testing.T) {
 	assert.Equal(t, monURL.String(), monascaAPIStub.URL)
 }
 
-func TestGetTokenWhenMissing(t *testing.T) {
+func TestCreateUnscopedToken(t *testing.T) {
 	// setup
 	ksClient, err := NewKeystoneClient(testConfig)
 	assert.NoError(t, err)
@@ -45,6 +45,20 @@ func TestGetTokenWhenMissing(t *testing.T) {
 	// assert
 	assert.NoError(t, err)
 	assert.Equal(t, token, testToken)
+}
+
+func TestCreateScopedToken(t *testing.T) {
+	// setup
+	scopedConfig := testConfig
+	scopedConfig.TenantID = testTenantID
+	ksClient, err := NewKeystoneClient(scopedConfig)
+
+	// do
+	token, err := ksClient.GetToken()
+
+	// assert
+	assert.NoError(t, err)
+	assert.Equal(t, token, testScopedToken)
 }
 
 func TestGetTokenWhenInvalid(t *testing.T) {


### PR DESCRIPTION
In practice most Monasca monitoring setups require an authorization role for the monasca metric collecting agents (hear the heapster monasca sink). Since roles are only associated with scope authorization, this needs to be supported.

The required change is in the `keystone_client.go`, where a scope is added to the token creation request if `TenantID` has been provided by the user. Note that the currently used version of `gophercloud` (OpenStack client) requires that there is no `TenantID` field in the AuthOpts passed to a token creation request, that's why it needs to be set to empty.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/heapster/1324)

<!-- Reviewable:end -->
