### PR TITLE
Docs:  Maintenance: PR number for Graphite Sink

### DIFF
--- a/docs/sink-owners.md
+++ b/docs/sink-owners.md
@@ -34,7 +34,7 @@ List of Owners
 | Monasca         | :heavy_check_mark: | :x:                |                                               | :no_entry: [1] |
 | OpenTSDB        | :heavy_check_mark: | :x:                | @bluebreezecf                                 | :ok:           |
 | Riemann         | :heavy_check_mark: | :x: :new:          | @jsoriano (temporarily)                       | :no_entry: [2] |
-| Graphite        | :heavy_check_mark: | :x:                | @jsoriano / @theairkit                        | :new: #1407    |
+| Graphite        | :heavy_check_mark: | :x:                | @jsoriano / @theairkit                        | :new: #1341    |
 | Wavefront       | :heavy_check_mark: | :x:                | @ezeev                                        | :new: #1400    |
 
 - [1] Monasca now has native support for Kubernetes, so this is no longer needed (see https://github.com/kubernetes/heapster/issues/1407#issuecomment-266008730 and https://github.com/openstack/monasca-agent/blob/master/docs/Plugins.md#docker)


### PR DESCRIPTION
The PR number for the Graphite sink in the maintenance docs
was incorrect.  This fixes it.

See https://github.com/kubernetes/heapster/pull/1447#discussion_r95159533