### PR TITLE
Document Heapster Maintenance Procedures

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -1,0 +1,56 @@
+Heapster Maintenance Procedures
+===============================
+
+Triage
+------
+
+Triage is done on a weekly rotation by members of the
+@kubernetes/heapster-maintainers team.  Initially this will be limitted to
+the following people:
+
+- @piosz
+- @directxman12
+
+The on-duty triage maintainer is responsible for initial triage of bugs
+and pull requests (labeling, assigning, etc), initially responding to
+issues, merging pull requests approved by sink owners, and reviewing
+non-sink-specific pull requests.
+
+### Labels ###
+
+Each issue and pull request should be assinged one of:
+
+- bug
+- enhancement
+- question
+- support
+- testing
+- invalid
+- docs
+
+A priority label should also be assigned (`Priority/P[0-3]`, with `Priority/P0`
+being the highest priority) for `bug` and `enhancement` issues and pull
+requests.
+
+Duplicate bugs should be tagged with `duplicate`, and should have a comment
+referencing the main bug.  `wontfix` may be applied as appropriate for issues
+which won't be fixed.
+
+Additionally, a sink label should be applied to sink-related issues and pull
+requests (`sink/$SINK_NAME`).
+
+Sink Maintenance
+----------------
+
+Each sink will have a set of one or more owners who are responsible for
+responding to issues and pull requests, once triaged.  If a sink has no owners,
+a call will be put out for owners, and if none are found, the sink may be
+subject to deprecation and removal after a release.
+
+See the [sink owners](sink-owners.md) reference file for more information.
+
+Releases
+--------
+
+Releases will be performed by @piosz.  Any issues about releases should be
+assigned to him.

--- a/docs/sink-owners.md
+++ b/docs/sink-owners.md
@@ -1,0 +1,41 @@
+Sink Owners
+===========
+
+Each sink in Heapster needs to have at least one "owner".  The owner will
+be responsible for doing code reviews of pull requests regarding their
+sink, and will be a point of contact for issues relating to their sink.
+
+Owners will *not* be responsible for actually triaging issues and pull
+requests, but once assigned, they will be responsible for responding to
+the issues.
+
+PRs affecting a particular sink generally need to be approved by the sink
+owner.  Similarly, PRs affecting a particular sink that have LGTM from the
+sink owner will be considered ok-to-merge by the Heapster maintainers
+(i.e. sink owners will not have official merge permissions, but the
+maintainer's role in this case is just to perform the actual merge).
+
+List of Owners
+--------------
+
+- :ok: : has owners
+- :sos: : needs owners, will eventually be deprecated and removed without owners
+- :new: : in development
+- :no_entry: : deprecated, pending removal
+
+| Sink            | Metric             | Event              | Owner(s)                                      | Status         |
+| --------------- | ------------------ | -------------------| --------------------------------------------- | -------------- |
+| ElasticSearch   | :heavy_check_mark: | :heavy_check_mark: | @AlmogBaku / @andyxning / @huangyuqi          | :ok:           |
+| GCM             | :heavy_check_mark: | :x:                | @kubernetes/heapster-maintainers              | :ok:           |
+| Hawkular        | :heavy_check_mark: | :x:                | @burmanm / @mwringe                           | :ok:           |
+| InfluxDB        | :heavy_check_mark: | :heavy_check_mark: | @kubernetes/heapster-maintainers / @andyxning | :ok:           |
+| Metric (memory) | :heavy_check_mark: | :x:                | @kubernetes/heapster-maintainers              | :ok:           |
+| Kafka           | :heavy_check_mark: | :x:                | @huangyuqi                                    | :ok:           |
+| Monasca         | :heavy_check_mark: | :x:                |                                               | :no_entry: [1] |
+| OpenTSDB        | :heavy_check_mark: | :x:                | @bluebreezecf                                 | :ok:           |
+| Riemann         | :heavy_check_mark: | :x: :new:          | @jsoriano (temporarily)                       | :no_entry: [2] |
+| Graphite        | :heavy_check_mark: | :x:                | @jsoriano / @theairkit                        | :new: #1407    |
+| Wavefront       | :heavy_check_mark: | :x:                | @ezeev                                        | :new: #1400    |
+
+- [1] Monasca now has native support for Kubernetes, so this is no longer needed (see https://github.com/kubernetes/heapster/issues/1407#issuecomment-266008730 and https://github.com/openstack/monasca-agent/blob/master/docs/Plugins.md#docker)
+- [2] The Riemann library has disappeared (see #1419) and users seem to be moving towards using Graphite (see https://github.com/kubernetes/heapster/issues/1407#issuecomment-265850414) or are unresponsive


### PR DESCRIPTION
This commit adds documentation for Heapster maintenance producers and
sink owners.  This should make it clearer what needs to be done to take
care of Heapster going forward.

Closes #1407