### PR TITLE
Update influxdb image to a valid/working name:tag

### DIFF
--- a/deploy/kube-config/influxdb/influxdb-deployment.yaml
+++ b/deploy/kube-config/influxdb/influxdb-deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: influxdb
-        image: gcr.io/google_containers/heapster-influxdb:v1.1.1
+        image: gcr.io/google_containers/heapster-influxdb-amd64:v1.1.1
         volumeMounts:
         - mountPath: /data
           name: influxdb-storage


### PR DESCRIPTION
Their is currently no image `gcr.io/google_containers/heapster-influxdb:v1.1.1`. Checking the repository it seems only arch-specific version tags are there now, and `gcr.io/google_containers/heapster-influxdb-amd64:v1.1.1` worked for me.

$ curl https://gcr.io/v2/google-containers/heapster-influxdb-amd64/tags/list
{"child":[],"manifest":{"sha256:15d48e8a864d73e763f6eb7a010e93902cf625967062bdf25a055098a6aac634":{"layerId":"55d63942e2eb6a74ea81cbfccd95ef0f44f599a04ed4a46a41dc868a639c847d","tag":["v1.1.1"],"timeCreatedMs":"1484908591867"}},"name":"google-containers/heapster-influxdb-amd64","tags":["v1.1.1"]}