### PR TITLE
fail fast when there is no available sinks

### DIFF
--- a/events/eventer.go
+++ b/events/eventer.go
@@ -81,6 +81,10 @@ func main() {
 	// sinks
 	sinksFactory := sinks.NewSinkFactory()
 	sinkList := sinksFactory.BuildAll(argSinks)
+	if len([]flags.Uri(argSinks)) != 0 && len(sinkList) == 0 {
+		glog.Fatal("No available sink to use")
+	}
+
 	for _, sink := range sinkList {
 		glog.Infof("Starting with %s sink", sink.Name())
 	}

--- a/metrics/sinks/factory.go
+++ b/metrics/sinks/factory.go
@@ -87,6 +87,11 @@ func (this *SinkFactory) BuildAll(uris flags.Uris, historicalUri string) (*metri
 		}
 		result = append(result, sink)
 	}
+
+	if len([]flags.Uri(uris)) != 0 && len(result) == 0 {
+		glog.Fatal("No available sink to use")
+	}
+
 	if metric == nil {
 		uri := flags.Uri{}
 		uri.Set("metric")


### PR DESCRIPTION
I have run into a situation where i configure an `es` cluster to store Kubernetes events and the `es` configuration is invalid. After checking that `eventer` is running through `systemctl --user status eventer.service`, i leave it there to run. After some days, when i need to query `es` about the recent events, nothing was collected.  

I turns out that the `es` configuration is invalid and an error is logged, but `eventer` continues to run without fail. As `es` is the only sink i configured, this makes `eventer` got no valid sinks and even Kubernetes emits some events, the events will not be sinked to `es`. 

This PR will make `eventer` and `heapster` fail faster when there is no valid sinks.