### PR TITLE
Make retention policy configurable when using influxdb

### DIFF
--- a/common/influxdb/influxdb.go
+++ b/common/influxdb/influxdb.go
@@ -32,13 +32,14 @@ type InfluxdbClient interface {
 }
 
 type InfluxdbConfig struct {
-	User        string
-	Password    string
-	Secure      bool
-	Host        string
-	DbName      string
-	WithFields  bool
-	InsecureSsl bool
+	User            string
+	Password        string
+	Secure          bool
+	Host            string
+	DbName          string
+	WithFields      bool
+	InsecureSsl     bool
+	RetentionPolicy string
 }
 
 func NewClient(c InfluxdbConfig) (InfluxdbClient, error) {
@@ -70,13 +71,14 @@ func NewClient(c InfluxdbConfig) (InfluxdbClient, error) {
 
 func BuildConfig(uri *url.URL) (*InfluxdbConfig, error) {
 	config := InfluxdbConfig{
-		User:        "root",
-		Password:    "root",
-		Host:        "localhost:8086",
-		DbName:      "k8s",
-		Secure:      false,
-		WithFields:  false,
-		InsecureSsl: false,
+		User:            "root",
+		Password:        "root",
+		Host:            "localhost:8086",
+		DbName:          "k8s",
+		Secure:          false,
+		WithFields:      false,
+		InsecureSsl:     false,
+		RetentionPolicy: "0",
 	}
 
 	if len(uri.Host) > 0 {
@@ -92,6 +94,9 @@ func BuildConfig(uri *url.URL) (*InfluxdbConfig, error) {
 	}
 	if len(opts["db"]) >= 1 {
 		config.DbName = opts["db"][0]
+	}
+	if len(opts["retention"]) >= 1 {
+		config.RetentionPolicy = opts["retention"][0]
 	}
 	if len(opts["withfields"]) >= 1 {
 		val, err := strconv.ParseBool(opts["withfields"][0])

--- a/docs/sink-configuration.md
+++ b/docs/sink-configuration.md
@@ -31,6 +31,7 @@ The following options are available:
 * `user` - InfluxDB username (default: `root`)
 * `pw` - InfluxDB password (default: `root`)
 * `db` - InfluxDB Database name (default: `k8s`)
+* `retention` - Duration of the default InfluxDB retention policy, e.g. `4h` or `7d` (default: `0` meaning infinite)
 * `secure` - Connect securely to InfluxDB (default: `false`)
 * `insecuressl` - Ignore SSL certificate validity (default: `false`)
 * `withfields` - Use [InfluxDB fields](storage-schema.md#using-fields) (default: `false`)

--- a/metrics/sinks/influxdb/influxdb.go
+++ b/metrics/sinks/influxdb/influxdb.go
@@ -197,7 +197,6 @@ func (sink *influxdbSink) createDatabase() error {
 	if sink.dbExists {
 		return nil
 	}
-
 	q := influxdb.Query{
 		Command: fmt.Sprintf(`CREATE DATABASE %s WITH NAME "default"`, sink.c.DbName),
 	}
@@ -218,7 +217,7 @@ func (sink *influxdbSink) createDatabase() error {
 
 func (sink *influxdbSink) createRetentionPolicy() error {
 	q := influxdb.Query{
-		Command: fmt.Sprintf(`CREATE RETENTION POLICY "default" ON %s DURATION 0d REPLICATION 1 DEFAULT`, sink.c.DbName),
+		Command: fmt.Sprintf(`CREATE RETENTION POLICY "default" ON %s DURATION %s REPLICATION 1 DEFAULT`, sink.c.DbName, sink.c.RetentionPolicy),
 	}
 
 	if resp, err := sink.client.Query(q); err != nil {


### PR DESCRIPTION
This makes Heapster configure the retention policy used by InfluxDB for the data Heapster stores. This will make it possible to limit Heapster data collection to a certain period of time.  In the previous situation, Heapster data is stored forever until the disk is full, and there is no way to reliably override this retention policy in a kubernetes environment. 

This fixes #566