### PR TITLE
improved error logging when creating monasca sink

### DIFF
--- a/metrics/sinks/monasca/monasca_client_test.go
+++ b/metrics/sinks/monasca/monasca_client_test.go
@@ -94,10 +94,10 @@ func TestMonascaHealthy(t *testing.T) {
 	ksClientMock.On("GetToken").Return(testToken, nil).Once()
 
 	// do
-	healthy := sut.CheckHealth()
+	err := sut.CheckHealth()
 
 	// assert
-	assert.True(t, healthy)
+	assert.NoError(t, err)
 	ksClientMock.AssertExpectations(t)
 }
 
@@ -110,9 +110,9 @@ func TestMonascaUnhealthy(t *testing.T) {
 	ksClientMock.On("GetToken").Return(testToken, nil).Once()
 
 	// do
-	healthy := sut.CheckHealth()
+	err := sut.CheckHealth()
 
 	// assert
-	assert.False(t, healthy)
+	assert.Error(t, err)
 	ksClientMock.AssertExpectations(t)
 }


### PR DESCRIPTION
I improved the error logging when trying to connect to OpenStack Monasca.

In the current code the error object is dropped in the first line of the CheckHealth() and replaced with a boolean. As a result it was not obvious why a connection attempt failed.

Refactored everything accordingly

Comment: I assume this is some refactoring left over when porting monasca sink from heapster version 0.1 to 0.2

@taimir could you please review

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/heapster/1337)

<!-- Reviewable:end -->
