### PR TITLE
Added option ignored_labels (IgnoredLabels) to ignore certain labels

### DIFF
--- a/metrics/heapster.go
+++ b/metrics/heapster.go
@@ -83,9 +83,13 @@ func main() {
 
 	podLister, nodeLister := getListersOrDie(kubernetesUrl)
 	dataProcessors := createDataProcessorsOrDie(kubernetesUrl, podLister)
-
+	if strings.Contains(strings.ToLower(opt.IgnoredLabels), "type=container") {
+		glog.Warning("Resource metrics for container are ignored. Certain metrics will not be reported and Horizontal Pod Autoscaling will not function!")
+	}
+	ignoredLabels := strings.Split(opt.IgnoredLabels, ",")
 	man, err := manager.NewManager(sourceManager, dataProcessors, sinkManager,
-		opt.MetricResolution, manager.DefaultScrapeOffset, manager.DefaultMaxParallelism)
+		opt.MetricResolution, manager.DefaultScrapeOffset, manager.DefaultMaxParallelism,
+		ignoredLabels)
 	if err != nil {
 		glog.Fatalf("Failed to create main manager: %v", err)
 	}

--- a/metrics/manager/manager_test.go
+++ b/metrics/manager/manager_test.go
@@ -27,7 +27,7 @@ func TestFlow(t *testing.T) {
 	sink := util.NewDummySink("sink", time.Millisecond)
 	processor := util.NewDummyDataProcessor(time.Millisecond)
 
-	manager, _ := NewManager(source, []core.DataProcessor{processor}, sink, time.Second, time.Millisecond, 1)
+	manager, _ := NewManager(source, []core.DataProcessor{processor}, sink, time.Second, time.Millisecond, 1, []string{})
 	manager.Start()
 
 	// 4-5 cycles
@@ -44,7 +44,7 @@ func TestThrottling(t *testing.T) {
 	sink := util.NewDummySink("sink", 4*time.Second)
 	processor := util.NewDummyDataProcessor(5 * time.Millisecond)
 
-	manager, _ := NewManager(source, []core.DataProcessor{processor}, sink, time.Second, time.Millisecond, 1)
+	manager, _ := NewManager(source, []core.DataProcessor{processor}, sink, time.Second, time.Millisecond, 1, []string{})
 	manager.Start()
 
 	// 4-5 cycles

--- a/metrics/options/options.go
+++ b/metrics/options/options.go
@@ -34,6 +34,7 @@ type HeapsterRunOptions struct {
 	TLSKeyFile       string
 	TLSClientCAFile  string
 	AllowedUsers     string
+	IgnoredLabels    string
 	Sources          flags.Uris
 	Sinks            flags.Uris
 	HistoricalSource string
@@ -66,6 +67,7 @@ func (h *HeapsterRunOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&h.TLSKeyFile, "tls_key", "", "file containing TLS key")
 	fs.StringVar(&h.TLSClientCAFile, "tls_client_ca", "", "file containing TLS client CA for client cert validation")
 	fs.StringVar(&h.AllowedUsers, "allowed_users", "", "comma-separated list of allowed users")
+	fs.StringVar(&h.IgnoredLabels, "ignored_labels", "", "comma-separated list of ignored namespaces")
 	fs.StringVar(&h.HistoricalSource, "historical_source", "", "which source type to use for the historical API (should be exactly the same as one of the sink URIs), or empty to disable the historical API")
 	fs.BoolVar(&h.Version, "version", false, "print version info and exit")
 	fs.StringVar(&h.LabelSeperator, "label_seperator", ",", "seperator used for joining labels")


### PR DESCRIPTION
This new option allows to ignore specific metrics by label.

In a project I'm currently working on we create about 100k pods a day, InfluxDB (1.1.0) has some problems with too many series (and tags).
In the project we also only need specific metrics, so the added option to ignore specific metrics by label, for example ignore all metric sets with `type=pod`, reduces the load and "too many series" InfluxDB problem.

***

Please let me know if there is anything I can improve. Please note that this is my first contribution to a project written in golang.