### PR TITLE
Add troubleshooting information regarding using heapster and autoscaler

### DIFF
--- a/docs/influxdb.md
+++ b/docs/influxdb.md
@@ -36,3 +36,5 @@ Grafana is set up to auto-populate nodes and pods using templates.
 2. To access the InfluxDB UI, you will have to make the InfluxDB service externally visible, similar to how Grafana is made publicly accessible.
 
 3. If you find InfluxDB to be using up a lot of CPU or memory, consider placing resource restrictions on the `InfluxDB & Grafana` pod. You can add `cpu: <millicores>` and `memory: <bytes>` in the [Controller Spec](../deploy/kube-config/influxdb/influxdb-grafana-controller.yaml) and relaunch the controllers:
+
+4. Using heapster to get the autoscaler working requires CPU request set. CPU utilization is the recent CPU usage of a pod divided by the sum of CPU requested by the pod’s containers. Please note that if some of the pod’s containers do not have CPU request set, CPU utilization for the pod will not be defined and the autoscaler will not take any action.


### PR DESCRIPTION
Many users install heapster to get autoscaling working.
Maybe it's worth adding an additional point for those users to clarify the need of setting CPU request in order to get it working, since the user is able to see the metrics but unable to get it working in the autoscaler.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/heapster/1340)

<!-- Reviewable:end -->
