### PR TITLE
fixes eventer doesn't show logs

### DIFF
--- a/events/eventer.go
+++ b/events/eventer.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/heapster/events/sinks"
 	"k8s.io/heapster/events/sources"
 	"k8s.io/heapster/version"
+	"k8s.io/kubernetes/pkg/util/logs"
 )
 
 var (
@@ -42,11 +43,15 @@ var (
 func main() {
 	quitChannel := make(chan struct{}, 0)
 
-	defer glog.Flush()
 	flag.Var(&argSources, "source", "source(s) to read events from")
 	flag.Var(&argSinks, "sink", "external sink(s) that receive events")
 	flag.Parse()
+
+	logs.InitLogs()
+	defer logs.FlushLogs()
+
 	setMaxProcs()
+
 	glog.Infof(strings.Join(os.Args, " "))
 	glog.Infof("Eventer version %v", version.HeapsterVersion)
 	if err := validateFlags(); err != nil {


### PR DESCRIPTION
This fixes a bug due to refactoring the `main.go` which caused the logs to not showing up.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/heapster/1347)

<!-- Reviewable:end -->
