### PR TITLE
[ES] enhance es mapping for event

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: false
-
 language: go
 
 go_import_path: k8s.io/heapster

--- a/common/elasticsearch/mapping.go
+++ b/common/elasticsearch/mapping.go
@@ -141,6 +141,22 @@ const mapping = `{
       "properties": {
         "EventTags": {
           "properties": {
+            "eventType": {
+              "type": "string",
+              "index": "not_analyzed"
+            },
+            "eventKind": {
+              "type": "string",
+              "index": "not_analyzed"
+            },
+            "eventReason": {
+              "type": "string",
+              "index": "not_analyzed"
+            },
+            "eventMessage": {
+              "type": "string",
+              "index": "analyzed"
+            },
             "eventID": {
               "type": "string",
               "index": "not_analyzed"

--- a/events/sinks/elasticsearch/driver.go
+++ b/events/sinks/elasticsearch/driver.go
@@ -67,12 +67,17 @@ func eventToPoint(event *kube_api.Event) (*EsSinkPoint, error) {
 		EventTimestamp: event.LastTimestamp.Time.UTC(),
 		EventValue:     value,
 		EventTags: map[string]string{
-			"eventID": string(event.UID),
+			"eventID":      string(event.UID),
+			"eventType":    event.Type,
+			"eventKind":    event.InvolvedObject.Kind,
+			"eventReason":  event.Reason,
+			"eventMessage": event.Message,
 		},
 	}
 	if event.InvolvedObject.Kind == "Pod" {
 		point.EventTags[core.LabelPodId.Key] = string(event.InvolvedObject.UID)
 		point.EventTags[core.LabelPodName.Key] = event.InvolvedObject.Name
+		point.EventTags[core.LabelPodNamespace.Key] = event.InvolvedObject.Namespace
 	}
 	point.EventTags[core.LabelHostname.Key] = event.Source.Host
 	return &point, nil


### PR DESCRIPTION
This PR adds support for adding more info for analyze events in ElasticSearch. This PR adds `EventType`, `EventKind`, `EventReason` and `EventMessage` as tags and thus allows us to query based on them. Such as, what are the warning events in last two hours. When does the cluster emits `FailedScheduling` events.

This PR also adds the **namespace** tag info when the event is of Pod kind.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/heapster/1379)
<!-- Reviewable:end -->
