### PR TITLE
added url param to force ipv4 or ipv6 mode

### DIFF
--- a/metrics/sources/kubelet/configs.go
+++ b/metrics/sources/kubelet/configs.go
@@ -57,11 +57,19 @@ func GetKubeConfigs(uri *url.URL) (*kube_client.Config, *kubelet_client.KubeletC
 			return nil, nil, err
 		}
 	}
+
+	ipMode := ""
+	if len(opts["ipMode"]) >= 1 {
+		ipMode = opts["ipMode"][0]
+		glog.Infof("Using IP mode %s", ipMode)
+	}
+
 	glog.Infof("Using Kubernetes client with master %q and version %+v\n", kubeConfig.Host, kubeConfig.GroupVersion)
 	glog.Infof("Using kubelet port %d", kubeletPort)
 
 	kubeletConfig := &kubelet_client.KubeletClientConfig{
 		Port:            uint(kubeletPort),
+		IpMode:          string(ipMode),
 		EnableHttps:     kubeletHttps,
 		TLSClientConfig: kubeConfig.TLSClientConfig,
 		BearerToken:     kubeConfig.BearerToken,

--- a/metrics/sources/kubelet/configs.go
+++ b/metrics/sources/kubelet/configs.go
@@ -58,18 +58,11 @@ func GetKubeConfigs(uri *url.URL) (*kube_client.Config, *kubelet_client.KubeletC
 		}
 	}
 
-	ipMode := ""
-	if len(opts["ipMode"]) >= 1 {
-		ipMode = opts["ipMode"][0]
-		glog.Infof("Using IP mode %s", ipMode)
-	}
-
 	glog.Infof("Using Kubernetes client with master %q and version %+v\n", kubeConfig.Host, kubeConfig.GroupVersion)
 	glog.Infof("Using kubelet port %d", kubeletPort)
 
 	kubeletConfig := &kubelet_client.KubeletClientConfig{
 		Port:            uint(kubeletPort),
-		IpMode:          string(ipMode),
 		EnableHttps:     kubeletHttps,
 		TLSClientConfig: kubeConfig.TLSClientConfig,
 		BearerToken:     kubeConfig.BearerToken,

--- a/metrics/sources/kubelet/kubelet_test.go
+++ b/metrics/sources/kubelet/kubelet_test.go
@@ -372,9 +372,48 @@ var nodes = []kube_api.Node{
 	},
 }
 
+var IpV6Nodes = []kube_api.Node{
+	kube_api.Node{
+		ObjectMeta: kube_api.ObjectMeta{
+			Name: "testNode",
+		},
+		Status: kube_api.NodeStatus{
+			Conditions: []kube_api.NodeCondition{
+				{
+					Type:   "NotReady",
+					Status: kube_api.ConditionTrue,
+				},
+			},
+			Addresses: []kube_api.NodeAddress{
+				{
+					Type:    kube_api.NodeHostName,
+					Address: "testNode",
+				},
+				{
+					Type:    kube_api.NodeInternalIP,
+					Address: "::1",
+				},
+				{
+					Type:    kube_api.NodeInternalIP,
+					Address: "127.0.0.1",
+				},
+			},
+		},
+	},
+}
+
+func TestGetNodeHostnameAndIpV4(t *testing.T) {
+	for _, node := range IpV6Nodes {
+		hostname, ip, err := getNodeHostnameAndIP(&node, "ipv6")
+		assert.NoError(t, err)
+		assert.Equal(t, hostname, "testNode")
+		assert.Equal(t, ip, "::1")
+	}
+}
+
 func TestGetNodeHostnameAndIP(t *testing.T) {
 	for _, node := range nodes {
-		hostname, ip, err := getNodeHostnameAndIP(&node)
+		hostname, ip, err := getNodeHostnameAndIP(&node, "")
 		assert.NoError(t, err)
 		assert.Equal(t, hostname, "testNode")
 		assert.Equal(t, ip, "127.0.0.1")


### PR DESCRIPTION
This PR allowed the user to pass a URL parameter with the `source` argument when executing `heapster`, effectively forcing the IP scraper to get the first IP it encounters of the specified type.

Name: `ipMode`
Valid options: `4, v4, ipv4` || `6, 16, v6, ipv6`

```
...
heapster --source=kubernetes:https://foo.default?ipMode=v4 --sink=...
```

Without this parameter, the application should behave as it did before, selecting the first IP it encounters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/heapster/1378)
<!-- Reviewable:end -->
