### PR TITLE
Fixes issues with building on MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ ARCH?=amd64
 ALL_ARCHITECTURES=amd64 arm arm64 ppc64le s390x
 ML_PLATFORMS=linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/s390x
 GOLANG_VERSION?=1.7
-TEMP_DIR:=$(shell mktemp -d)
+TEMP_DIR:=$(shell mktemp -d /tmp/heapster.XXXXXX)
 
 VERSION?=v1.3.0-beta.1
 GIT_COMMIT:=$(shell git rev-parse --short HEAD)
@@ -74,7 +74,7 @@ container:
 		&& GOARCH=$(ARCH) CGO_ENABLED=0 go build -ldflags \"$(HEAPSTER_LDFLAGS)\" -o /build/eventer k8s.io/heapster/events"
 
 	cp deploy/docker/Dockerfile $(TEMP_DIR)
-	cd $(TEMP_DIR) && sed -i "s|BASEIMAGE|$(BASEIMAGE)|g" Dockerfile
+	cd $(TEMP_DIR) && sed -i -e "s|BASEIMAGE|$(BASEIMAGE)|g" Dockerfile
 
 	docker build --pull -t $(PREFIX)/heapster-$(ARCH):$(VERSION) $(TEMP_DIR)
 ifneq ($(OVERRIDE_IMAGE_NAME),)


### PR DESCRIPTION
1. tempfile is unrestricted for docker
```
# Run the build in a container in order to have reproducible builds
# Also, fetch the latest ca certificates
docker run --rm -i -t -v /var/folders/pb/51g49l9x0x59p7qzc0m3qqdr0000gn/T/heapster.XVvw2ydR:/build -v /Users/AlmogBaku/Documents/Projects/golang/src/k8s.io/heapster:/go/src/k8s.io/heapster -w /go/src/k8s.io/heapster golang:1.7 /bin/bash -c "\
		cp /etc/ssl/certs/ca-certificates.crt /build \
		&& GOARCH=amd64 CGO_ENABLED=0 go build -ldflags \"-w -X k8s.io/heapster/version.HeapsterVersion=v1.3.0-alpha.0 -X k8s.io/heapster/version.GitCommit=3e79aa3\" -o /build/heapster k8s.io/heapster/metrics \
		&& GOARCH=amd64 CGO_ENABLED=0 go build -ldflags \"-w -X k8s.io/heapster/version.HeapsterVersion=v1.3.0-alpha.0 -X k8s.io/heapster/version.GitCommit=3e79aa3\" -o /build/eventer k8s.io/heapster/events"
docker: Error response from daemon: Mounts denied: mac/osxfs/#namespaces for more info.
.
x0x59p7qzc0m3qqdr0000gn/T/heapster.XVvw2ydR
is not shared from OS X and is not known to Docker.
You can configure shared paths from Docker -> Preferences... -> File Sharing.
See https://docs.docker.com/docker-for-.
ERRO[0000] error getting events from daemon: net/http: request canceled 
make: *** [container] Error 125
```

This issue occurs since the directory that the `mktemp` creates isn't allowed by the docker. This patch creates the temporary dir under the `tmp` dir, which is allowed.

(reference: https://forums.docker.com/t/getting-mounts-denied-on-previously-working-container-after-upgrading-to-v1-12-0-beta18-3-gec40b14/17546)

2. sed require extra argument
http://stackoverflow.com/questions/16745988/sed-command-works-fine-on-ubuntu-but-not-mac