### PR TITLE
abstract the GetNodeLister() function

### DIFF
--- a/metrics/heapster.go
+++ b/metrics/heapster.go
@@ -206,7 +206,7 @@ func getListersOrDie(kubernetesUrl *url.URL) (*cache.StoreToPodLister, *cache.St
 	if err != nil {
 		glog.Fatalf("Failed to create podLister: %v", err)
 	}
-	nodeLister, err := getNodeLister(kubeClient)
+	nodeLister, _, err := util.GetNodeLister(kubeClient)
 	if err != nil {
 		glog.Fatalf("Failed to create nodeLister: %v", err)
 	}
@@ -319,14 +319,6 @@ func getPodLister(kubeClient *kube_client.Client) (*cache.StoreToPodLister, erro
 	reflector := cache.NewReflector(lw, &kube_api.Pod{}, store, time.Hour)
 	reflector.Run()
 	return podLister, nil
-}
-
-func getNodeLister(kubeClient *kube_client.Client) (*cache.StoreToNodeLister, error) {
-	lw := cache.NewListWatchFromClient(kubeClient, "nodes", kube_api.NamespaceAll, fields.Everything())
-	nodeLister := &cache.StoreToNodeLister{Store: cache.NewStore(cache.MetaNamespaceKeyFunc)}
-	reflector := cache.NewReflector(lw, &kube_api.Node{}, nodeLister.Store, time.Hour)
-	reflector.Run()
-	return nodeLister, nil
 }
 
 func validateFlags(opt *options.HeapsterRunOptions) error {

--- a/metrics/processors/node_autoscaling_enricher.go
+++ b/metrics/processors/node_autoscaling_enricher.go
@@ -15,16 +15,13 @@
 package processors
 
 import (
-	"net/url"
-	"time"
-
 	kube_config "k8s.io/heapster/common/kubernetes"
 	"k8s.io/heapster/metrics/core"
 	"k8s.io/heapster/metrics/util"
 	kube_api "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/cache"
 	kube_client "k8s.io/kubernetes/pkg/client/unversioned"
-	"k8s.io/kubernetes/pkg/fields"
+	"net/url"
 )
 
 type NodeAutoscalingEnricher struct {
@@ -95,10 +92,7 @@ func NewNodeAutoscalingEnricher(url *url.URL) (*NodeAutoscalingEnricher, error) 
 	kubeClient := kube_client.NewOrDie(kubeConfig)
 
 	// watch nodes
-	lw := cache.NewListWatchFromClient(kubeClient, "nodes", kube_api.NamespaceAll, fields.Everything())
-	nodeLister := &cache.StoreToNodeLister{Store: cache.NewStore(cache.MetaNamespaceKeyFunc)}
-	reflector := cache.NewReflector(lw, &kube_api.Node{}, nodeLister.Store, time.Hour)
-	reflector.Run()
+	nodeLister, reflector, _ := util.GetNodeLister(kubeClient)
 
 	return &NodeAutoscalingEnricher{
 		nodeLister: nodeLister,

--- a/metrics/sources/kubelet/kubelet.go
+++ b/metrics/sources/kubelet/kubelet.go
@@ -26,6 +26,7 @@ import (
 	"github.com/golang/glog"
 	cadvisor "github.com/google/cadvisor/info/v1"
 	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/heapster/metrics/util"
 	kube_api "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/cache"
 	kube_client "k8s.io/kubernetes/pkg/client/unversioned"
@@ -337,10 +338,7 @@ func NewKubeletProvider(uri *url.URL) (MetricsSourceProvider, error) {
 	}
 
 	// watch nodes
-	lw := cache.NewListWatchFromClient(kubeClient, "nodes", kube_api.NamespaceAll, fields.Everything())
-	nodeLister := &cache.StoreToNodeLister{Store: cache.NewStore(cache.MetaNamespaceKeyFunc)}
-	reflector := cache.NewReflector(lw, &kube_api.Node{}, nodeLister.Store, time.Hour)
-	reflector.Run()
+	nodeLister, reflector, _ := util.GetNodeLister(kubeClient)
 
 	return &kubeletProvider{
 		nodeLister:    nodeLister,

--- a/metrics/sources/summary/summary.go
+++ b/metrics/sources/summary/summary.go
@@ -24,10 +24,10 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/heapster/metrics/util"
 	kube_api "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/cache"
 	kube_client "k8s.io/kubernetes/pkg/client/unversioned"
-	"k8s.io/kubernetes/pkg/fields"
 	"k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/stats"
 	"k8s.io/kubernetes/pkg/version"
 )
@@ -449,10 +449,7 @@ func NewSummaryProvider(uri *url.URL) (MetricsSourceProvider, error) {
 		return nil, err
 	}
 	// watch nodes
-	lw := cache.NewListWatchFromClient(kubeClient, "nodes", kube_api.NamespaceAll, fields.Everything())
-	nodeLister := &cache.StoreToNodeLister{Store: cache.NewStore(cache.MetaNamespaceKeyFunc)}
-	reflector := cache.NewReflector(lw, &kube_api.Node{}, nodeLister.Store, time.Hour)
-	reflector.Run()
+	nodeLister, reflector, _ := util.GetNodeLister(kubeClient)
 
 	return &summaryProvider{
 		nodeLister:    nodeLister,

--- a/metrics/util/util.go
+++ b/metrics/util/util.go
@@ -16,6 +16,10 @@ package util
 
 import (
 	"fmt"
+	kube_api "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/client/cache"
+	kube_client "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/fields"
 	"sort"
 	"strings"
 	"time"
@@ -52,4 +56,12 @@ func GetLatest(a, b time.Time) time.Time {
 
 func SetLabelSeperator(seperator string) {
 	labelSeperator = seperator
+}
+
+func GetNodeLister(kubeClient *kube_client.Client) (*cache.StoreToNodeLister, *cache.Reflector, error) {
+	lw := cache.NewListWatchFromClient(kubeClient, "nodes", kube_api.NamespaceAll, fields.Everything())
+	nodeLister := &cache.StoreToNodeLister{Store: cache.NewStore(cache.MetaNamespaceKeyFunc)}
+	reflector := cache.NewReflector(lw, &kube_api.Node{}, nodeLister.Store, time.Hour)
+	reflector.Run()
+	return nodeLister, reflector, nil
 }


### PR DESCRIPTION
there are duplicated codes spreads in the source code, and I abstract into the util.GetNodeLister().
Is this ok?