### PR TITLE
skip non-ipv4 addresses when scraping node ip

### DIFF
--- a/metrics/sources/kubelet/configs.go
+++ b/metrics/sources/kubelet/configs.go
@@ -57,6 +57,7 @@ func GetKubeConfigs(uri *url.URL) (*kube_client.Config, *kubelet_client.KubeletC
 			return nil, nil, err
 		}
 	}
+
 	glog.Infof("Using Kubernetes client with master %q and version %+v\n", kubeConfig.Host, kubeConfig.GroupVersion)
 	glog.Infof("Using kubelet port %d", kubeletPort)
 

--- a/metrics/sources/kubelet/kubelet.go
+++ b/metrics/sources/kubelet/kubelet.go
@@ -302,7 +302,7 @@ func getNodeHostnameAndIP(node *kube_api.Node) (string, string, error) {
 		if addr.Type == kube_api.NodeHostName && addr.Address != "" {
 			hostname = addr.Address
 		}
-		if addr.Type == kube_api.NodeInternalIP && addr.Address != "" && ip == "" {
+		if addr.Type == kube_api.NodeInternalIP && addr.Address != "" {
 			if net.ParseIP(addr.Address).To4() != nil {
 				ip = addr.Address
 			}

--- a/metrics/sources/kubelet/kubelet.go
+++ b/metrics/sources/kubelet/kubelet.go
@@ -16,6 +16,7 @@ package kubelet
 
 import (
 	"fmt"
+	"net"
 	"net/url"
 	"strings"
 	"time"
@@ -301,8 +302,10 @@ func getNodeHostnameAndIP(node *kube_api.Node) (string, string, error) {
 		if addr.Type == kube_api.NodeHostName && addr.Address != "" {
 			hostname = addr.Address
 		}
-		if addr.Type == kube_api.NodeInternalIP && addr.Address != "" {
-			ip = addr.Address
+		if addr.Type == kube_api.NodeInternalIP && addr.Address != "" && ip == "" {
+			if net.ParseIP(addr.Address).To4() != nil {
+				ip = addr.Address
+			}
 		}
 		if addr.Type == kube_api.NodeLegacyHostIP && addr.Address != "" && ip == "" {
 			ip = addr.Address

--- a/metrics/sources/kubelet/kubelet_test.go
+++ b/metrics/sources/kubelet/kubelet_test.go
@@ -365,6 +365,10 @@ var nodes = []kube_api.Node{
 				},
 				{
 					Type:    kube_api.NodeInternalIP,
+					Address: "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+				},
+				{
+					Type:    kube_api.NodeInternalIP,
 					Address: "127.0.0.1",
 				},
 			},


### PR DESCRIPTION
fix #1311

this fixes an issue where certain clusters assign ipv6 addresses to the nodes first (or perhaps last). In either case, Heapster is scraping that ip and it results in an error (heapster cannot scrape data).

the change I made ensures that an ipv4 address is extracted from the node network data

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/heapster/1381)
<!-- Reviewable:end -->
