### PR TITLE
add disk io metric

### DIFF
--- a/docs/storage-schema.md
+++ b/docs/storage-schema.md
@@ -17,6 +17,10 @@ Heapster exports the following metrics to its backends.
 | filesystem/available | The number of available bytes remaining in a the filesystem |
 | filesystem/inodes | The number of available inodes in a the filesystem |
 | filesystem/inodes_free | The number of free inodes remaining in a the filesystem |
+| disk/io_read_bytes | Number of bytes read from a disk partition |
+| disk/io_write_bytes | Number of bytes written to a disk partition |
+| disk/io_read_bytes_rate | Number of bytes read from a disk partition per second |
+| disk/io_write_bytes_rate | Number of bytes written to a disk partition per second |
 | memory/limit | Memory hard limit in bytes. |
 | memory/major_page_faults | Number of major page faults. |
 | memory/major_page_faults_rate | Number of major page faults per second. |
@@ -62,7 +66,7 @@ Heapster tags each metric with the following labels.
 | labels         | Comma-separated(Default) list of user-provided labels. Format is 'key:value'  |
 | namespace_id   | UID of the namespace of a Pod                                                 |
 | namespace_name | User-provided name of a Namespace                                             |
-| resource_id    | A unique identifier used to differentiate multiple metrics of the same type. e.x. Fs partitions under filesystem/usage |
+| resource_id    | A unique identifier used to differentiate multiple metrics of the same type. e.x. Fs partitions under filesystem/usage, disk device name under disk/io_read_bytes |
 | make  | Make of the accelerator (nvidia, amd, google etc.) |
 | model | Model of the accelerator (tesla-p100, tesla-k80 etc.) |
 | accelerator_id    | ID of the accelerator |

--- a/integration/heapster_api_test.go
+++ b/integration/heapster_api_test.go
@@ -359,7 +359,11 @@ func runMetricExportTest(fm kubeFramework, svc *kube_v1.Service) error {
 			core.MetricFilesystemInodesFree.Name:             {core.LabelResourceID.Key},
 			core.MetricAcceleratorMemoryTotal.Name:           {core.LabelAcceleratorMake.Key, core.LabelAcceleratorModel.Key, core.LabelAcceleratorID.Key},
 			core.MetricAcceleratorMemoryUsed.Name:            {core.LabelAcceleratorMake.Key, core.LabelAcceleratorModel.Key, core.LabelAcceleratorID.Key},
-			core.MetricAcceleratorDutyCycle.Name:             {core.LabelAcceleratorMake.Key, core.LabelAcceleratorModel.Key, core.LabelAcceleratorID.Key}}
+			core.MetricAcceleratorDutyCycle.Name:             {core.LabelAcceleratorMake.Key, core.LabelAcceleratorModel.Key, core.LabelAcceleratorID.Key},
+			core.MetricDiskIORead.Name:                       {core.LabelResourceID.Key},
+			core.MetricDiskIOReadRate.Name:                   {core.LabelResourceID.Key},
+			core.MetricDiskIOWrite.Name:                      {core.LabelResourceID.Key},
+			core.MetricDiskIOWriteRate.Name:                  {core.LabelResourceID.Key}}
 
 		for metricName, points := range ts.Metrics {
 			md, exists := mdMap[metricName]


### PR DESCRIPTION
Address #690.

This PR will add disk io metrics to heapster. It will add these metrics:
* `disk/io_read_bytes`: Number of bytes read from a disk partition
* `disk/io_write_bytes`: Number of bytes written to a disk partition
* `disk/io_read_bytes_rate`: Number of bytes read from a disk partition per second
*  `disk/io_write_bytes_rate`: Number of bytes written to a disk partition per second

all these metrics will add `resource_id` label with values in `major:minor` format.

FYI：[kernel blkio cgroup](https://www.kernel.org/doc/Documentation/cgroup-v1/blkio-controller.txt)