### PR TITLE
fix es sink doc

### DIFF
--- a/docs/sink-configuration.md
+++ b/docs/sink-configuration.md
@@ -163,7 +163,7 @@ to be configured for the ElasticSearch sink. To do this, you can set
 `ES_SERVER_URL` to a dummy value, and use the `?nodes=` query value for each
 additional node in the cluster. For example:
 ```
-  --sink=elasticsearch:?nodes=foo.com:9200&nodes=bar.com:9200
+  --sink=elasticsearch:?nodes=http://foo.com:9200&nodes=http://bar.com:9200
 ```
 (*) Notice that using the `?nodes` notation will override the `ES_SERVER_URL`
 
@@ -186,11 +186,11 @@ Besides this, the following options can be set in query string:
 
 Like this:
 
-    --sink="elasticsearch:?nodes=0.0.0.0:9200&Index=testMetric"
+    --sink="elasticsearch:?nodes=http://127.0.0.1:9200&Index=testMetric"
 
 	or
 
-	--sink="elasticsearch:?nodes=0.0.0.0:9200&Index=testEvent"
+	--sink="elasticsearch:?nodes=http://127.0.0.1:9200&Index=testEvent"
 
 #### AWS Integration
 In order to use AWS Managed Elastic we need to use one of the following methods:


### PR DESCRIPTION
I have test that when we use es sink to store metrics and events, we should specify the "http://" prefix, otherwise i got error like below with ElasticSearch 2.4.1, kibana 4.6.2 and eventer 1.2.0.

```
andy@localhost:~/go/src/k8s.io/heapster$ ./eventer -logtostderr=false -log_dir=/home/andy/log -v=4 -max_procs=4 --frequency=5s -sink="elasticsearch:?nodes=127.0.0.1:9200&Index=eventer&maxRetries=3" -source="kubernetes:http://127.0.0.1:8080?inClusterConfig=false"
E1110 15:28:38.747801   64037 factory.go:53] Failed to create sink: Failed to create ElasticSearch client: no Elasticsearch node available
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/heapster/1374)
<!-- Reviewable:end -->
