### PR TITLE
Updating Grafana to version 3.1.1

### DIFF
--- a/deploy/kube-config/influxdb/grafana-deployment.yaml
+++ b/deploy/kube-config/influxdb/grafana-deployment.yaml
@@ -16,7 +16,7 @@ spec:
         emptyDir: {}
       containers:
       - name: grafana
-        image: kubernetes/heapster_grafana:v2.6.0
+        image: gcr.io/google_containers/heapster_grafana:v3.1.1
         ports:
           - containerPort: 3000
             protocol: TCP

--- a/grafana/RELEASES.md
+++ b/grafana/RELEASES.md
@@ -1,5 +1,8 @@
 # Release Notes for Grafana container.
 
+## 3.1.1 (24-11-2016) 
+- Support Grafana 3.1.1.
+
 ## 2.6.0-2 (29-02-2016)
 - Handle new Influxdb format
 - Updated dashboards
@@ -17,4 +20,3 @@
 ## 2.1.0 (9-28-2015)
 - Support Grafana 2.1.0.
 - Auto populate pods and nodes using Grafana templates.
-


### PR DESCRIPTION
Updated Grafana to version 3.1.1, tested using [this docker image](https://hub.docker.com/r/evergreenitco/heapster_grafana/) on Kubernetes version 1.3.6.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/heapster/1325)

<!-- Reviewable:end -->
