### PR TITLE
add labels to eventer es mapping

### DIFF
--- a/common/elasticsearch/mapping.go
+++ b/common/elasticsearch/mapping.go
@@ -311,6 +311,15 @@ var mapping = `{
         "Count": {
           "type": "long"
         },
+        "Labels": {
+          "type": "string",
+          "fields": {
+            "raw": {
+              "type": "string",
+              "index": "not_analyzed"
+            }
+          }
+        },
         "Metadata": {
           "properties": {
             "creationTimestamp": {

--- a/events/sinks/elasticsearch/driver.go
+++ b/events/sinks/elasticsearch/driver.go
@@ -23,6 +23,7 @@ import (
 	esCommon "k8s.io/heapster/common/elasticsearch"
 	event_core "k8s.io/heapster/events/core"
 	"k8s.io/heapster/metrics/core"
+	"k8s.io/heapster/metrics/util"
 	kube_api "k8s.io/kubernetes/pkg/api"
 )
 
@@ -50,6 +51,7 @@ type EsSinkPoint struct {
 	Message                  string
 	Reason                   string
 	Type                     string
+	Labels                   string
 	EventTags                map[string]string
 }
 
@@ -61,6 +63,7 @@ func eventToPoint(event *kube_api.Event, clusterName string) (*EsSinkPoint, erro
 		Reason:                   event.Reason,
 		Type:                     event.Type,
 		Count:                    event.Count,
+		Labels:                   util.LabelsToString(event.ObjectMeta.Labels),
 		Metadata:                 event.ObjectMeta,
 		InvolvedObject:           event.InvolvedObject,
 		Source:                   event.Source,

--- a/events/sinks/elasticsearch/driver_test.go
+++ b/events/sinks/elasticsearch/driver_test.go
@@ -101,8 +101,8 @@ func TestStoreMultipleDataInput(t *testing.T) {
 	assert.Equal(t, 2, len(FakeESSink.savedData))
 
 	var expectMsgTemplate = [2]string{
-		`{"Count":100,"Metadata":{"creationTimestamp":null},"InvolvedObject":{},"Source":{},"FirstOccurrenceTimestamp":%s,"LastOccurrenceTimestamp":%s,"Message":"event1","Reason":"","Type":"","EventTags":{"cluster_name":"default","eventID":"","hostname":""}}`,
-		`{"Count":101,"Metadata":{"creationTimestamp":null},"InvolvedObject":{},"Source":{},"FirstOccurrenceTimestamp":%s,"LastOccurrenceTimestamp":%s,"Message":"event2","Reason":"","Type":"","EventTags":{"cluster_name":"default","eventID":"","hostname":""}}`,
+		`{"Count":100,"Metadata":{"creationTimestamp":null},"InvolvedObject":{},"Source":{},"FirstOccurrenceTimestamp":%s,"LastOccurrenceTimestamp":%s,"Message":"event1","Reason":"","Type":"","Labels":"","EventTags":{"cluster_name":"default","eventID":"","hostname":""}}`,
+		`{"Count":101,"Metadata":{"creationTimestamp":null},"InvolvedObject":{},"Source":{},"FirstOccurrenceTimestamp":%s,"LastOccurrenceTimestamp":%s,"Message":"event2","Reason":"","Type":"","Labels":"","EventTags":{"cluster_name":"default","eventID":"","hostname":""}}`,
 	}
 
 	msgsString := fmt.Sprintf("%s", FakeESSink.savedData)

--- a/metrics/util/util.go
+++ b/metrics/util/util.go
@@ -21,7 +21,9 @@ import (
 	"time"
 )
 
-var labelSeperator string
+var (
+	labelSeperator = ","
+)
 
 // Concatenates a map of labels into a Seperator-seperated key:value pairs.
 func LabelsToString(labels map[string]string) string {


### PR DESCRIPTION
This PR adds `labels` field to eventer elasticsearch mappings. 

We often use `labels` to add some meta info such as the cluster name or service name corresponding to this pod. We need this info to do some filter search. 