### PR TITLE
add version info for heapster/eventer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: false
-
 language: go
 
 go_import_path: k8s.io/heapster

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 all: build
 
-TAG = v1.2.0
 PREFIX = gcr.io/google_containers
 FLAGS = 
+
+VERSION = v1.2.0
+GIT_COMMIT := `git rev-parse --short HEAD`
 
 SUPPORTED_KUBE_VERSIONS = "1.4.6"
 TEST_NAMESPACE = heapster-e2e-tests
@@ -11,8 +13,8 @@ deps:
 	which godep || go get github.com/tools/godep
 
 build: clean deps
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 godep go build -o heapster k8s.io/heapster/metrics
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 godep go build -o eventer k8s.io/heapster/events
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 godep go build -ldflags "-X k8s.io/heapster/version.HeapsterVersion=$(VERSION) -X k8s.io/heapster/version.GitCommit=$(GIT_COMMIT)" -o heapster k8s.io/heapster/metrics
+	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 godep go build -ldflags "-X k8s.io/heapster/version.HeapsterVersion=$(VERSION) -X k8s.io/heapster/version.GitCommit=$(GIT_COMMIT)" -o eventer k8s.io/heapster/events
 
 sanitize:
 	hooks/check_boilerplate.sh
@@ -31,13 +33,13 @@ test-integration: clean deps build
 container: build
 	cp heapster deploy/docker/heapster
 	cp eventer deploy/docker/eventer
-	docker build -t $(PREFIX)/heapster:$(TAG) deploy/docker/
+	docker build -t $(PREFIX)/heapster:$(VERSION) deploy/docker/
 
 grafana:
-	docker build -t $(PREFIX)/heapster_grafana:$(TAG) grafana/
+	docker build -t $(PREFIX)/heapster_grafana:$(VERSION) grafana/
 
 influxdb:
-	docker build -t $(PREFIX)/heapster_influxdb:$(TAG) influxdb/
+	docker build -t $(PREFIX)/heapster_influxdb:$(VERSION) influxdb/
 
 clean:
 	rm -f heapster

--- a/events/eventer.go
+++ b/events/eventer.go
@@ -38,6 +38,7 @@ var (
 	argMaxProcs  = flag.Int("max_procs", 0, "max number of CPUs that can be used simultaneously. Less than 1 for default (number of cores)")
 	argSources   flags.Uris
 	argSinks     flags.Uris
+	argVersion   bool
 )
 
 func main() {
@@ -45,7 +46,13 @@ func main() {
 
 	flag.Var(&argSources, "source", "source(s) to read events from")
 	flag.Var(&argSinks, "sink", "external sink(s) that receive events")
+	flag.BoolVar(&argVersion, "version", false, "print version info and exit")
 	flag.Parse()
+
+	if argVersion {
+		fmt.Println(version.VersionInfo())
+		os.Exit(0)
+	}
 
 	logs.InitLogs()
 	defer logs.FlushLogs()

--- a/metrics/heapster.go
+++ b/metrics/heapster.go
@@ -49,7 +49,6 @@ import (
 	"k8s.io/kubernetes/pkg/healthz"
 	"k8s.io/kubernetes/pkg/util/flag"
 	"k8s.io/kubernetes/pkg/util/logs"
-	"k8s.io/kubernetes/pkg/version/verflag"
 )
 
 func main() {
@@ -57,9 +56,14 @@ func main() {
 	opt.AddFlags(pflag.CommandLine)
 
 	flag.InitFlags()
+
+	if opt.Version {
+		fmt.Println(version.VersionInfo())
+		os.Exit(0)
+	}
+
 	logs.InitLogs()
 	defer logs.FlushLogs()
-	verflag.PrintAndExitIfRequested()
 
 	setMaxProcs(opt)
 	glog.Infof(strings.Join(os.Args, " "))

--- a/metrics/options/options.go
+++ b/metrics/options/options.go
@@ -37,6 +37,7 @@ type HeapsterRunOptions struct {
 	Sources          flags.Uris
 	Sinks            flags.Uris
 	HistoricalSource string
+	Version          bool
 }
 
 func NewHeapsterRunOptions() *HeapsterRunOptions {
@@ -65,4 +66,5 @@ func (h *HeapsterRunOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&h.TLSClientCAFile, "tls_client_ca", "", "file containing TLS client CA for client cert validation")
 	fs.StringVar(&h.AllowedUsers, "allowed_users", "", "comma-separated list of allowed users")
 	fs.StringVar(&h.HistoricalSource, "historical_source", "", "which source type to use for the historical API (should be exactly the same as one of the sink URIs), or empty to disable the historical API")
+	fs.BoolVar(&h.Version, "version", false, "print version info and exit")
 }

--- a/version/version.go
+++ b/version/version.go
@@ -14,9 +14,18 @@
 
 package version
 
+import "fmt"
+
 // Heapster version. Update this whenever making a new release.
 // The version is of the format Major.Minor.Patch
 // Increment major number for new feature additions and behavioral changes.
 // Increment minor number for bug fixes and performance enhancements.
 // Increment patch number for critical fixes to existing releases.
-const HeapsterVersion = "1.2.0"
+var HeapsterVersion string
+
+// Heapster git short commit hash.
+var GitCommit string
+
+func VersionInfo() string {
+	return fmt.Sprintf("version: %s\ncommit: %s", HeapsterVersion, GitCommit)
+}


### PR DESCRIPTION
Currently, Heapster supports print version info with `--version` command line option. It utilizes [the version package from Kubernetes](https://github.com/kubernetes/kubernetes/tree/master/pkg/version) and the output is useless when i just run `heapster --version`. 

IMO, Kubernetes is used to distributed with binary, we need the info about `GitVersion`, `GitCommit`, `BuildDate`, `GoVersion` and so on to determine which go version it is built and when it is built cause it is build by others. Heapster is mainly distributed with source code. So, i think what we mainly need is the version and git commit hash value.

Version info is not hard coded in the version package in Heapster. To be more like a gopher, we can use the `-ldflags` to set the version info when compile. :)

Also, currently, `Eventer` does not support print version info with `--version`.

This PR will remove the use of version package from Kubernetes, and write the simple  process about printing the version and git commit hash info with `-ldflags`.

fix #714

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/heapster/1364)
<!-- Reviewable:end -->
