### PR TITLE
Prepare for mapping volume docker-to-docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ TEMP_DIR:=$(shell mktemp -d)
 
 VERSION?=v1.3.0-beta.1
 GIT_COMMIT:=$(shell git rev-parse --short HEAD)
+REPO_DIR?=$(shell pwd)
 
 # You can set this variable for testing and the built image will also be tagged with this name
 OVERRIDE_IMAGE_NAME?=
@@ -68,7 +69,7 @@ test-integration: clean build
 container:
 	# Run the build in a container in order to have reproducible builds
 	# Also, fetch the latest ca certificates
-	docker run --rm -i $(TTY) -v $(TEMP_DIR):/build -v $(shell pwd):/go/src/k8s.io/heapster -w /go/src/k8s.io/heapster golang:$(GOLANG_VERSION) /bin/bash -c "\
+	docker run --rm -i $(TTY) -v $(TEMP_DIR):/build -v $(REPO_DIR):/go/src/k8s.io/heapster -w /go/src/k8s.io/heapster golang:$(GOLANG_VERSION) /bin/bash -c "\
 		cp /etc/ssl/certs/ca-certificates.crt /build \
 		&& GOARCH=$(ARCH) CGO_ENABLED=0 go build -ldflags \"$(HEAPSTER_LDFLAGS)\" -o /build/heapster k8s.io/heapster/metrics \
 		&& GOARCH=$(ARCH) CGO_ENABLED=0 go build -ldflags \"$(HEAPSTER_LDFLAGS)\" -o /build/eventer k8s.io/heapster/events"


### PR DESCRIPTION
This is necessary for https://github.com/kubernetes/test-infra/pull/1773 to work since it's initiated from a docker container now. And should not change local testing behavior.