### PR TITLE
Always --pull in docker build to ensure recent base images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ container:
 	cp deploy/docker/Dockerfile $(TEMP_DIR)
 	cd $(TEMP_DIR) && sed -i "s|BASEIMAGE|$(BASEIMAGE)|g" Dockerfile
 
-	docker build -t $(PREFIX)/heapster-$(ARCH):$(VERSION) $(TEMP_DIR)
+	docker build --pull -t $(PREFIX)/heapster-$(ARCH):$(VERSION) $(TEMP_DIR)
 ifneq ($(OVERRIDE_IMAGE_NAME),)
 	docker tag $(PREFIX)/heapster-$(ARCH):$(VERSION) $(OVERRIDE_IMAGE_NAME)
 endif

--- a/grafana/Makefile
+++ b/grafana/Makefile
@@ -70,7 +70,7 @@ build:
 		&& cd /tmp/grafanarootfs && tar -cf /build/grafana.tar . \
 		&& cd /build && CGO_ENABLED=0 GOARCH=$(ARCH) go build -o setup_grafana setup_grafana.go"
 
-	docker build -t $(PREFIX)/heapster-grafana-$(ARCH):$(VERSION) $(TEMP_DIR)
+	docker build --pull -t $(PREFIX)/heapster-grafana-$(ARCH):$(VERSION) $(TEMP_DIR)
 
 	rm -rf $(TEMP_DIR)
 

--- a/influxdb/Makefile
+++ b/influxdb/Makefile
@@ -59,7 +59,7 @@ build:
 		&& ln -s /go/src/github.com/influxdb/influxdb /go/src/github.com/influxdata/ \
 		&& GOARCH=$(ARCH) CGO_ENABLED=0 go build -a --installsuffix cgo --ldflags=\"-s\" -o /build/influxd ./cmd/influxd"
 
-	docker build -t $(PREFIX)/heapster-influxdb-$(ARCH):$(VERSION) $(TEMP_DIR)
+	docker build --pull -t $(PREFIX)/heapster-influxdb-$(ARCH):$(VERSION) $(TEMP_DIR)
 
 	rm -rf $(TEMP_DIR)
 

--- a/kafka/build.sh
+++ b/kafka/build.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
 
 pushd $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-docker build -t heapster_kafka:canary .
+docker build --pull -t heapster_kafka:canary .
 popd

--- a/riemann/build.sh
+++ b/riemann/build.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
 
 pushd $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-docker build -t heapster_riemann:canary .
+docker build --pull -t heapster_riemann:canary .
 popd


### PR DESCRIPTION
@timstclair 

x-ref https://github.com/kubernetes/kubernetes/pull/39695

The riemann image is using debian:8.1 explicitly, which is pretty old (June 2015). Should we update it? I'm not sure who uses it.