### PR TITLE
Show only pods from matching namespace in Grafana.

### DIFF
--- a/grafana/dashboards/influxdb_withfields/pods.json
+++ b/grafana/dashboards/influxdb_withfields/pods.json
@@ -1041,7 +1041,7 @@
               "selected": false
             }
           ],
-          "query": "SHOW TAG VALUES FROM \"uptime\" WITH KEY = \"pod_name\"",
+          "query": "SHOW TAG VALUES FROM \"uptime\" WITH KEY = \"pod_name\" WHERE \"pod_namespace\" =~ /$namespace$/",
           "refresh": true,
           "regex": "",
           "type": "query"

--- a/grafana/dashboards/pods.json
+++ b/grafana/dashboards/pods.json
@@ -1041,7 +1041,7 @@
               "selected": false
             }
           ],
-          "query": "SHOW TAG VALUES FROM \"uptime\" WITH KEY = \"pod_name\"",
+          "query": "SHOW TAG VALUES FROM \"uptime\" WITH KEY = \"pod_name\" WHERE \"pod_namespace\" =~ /$namespace$/",
           "refresh": true,
           "regex": "",
           "type": "query"


### PR DESCRIPTION
In "pods.json" dashboard there is a list of pods to select from.
This change filters the list, to contain only pods from previously selected namespace.

Fixes: #1396.

![zrzut ekranu z 2017-01-12 18-12-40](https://cloud.githubusercontent.com/assets/1043875/21900795/731c0118-d8f5-11e6-8809-f038249f6acc.png)
