### PR TITLE
Disabled manifest lists for now so we can release v1.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,12 +82,21 @@ ifneq ($(OVERRIDE_IMAGE_NAME),)
 endif
 	rm -rf $(TEMP_DIR)
 
-push: ./manifest-tool gcr-login $(addprefix sub-push-,$(ALL_ARCHITECTURES))
-	./manifest-tool push from-args --platforms $(ML_PLATFORMS) --template $(PREFIX)/heapster-ARCH:$(VERSION) --target $(PREFIX)/heapster:$(VERSION)
+do-push:
+	docker push $(PREFIX)/heapster-$(ARCH):$(VERSION)
+ifeq ($(ARCH),amd64)
+# TODO: Remove this and push the manifest list as soon as it's working
+	docker tag $(PREFIX)/heapster-$(ARCH):$(VERSION) $(PREFIX)/heapster:$(VERSION)
+	docker push $(PREFIX)/heapster:$(VERSION)
+endif
+
+# Should depend on target: ./manifest-tool
+push: gcr-login $(addprefix sub-push-,$(ALL_ARCHITECTURES))
+#	./manifest-tool push from-args --platforms $(ML_PLATFORMS) --template $(PREFIX)/heapster-ARCH:$(VERSION) --target $(PREFIX)/heapster:$(VERSION)
 
 sub-push-%:
 	$(MAKE) ARCH=$* PREFIX=$(PREFIX) VERSION=$(VERSION) container
-	docker push $(PREFIX)/heapster-$*:$(VERSION)
+	$(MAKE) ARCH=$* PREFIX=$(PREFIX) VERSION=$(VERSION) do-push
 
 influxdb:
 	ARCH=$(ARCH) PREFIX=$(PREFIX) make -C influxdb build
@@ -101,16 +110,17 @@ push-influxdb:
 push-grafana:
 	PREFIX=$(PREFIX) make -C grafana push
 
-./manifest-tool:
-	curl -sSL https://github.com/luxas/manifest-tool/releases/download/v0.3.0/manifest-tool > manifest-tool
-	chmod +x manifest-tool
-
 gcr-login:
 ifeq ($(findstring gcr.io,$(PREFIX)),gcr.io)
 	@echo "If you are pushing to a gcr.io registry, you have to be logged in via 'docker login'; 'gcloud docker push' can't push manifest lists yet."
-	@echo "This script is automatically logging you in now."
-	docker login -u oauth2accesstoken -p "$(shell gcloud auth print-access-token)" https://gcr.io
+	@echo "This script is automatically logging you in now with 'gcloud docker -a'"
+	gcloud docker -a
 endif
+
+# TODO(luxas): As soon as it's working to push fat manifests to gcr.io, reenable this code
+#./manifest-tool:
+#	curl -sSL https://github.com/luxas/manifest-tool/releases/download/v0.3.0/manifest-tool > manifest-tool
+#	chmod +x manifest-tool
 
 clean:
 	rm -f heapster

--- a/deploy/kube-config/google/heapster-controller.yaml
+++ b/deploy/kube-config/google/heapster-controller.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: heapster
-        image: kubernetes/heapster:canary
+        image: gcr.io/google_containers/heapster-amd64:v1.3.0-beta.0
         imagePullPolicy: Always
         command:
         - /heapster

--- a/deploy/kube-config/influxdb/grafana-deployment.yaml
+++ b/deploy/kube-config/influxdb/grafana-deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: grafana
-        image: gcr.io/google_containers/heapster-grafana:v4.0.2
+        image: gcr.io/google_containers/heapster-grafana-amd64:v4.0.2
         ports:
           - containerPort: 3000
             protocol: TCP

--- a/deploy/kube-config/influxdb/heapster-deployment.yaml
+++ b/deploy/kube-config/influxdb/heapster-deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: heapster
-        image: gcr.io/google_containers/heapster:v1.3.0-beta.0
+        image: gcr.io/google_containers/heapster-amd64:v1.3.0-beta.0
         imagePullPolicy: IfNotPresent
         command:
         - /heapster

--- a/deploy/kube-config/influxdb/influxdb-deployment.yaml
+++ b/deploy/kube-config/influxdb/influxdb-deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: influxdb
-        image: gcr.io/google_containers/heapster-influxdb:v1.1.1
+        image: gcr.io/google_containers/heapster-influxdb-amd64:v1.1.1
         volumeMounts:
         - mountPath: /data
           name: influxdb-storage

--- a/deploy/kube-config/standalone-test/heapster-controller.yaml
+++ b/deploy/kube-config/standalone-test/heapster-controller.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: heapster-test
-        image: kubernetes/heapster:canary
+        image: gcr.io/google_containers/heapster-amd64:v1.3.0-beta.0
         imagePullPolicy: Always
         command:
         - /heapster

--- a/deploy/kube-config/standalone-test/heapster-summary-controller.yaml
+++ b/deploy/kube-config/standalone-test/heapster-summary-controller.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: heapster-test
-        image: kubernetes/heapster:canary
+        image: gcr.io/google_containers/heapster-amd64:v1.3.0-beta.0
         imagePullPolicy: Always
         command:
         - /heapster
@@ -28,7 +28,7 @@ spec:
           mountPath: /etc/ssl/certs
           readOnly: true
       - name: eventer-test
-        image: kubernetes/heapster:canary
+        image: gcr.io/google_containers/heapster-amd64:v1.3.0-beta.0
         imagePullPolicy: Always
         command:
         - /eventer

--- a/deploy/kube-config/standalone-with-apiserver/heapster-deployment.yaml
+++ b/deploy/kube-config/standalone-with-apiserver/heapster-deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: heapster
-        image: heapster:canary
+        image: gcr.io/google_containers/heapster-amd64:v1.3.0-beta.0
         command:
         - /heapster
         - --source=kubernetes.summary_api:''

--- a/deploy/kube-config/standalone/heapster-controller.yaml
+++ b/deploy/kube-config/standalone/heapster-controller.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: heapster
-        image: kubernetes/heapster:canary
+        image: gcr.io/google_containers/heapster-amd64:v1.3.0-beta.0
         imagePullPolicy: Always
         command:
         - /heapster

--- a/grafana/Makefile
+++ b/grafana/Makefile
@@ -27,7 +27,8 @@ LDFLAGS=-w -X main.version=$(VERSION) -X main.commit=unknown-dev -X main.timesta
 DEB_BUILD=4.0.2-1481203731
 KUBE_CROSS_IMAGE=gcr.io/google_containers/kube-cross:v1.7.3-0
 
-ALL_ARCHITECTURES=amd64 arm arm64 ppc64le s390x
+# s390x
+ALL_ARCHITECTURES=amd64 arm arm64 ppc64le
 ML_PLATFORMS=linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/s390x
 
 # Set default base image dynamically for each arch
@@ -74,20 +75,22 @@ build:
 
 	rm -rf $(TEMP_DIR)
 
-push: ./manifest-tool gcr-login $(addprefix sub-push-,$(ALL_ARCHITECTURES))
-	./manifest-tool push from-args --platforms $(ML_PLATFORMS) --template $(PREFIX)/heapster-grafana-ARCH:$(VERSION) --target $(PREFIX)/heapster-grafana:$(VERSION)
+# Should depend on target: ./manifest-tool
+push: gcr-login $(addprefix sub-push-,$(ALL_ARCHITECTURES))
+#	./manifest-tool push from-args --platforms $(ML_PLATFORMS) --template $(PREFIX)/heapster-grafana-ARCH:$(VERSION) --target $(PREFIX)/heapster-grafana:$(VERSION)
 
 sub-push-%:
 	$(MAKE) ARCH=$* PREFIX=$(PREFIX) VERSION=$(VERSION) build
 	docker push $(PREFIX)/heapster-grafana-$*:$(VERSION)
 
-./manifest-tool:
-	curl -sSL https://github.com/luxas/manifest-tool/releases/download/v0.3.0/manifest-tool > manifest-tool
-	chmod +x manifest-tool
+# TODO(luxas): As soon as it's working to push fat manifests to gcr.io, reenable this code
+#./manifest-tool:
+#	curl -sSL https://github.com/luxas/manifest-tool/releases/download/v0.3.0/manifest-tool > manifest-tool
+#	chmod +x manifest-tool
 
 gcr-login:
 ifeq ($(findstring gcr.io,$(PREFIX)),gcr.io)
 	@echo "If you are pushing to a gcr.io registry, you have to be logged in via 'docker login'; 'gcloud docker push' can't push manifest lists yet."
 	@echo "This script is automatically logging you in now."
-	docker login -u oauth2accesstoken -p "$(shell gcloud auth print-access-token)" https://gcr.io
+	gcloud docker -a
 endif

--- a/influxdb/Makefile
+++ b/influxdb/Makefile
@@ -63,20 +63,22 @@ build:
 
 	rm -rf $(TEMP_DIR)
 
-push: ./manifest-tool gcr-login $(addprefix sub-push-,$(ALL_ARCHITECTURES))
-	./manifest-tool push from-args --platforms $(ML_PLATFORMS) --template $(PREFIX)/heapster-influxdb-ARCH:$(VERSION) --target $(PREFIX)/heapster-influxdb:$(VERSION)
+# Should depend on target: ./manifest-tool
+push: gcr-login $(addprefix sub-push-,$(ALL_ARCHITECTURES))
+#	./manifest-tool push from-args --platforms $(ML_PLATFORMS) --template $(PREFIX)/heapster-influxdb-ARCH:$(VERSION) --target $(PREFIX)/heapster-influxdb:$(VERSION)
 
 sub-push-%:
 	$(MAKE) ARCH=$* PREFIX=$(PREFIX) VERSION=$(VERSION) build
-	docker push $(PREFIX)/heapster-influxdb-$*:$(VERSION)
+	docker push $(PREFIX)/heapster-influxdb-$(ARCH):$(VERSION)
 
 gcr-login:
 ifeq ($(findstring gcr.io,$(PREFIX)),gcr.io)
 	@echo "If you are pushing to a gcr.io registry, you have to be logged in via 'docker login'; 'gcloud docker push' can't push manifest lists yet."
 	@echo "This script is automatically logging you in now."
-	docker login -u oauth2accesstoken -p "$(shell gcloud auth print-access-token)" https://gcr.io
+	gcloud docker -a
 endif
 
-./manifest-tool:
-	curl -sSL https://github.com/luxas/manifest-tool/releases/download/v0.3.0/manifest-tool > manifest-tool
-	chmod +x manifest-tool
+# TODO(luxas): As soon as it's working to push fat manifests to gcr.io, reenable this code
+#./manifest-tool:
+#	curl -sSL https://github.com/luxas/manifest-tool/releases/download/v0.3.0/manifest-tool > manifest-tool
+#	chmod +x manifest-tool


### PR DESCRIPTION
Although GCR [claims](https://cloud.google.com/container-registry/release-notes) they support manifest lists, they do not, at least not fully. The "fat manifest" aka manifest list which makes the docker registry point to the right layers depending on the host platform doesn't work at the moment on gcr.io.

While we're waiting for that, we have to use `-ARCH` suffixed images like other k8s images.
@piosz 