### PR TITLE
Add cluster tag for es event

### DIFF
--- a/common/elasticsearch/elasticsearch.go
+++ b/common/elasticsearch/elasticsearch.go
@@ -27,13 +27,15 @@ import (
 )
 
 const (
-	ESIndex = "heapster"
+	ESIndex       = "heapster"
+	ESClusterName = "default"
 )
 
 type ElasticSearchService struct {
 	EsClient      *elastic.Client
 	bulkProcessor *elastic.BulkProcessor
 	baseIndex     string
+	ClusterName   string
 }
 
 func (esSvc *ElasticSearchService) Index(date time.Time) string {
@@ -107,6 +109,11 @@ func CreateElasticSearchService(uri *url.URL) (*ElasticSearchService, error) {
 	opts, err := url.ParseQuery(uri.RawQuery)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to parser url's query string: %s", err)
+	}
+
+	esSvc.ClusterName = ESClusterName
+	if len(opts["cluster_name"]) > 0 {
+		esSvc.ClusterName = opts["cluster_name"][0]
 	}
 
 	// set the index for es,the default value is "heapster"

--- a/common/elasticsearch/elasticsearch_test.go
+++ b/common/elasticsearch/elasticsearch_test.go
@@ -20,11 +20,17 @@ import (
 	"testing"
 	"time"
 
+	"fmt"
 	"gopkg.in/olivere/elastic.v3"
 )
 
 func TestCreateElasticSearchService(t *testing.T) {
-	url, err := url.Parse("?nodes=https://foo.com:20468&nodes=https://bar.com:20468&esUserName=test&esUserSecret=password&maxRetries=10&startupHealthcheckTimeout=30&sniff=false&healthCheck=false")
+	clusterName := "sandbox"
+	esURI := fmt.Sprintf("?nodes=https://foo.com:20468&nodes=https://bar.com:20468&"+
+		"esUserName=test&esUserSecret=password&maxRetries=10&startupHealthcheckTimeout=30&"+
+		"sniff=false&healthCheck=false&cluster_name=%s", clusterName)
+
+	url, err := url.Parse(esURI)
 	if err != nil {
 		t.Fatalf("Error when parsing URL: %s", err.Error())
 	}
@@ -49,21 +55,44 @@ func TestCreateElasticSearchService(t *testing.T) {
 	expectedClientRefl := reflect.ValueOf(expectedClient).Elem()
 
 	if actualClientRefl.FieldByName("basicAuthUsername").String() != expectedClientRefl.FieldByName("basicAuthUsername").String() {
-		t.Fatalf("basicAuthUsername is not equal")
+		t.Fatal("basicAuthUsername is not equal")
 	}
 	if actualClientRefl.FieldByName("basicAuthUsername").String() != expectedClientRefl.FieldByName("basicAuthUsername").String() {
-		t.Fatalf("basicAuthUsername is not equal")
+		t.Fatal("basicAuthUsername is not equal")
 	}
 	if actualClientRefl.FieldByName("maxRetries").Int() != expectedClientRefl.FieldByName("maxRetries").Int() {
-		t.Fatalf("maxRetries is not equal")
+		t.Fatal("maxRetries is not equal")
 	}
 	if actualClientRefl.FieldByName("healthcheckTimeoutStartup").Int() != expectedClientRefl.FieldByName("healthcheckTimeoutStartup").Int() {
-		t.Fatalf("healthcheckTimeoutStartup is not equal")
+		t.Fatal("healthcheckTimeoutStartup is not equal")
 	}
 	if actualClientRefl.FieldByName("snifferEnabled").Bool() != expectedClientRefl.FieldByName("snifferEnabled").Bool() {
-		t.Fatalf("snifferEnabled is not equal")
+		t.Fatal("snifferEnabled is not equal")
 	}
 	if actualClientRefl.FieldByName("healthcheckEnabled").Bool() != expectedClientRefl.FieldByName("healthcheckEnabled").Bool() {
-		t.Fatalf("healthcheckEnabled is not equal")
+		t.Fatal("healthcheckEnabled is not equal")
+	}
+	if esSvc.ClusterName != clusterName {
+		t.Fatal("cluster name is not equal")
+	}
+}
+
+func TestCreateElasticSearchServiceForDefaultClusterName(t *testing.T) {
+	esURI := "?nodes=https://foo.com:20468&nodes=https://bar.com:20468&" +
+		"esUserName=test&esUserSecret=password&maxRetries=10&startupHealthcheckTimeout=30&" +
+		"sniff=false&healthCheck=false"
+
+	url, err := url.Parse(esURI)
+	if err != nil {
+		t.Fatalf("Error when parsing URL: %s", err.Error())
+	}
+
+	esSvc, err := CreateElasticSearchService(url)
+	if err != nil {
+		t.Fatalf("Error when creating config: %s", err.Error())
+	}
+
+	if esSvc.ClusterName != ESClusterName {
+		t.Fatalf("cluster name is not equal. Expected: %s, Got: %s", ESClusterName, esSvc.ClusterName)
 	}
 }

--- a/common/elasticsearch/mapping.go
+++ b/common/elasticsearch/mapping.go
@@ -14,8 +14,9 @@
 package elasticsearch
 
 import (
-	"k8s.io/heapster/metrics/core"
 	"strings"
+
+	"k8s.io/heapster/metrics/core"
 )
 
 func MetricFamilyTimestamp(metricFamily core.MetricFamily) string {
@@ -121,6 +122,10 @@ func customMetricTypeSchema(typeName string, customSchema string) string {
             }
           }
         },
+        "cluster_name": {
+          "type": "string",
+          "index": "not_analyzed"
+        },
         "pod_id": {
           "type": "string",
           "index": "not_analyzed"
@@ -198,6 +203,10 @@ var mapping = `{
         "EventTags": {
           "properties": {
             "eventID": {
+              "type": "string",
+              "index": "not_analyzed"
+            },
+            "cluster_name": {
               "type": "string",
               "index": "not_analyzed"
             },
@@ -299,7 +308,6 @@ var mapping = `{
           "type": "string",
           "index": "not_analyzed"
         },
-
         "Count": {
           "type": "long"
         },

--- a/docs/sink-configuration.md
+++ b/docs/sink-configuration.md
@@ -184,6 +184,7 @@ Besides this, the following options can be set in query string:
   a response from Elasticsearch on startup, i.e. when creating a client. The
   default value is `1`.
 * `bulkWorkers` - number of workers for bulk processing. Default value is `5`.
+* `cluster_name` - cluster name for different Kubernetes clusters. Default value is `default`.
 
 Like this:
 

--- a/metrics/sinks/elasticsearch/driver.go
+++ b/metrics/sinks/elasticsearch/driver.go
@@ -55,7 +55,7 @@ func (sink *elasticSearchSink) ExportData(dataBatch *core.DataBatch) {
 		familyPoints := EsFamilyPoints{}
 
 		for metricName, metricValue := range metricSet.MetricValues {
-			familyPoints = addMetric(familyPoints, metricName, dataBatch.Timestamp, metricSet.Labels, metricValue.GetValue())
+			familyPoints = addMetric(familyPoints, metricName, dataBatch.Timestamp, metricSet.Labels, metricValue.GetValue(), sink.esSvc.ClusterName)
 		}
 		for _, metric := range metricSet.LabeledMetrics {
 			labels := make(map[string]string)
@@ -66,7 +66,7 @@ func (sink *elasticSearchSink) ExportData(dataBatch *core.DataBatch) {
 				labels[k] = v
 			}
 
-			familyPoints = addMetric(familyPoints, metric.Name, dataBatch.Timestamp, labels, metric.GetValue())
+			familyPoints = addMetric(familyPoints, metric.Name, dataBatch.Timestamp, labels, metric.GetValue(), sink.esSvc.ClusterName)
 		}
 
 		for family, dataPoints := range familyPoints {
@@ -82,7 +82,7 @@ func (sink *elasticSearchSink) ExportData(dataBatch *core.DataBatch) {
 	}
 }
 
-func addMetric(points EsFamilyPoints, metricName string, date time.Time, tags esPointTags, value interface{}) EsFamilyPoints {
+func addMetric(points EsFamilyPoints, metricName string, date time.Time, tags esPointTags, value interface{}, clusterName string) EsFamilyPoints {
 	family := core.MetricFamilyForName(metricName)
 
 	if points[family] == nil {
@@ -92,6 +92,7 @@ func addMetric(points EsFamilyPoints, metricName string, date time.Time, tags es
 	if family == core.MetricFamilyGeneral {
 		point := EsSinkPointGeneral{}
 		point.MetricsTags = tags
+		point.MetricsTags["cluster_name"] = clusterName
 		point.GeneralMetricsTimestamp = date.UTC()
 		point.MetricsName = metricName
 		point.MetricsValue = EsPointValue(value)
@@ -111,6 +112,13 @@ func addMetric(points EsFamilyPoints, metricName string, date time.Time, tags es
 					glog.Warningf("Failed to cast metrics to map")
 				}
 
+				if tags, ok := point["MetricsTags"].(esPointTags); ok {
+					tags["cluster_name"] = clusterName
+					point["MetricsTags"] = tags
+				} else {
+					glog.Warningf("Failed to cast metricstags to map")
+				}
+
 				//add
 				points[family][idx] = point
 				return points
@@ -120,6 +128,7 @@ func addMetric(points EsFamilyPoints, metricName string, date time.Time, tags es
 
 	point := EsSinkPointFamily{}
 	point[esCommon.MetricFamilyTimestamp(family)] = date.UTC()
+	tags["cluster_name"] = clusterName
 	point["MetricsTags"] = tags
 	metrics := make(map[string]interface{})
 	metrics[metricName] = EsPointValue(value)

--- a/metrics/sinks/elasticsearch/driver_test.go
+++ b/metrics/sinks/elasticsearch/driver_test.go
@@ -57,7 +57,8 @@ func NewFakeSink() fakeESSink {
 			saveData:  SaveDataIntoES_Stub,
 			flushData: func() error { return nil },
 			esSvc: esCommon.ElasticSearchService{
-				EsClient: &elastic.Client{},
+				EsClient:    &elastic.Client{},
+				ClusterName: esCommon.ESClusterName,
 			},
 		},
 		savedData,
@@ -189,12 +190,12 @@ func TestStoreMultipleDataInput(t *testing.T) {
 	assert.Equal(t, 2, len(FakeESSink.savedData))
 
 	var expectMsgTemplate = [6]string{
-		`{"GeneralMetricsTimestamp":%s,"MetricsTags":{"namespace_id":"","pod_id":"aaaa-bbbb-cccc-dddd"},"MetricsName":"test/metric/1","MetricsValue":{"value":123456}}`,
-		`{"GeneralMetricsTimestamp":%s,"MetricsTags":{"namespace_id":"123","pod_id":"aaaa-bbbb-cccc-dddd"},"MetricsName":"removeme","MetricsValue":{"value":123456}}`,
-		`{"GeneralMetricsTimestamp":%s,"MetricsTags":{"container_name":"/system.slice/-.mount","namespace_id":"123","pod_id":"aaaa-bbbb-cccc-dddd"},"MetricsName":"/system.slice/-.mount//cpu/limit","MetricsValue":{"value":123456}}`,
-		`{"GeneralMetricsTimestamp":%s,"MetricsTags":{"container_name":"/system.slice/dbus.service","namespace_id":"123","pod_id":"aaaa-bbbb-cccc-dddd"},"MetricsName":"/system.slice/dbus.service//cpu/usage","MetricsValue":{"value":123456}}`,
-		`{"GeneralMetricsTimestamp":%s,"MetricsTags":{"namespace_id":"123","pod_id":"aaaa-bbbb-cccc-dddd"},"MetricsName":"test/metric/1","MetricsValue":{"value":123456}}`,
-		`{"CpuMetricsTimestamp":%s,"Metrics":{"cpu/limit":{"value":223456},"cpu/usage":{"value":123456}},"MetricsTags":{"container_name":"/system.slice/-.mount","namespace_id":"123","pod_id":"aaaa-bbbb-cccc-dddd"}}`,
+		`{"GeneralMetricsTimestamp":%s,"MetricsTags":{"cluster_name":"default","namespace_id":"","pod_id":"aaaa-bbbb-cccc-dddd"},"MetricsName":"test/metric/1","MetricsValue":{"value":123456}}`,
+		`{"GeneralMetricsTimestamp":%s,"MetricsTags":{"cluster_name":"default","namespace_id":"123","pod_id":"aaaa-bbbb-cccc-dddd"},"MetricsName":"removeme","MetricsValue":{"value":123456}}`,
+		`{"GeneralMetricsTimestamp":%s,"MetricsTags":{"cluster_name":"default","container_name":"/system.slice/-.mount","namespace_id":"123","pod_id":"aaaa-bbbb-cccc-dddd"},"MetricsName":"/system.slice/-.mount//cpu/limit","MetricsValue":{"value":123456}}`,
+		`{"GeneralMetricsTimestamp":%s,"MetricsTags":{"cluster_name":"default","container_name":"/system.slice/dbus.service","namespace_id":"123","pod_id":"aaaa-bbbb-cccc-dddd"},"MetricsName":"/system.slice/dbus.service//cpu/usage","MetricsValue":{"value":123456}}`,
+		`{"GeneralMetricsTimestamp":%s,"MetricsTags":{"cluster_name":"default","namespace_id":"123","pod_id":"aaaa-bbbb-cccc-dddd"},"MetricsName":"test/metric/1","MetricsValue":{"value":123456}}`,
+		`{"CpuMetricsTimestamp":%s,"Metrics":{"cpu/limit":{"value":223456},"cpu/usage":{"value":123456}},"MetricsTags":{"cluster_name":"default","container_name":"/system.slice/-.mount","namespace_id":"123","pod_id":"aaaa-bbbb-cccc-dddd"}}`,
 	}
 
 	msgsString := fmt.Sprintf("%s", FakeESSink.savedData)


### PR DESCRIPTION
fix #1383

This PR will add a new elasticsearch field `eventCluster`. A new eventer command line argument `cluster` is added to config the value for `eventCluster`.

Let me explain why we should add this option. Image that, we have one Kubernetes `A` cluster in one datacenter, i have set up one ES to collect the events from A Kubernetes cluster. Everything is OK. After some time we added the second Kubernetes cluster `B` in the same datacenter as Kubernetes `A`. We want also want to collect the events of cluster `B` using the same one ES as cluster `A`. This will make our ES operation more easy and stability with maintaining small ES clusters.  However, currently, we can not make a difference between events for cluster `A` and `B`. 

We can accomplish this by setting a `eventCluster` field in the ES mapping to distinct this. This is just like what [syslog does to with facility to distinct log sources by adding facility in the emitted log]() and what [fluentd log plugin does when emitting log info by adding `container_id` and `container_name` meta info](https://docs.docker.com/engine/admin/logging/fluentd/).

**Update for #1383**
---
This PR has been refactored to adapt for #1383. 
New PR will support ElasticSearch `cluster` parameter for both Heapster and Eventer when using ElasticSearch. 
This PR will not add any top-level command line argument to either Heapster nor Eventer. It is implemented in ElasticSearch URI configuration, just as @piosz suggests. 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/heapster/1380)
<!-- Reviewable:end -->
