### PR TITLE
Add flag to skip SSL validation with InfluxDB

### DIFF
--- a/common/influxdb/influxdb.go
+++ b/common/influxdb/influxdb.go
@@ -32,12 +32,13 @@ type InfluxdbClient interface {
 }
 
 type InfluxdbConfig struct {
-	User       string
-	Password   string
-	Secure     bool
-	Host       string
-	DbName     string
-	WithFields bool
+	User        string
+	Password    string
+	Secure      bool
+	Host        string
+	DbName      string
+	WithFields  bool
+	InsecureSsl bool
 }
 
 func NewClient(c InfluxdbConfig) (InfluxdbClient, error) {
@@ -54,6 +55,7 @@ func NewClient(c InfluxdbConfig) (InfluxdbClient, error) {
 		Username:  c.User,
 		Password:  c.Password,
 		UserAgent: fmt.Sprintf("%v/%v", "heapster", version.HeapsterVersion),
+		UnsafeSsl: c.InsecureSsl,
 	}
 	client, err := influxdb.NewClient(*iConfig)
 
@@ -68,12 +70,13 @@ func NewClient(c InfluxdbConfig) (InfluxdbClient, error) {
 
 func BuildConfig(uri *url.URL) (*InfluxdbConfig, error) {
 	config := InfluxdbConfig{
-		User:       "root",
-		Password:   "root",
-		Host:       "localhost:8086",
-		DbName:     "k8s",
-		Secure:     false,
-		WithFields: false,
+		User:        "root",
+		Password:    "root",
+		Host:        "localhost:8086",
+		DbName:      "k8s",
+		Secure:      false,
+		WithFields:  false,
+		InsecureSsl: false,
 	}
 
 	if len(uri.Host) > 0 {
@@ -103,6 +106,14 @@ func BuildConfig(uri *url.URL) (*InfluxdbConfig, error) {
 			return nil, fmt.Errorf("failed to parse `secure` flag - %v", err)
 		}
 		config.Secure = val
+	}
+
+	if len(opts["insecuressl"]) >= 1 {
+		val, err := strconv.ParseBool(opts["insecuressl"][0])
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse `insecuressl` flag - %v", err)
+		}
+		config.InsecureSsl = val
 	}
 
 	return &config, nil

--- a/docs/sink-configuration.md
+++ b/docs/sink-configuration.md
@@ -32,6 +32,7 @@ The following options are available:
 * `pw` - InfluxDB password (default: `root`)
 * `db` - InfluxDB Database name (default: `k8s`)
 * `secure` - Connect securely to InfluxDB (default: `false`)
+* `insecuressl` - Ignore SSL certificate validity (default: `false`)
 * `withfields` - Use [InfluxDB fields](storage-schema.md#using-fields) (default: `false`)
 
 ### Google Cloud Monitoring


### PR DESCRIPTION
Hi
I've added a flag insecuressl=[true|false] to InfluxDB sink to skip validation of SSL certificates. Similar flag already exists for Kubernetes source.

Thanks and best regards,
- Ashley