### PR TITLE
Update grafana image to a valid/working name:tag

### DIFF
--- a/deploy/kube-config/influxdb/grafana-deployment.yaml
+++ b/deploy/kube-config/influxdb/grafana-deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: grafana
-        image: gcr.io/google_containers/heapster-grafana:v4.0.2
+        image: gcr.io/google_containers/heapster-grafana:v2.6.0-2
         ports:
           - containerPort: 3000
             protocol: TCP


### PR DESCRIPTION
Their is currently no image gcr.io/google_containers/heapster-grafana:v4.0.2. The container registry has only one image there, and that is tagged at v2.6.0-2. I was able to pull and apply to my cluster with this image.