### PR TITLE
add gofmt to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,10 @@ TEST_NAMESPACE = heapster-e2e-tests
 deps:
 	which godep || go get github.com/tools/godep
 
-build: clean deps
+fmt:
+	find . -type f -name "*.go" | grep -v "./vendor*" | xargs gofmt -s -w
+
+build: clean deps fmt
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 godep go build -ldflags "-w -X k8s.io/heapster/version.HeapsterVersion=$(VERSION) -X k8s.io/heapster/version.GitCommit=$(GIT_COMMIT)" -o heapster k8s.io/heapster/metrics
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 godep go build -ldflags "-w -X k8s.io/heapster/version.HeapsterVersion=$(VERSION) -X k8s.io/heapster/version.GitCommit=$(GIT_COMMIT)" -o eventer k8s.io/heapster/events
 

--- a/metrics/processors/pod_based_enricher_test.go
+++ b/metrics/processors/pod_based_enricher_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 var batches = []*core.DataBatch{
-	&core.DataBatch{
+	{
 		Timestamp: time.Now(),
 		MetricSets: map[string]*core.MetricSet{
 			core.PodContainerKey("ns1", "pod1", "c1"): {
@@ -51,7 +51,7 @@ var batches = []*core.DataBatch{
 			},
 		},
 	},
-	&core.DataBatch{
+	{
 		Timestamp: time.Now(),
 		MetricSets: map[string]*core.MetricSet{
 			core.PodContainerKey("ns1", "pod1", "c1"): {
@@ -65,7 +65,7 @@ var batches = []*core.DataBatch{
 			},
 		},
 	},
-	&core.DataBatch{
+	{
 		Timestamp: time.Now(),
 		MetricSets: map[string]*core.MetricSet{
 			core.PodKey("ns1", "pod1"): {

--- a/metrics/processors/rate_calculator_test.go
+++ b/metrics/processors/rate_calculator_test.go
@@ -38,12 +38,12 @@ func TestRateCalculator(t *testing.T) {
 					core.LabelMetricSetType.Key: core.MetricSetTypePodContainer,
 				},
 				MetricValues: map[string]core.MetricValue{
-					core.MetricCpuUsage.MetricDescriptor.Name: core.MetricValue{
+					core.MetricCpuUsage.MetricDescriptor.Name: {
 						ValueType:  core.ValueInt64,
 						MetricType: core.MetricCumulative,
 						IntValue:   947130377781,
 					},
-					core.MetricNetworkTxErrors.MetricDescriptor.Name: core.MetricValue{
+					core.MetricNetworkTxErrors.MetricDescriptor.Name: {
 						ValueType:  core.ValueInt64,
 						MetricType: core.MetricCumulative,
 						IntValue:   0,
@@ -65,12 +65,12 @@ func TestRateCalculator(t *testing.T) {
 					core.LabelMetricSetType.Key: core.MetricSetTypePodContainer,
 				},
 				MetricValues: map[string]core.MetricValue{
-					core.MetricCpuUsage.MetricDescriptor.Name: core.MetricValue{
+					core.MetricCpuUsage.MetricDescriptor.Name: {
 						ValueType:  core.ValueInt64,
 						MetricType: core.MetricCumulative,
 						IntValue:   948071062732,
 					},
-					core.MetricNetworkTxErrors.MetricDescriptor.Name: core.MetricValue{
+					core.MetricNetworkTxErrors.MetricDescriptor.Name: {
 						ValueType:  core.ValueInt64,
 						MetricType: core.MetricCumulative,
 						IntValue:   120,

--- a/metrics/sinks/monasca/data_test.go
+++ b/metrics/sinks/monasca/data_test.go
@@ -29,8 +29,8 @@ var testInput = &core.DataBatch{
 	MetricSets: map[string]*core.MetricSet{
 		"set1": {
 			MetricValues: map[string]core.MetricValue{
-				"m2": core.MetricValue{ValueType: core.ValueInt64, IntValue: 2 ^ 63},
-				"m3": core.MetricValue{ValueType: core.ValueFloat, FloatValue: -1023.0233},
+				"m2": {ValueType: core.ValueInt64, IntValue: 2 ^ 63},
+				"m3": {ValueType: core.ValueFloat, FloatValue: -1023.0233},
 			},
 			Labels: map[string]string{
 				core.LabelHostname.Key: "h1",

--- a/metrics/sinks/opentsdb/driver_test.go
+++ b/metrics/sinks/opentsdb/driver_test.go
@@ -190,7 +190,7 @@ func generateMetricSet(name string, metricType core.MetricType, value int64) *co
 	return &core.MetricSet{
 		Labels: fakeLabel,
 		MetricValues: map[string]core.MetricValue{
-			name: core.MetricValue{
+			name: {
 				MetricType: metricType,
 				ValueType:  core.ValueInt64,
 				IntValue:   value,

--- a/metrics/sources/kubelet/kubelet_test.go
+++ b/metrics/sources/kubelet/kubelet_test.go
@@ -255,7 +255,7 @@ func TestDecodeMetrics6(t *testing.T) {
 					LoadAverage: 20,
 				},
 				CustomMetrics: map[string][]cadvisor_api.MetricVal{
-					"test1": []cadvisor_api.MetricVal{
+					"test1": {
 						{
 							Label:      "test1",
 							Timestamp:  time.Now(),
@@ -263,7 +263,7 @@ func TestDecodeMetrics6(t *testing.T) {
 							FloatValue: 1.0,
 						},
 					},
-					"test2": []cadvisor_api.MetricVal{
+					"test2": {
 						{
 							Label:      "test2",
 							Timestamp:  time.Now(),
@@ -271,7 +271,7 @@ func TestDecodeMetrics6(t *testing.T) {
 							FloatValue: 1.0,
 						},
 					},
-					"test3": []cadvisor_api.MetricVal{
+					"test3": {
 						{
 							Label:      "test3",
 							Timestamp:  time.Now(),
@@ -279,7 +279,7 @@ func TestDecodeMetrics6(t *testing.T) {
 							FloatValue: 1.0,
 						},
 					},
-					"test4": []cadvisor_api.MetricVal{
+					"test4": {
 						{
 							Label:      "test4",
 							Timestamp:  time.Now(),
@@ -297,7 +297,7 @@ func TestDecodeMetrics6(t *testing.T) {
 }
 
 var nodes = []kube_api.Node{
-	kube_api.Node{
+	{
 		ObjectMeta: kube_api.ObjectMeta{
 			Name: "testNode",
 		},
@@ -320,7 +320,7 @@ var nodes = []kube_api.Node{
 			},
 		},
 	},
-	kube_api.Node{
+	{
 		ObjectMeta: kube_api.ObjectMeta{
 			Name: "testNode",
 		},
@@ -343,7 +343,7 @@ var nodes = []kube_api.Node{
 			},
 		},
 	},
-	kube_api.Node{
+	{
 		ObjectMeta: kube_api.ObjectMeta{
 			Name: "testNode",
 		},


### PR DESCRIPTION
This PR add gofmt to Makefile.

```
fmt:
	find . -type f -name "*.go" | grep -v "./vendor*" | xargs gofmt -s -w

build: clean deps fmt
	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 godep go build -o heapster k8s.io/heapster/metrics
	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 godep go build -o eventer k8s.io/heapster/events

```

* run `make fmt` to gofmt the code
* `fmt` will be run automatically when `make build`

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/heapster/1368)
<!-- Reviewable:end -->
