### PR TITLE
the --source should be enclosed by double quotes

### DIFF
--- a/docs/source-configuration.md
+++ b/docs/source-configuration.md
@@ -13,17 +13,17 @@ Kubernetes clusters.
 ### Kubernetes
 To use the kubernetes source add the following flag:
 
-	--source=kubernetes:<KUBERNETES_MASTER>[?<KUBERNETES_OPTIONS>]
+	--source="kubernetes:<KUBERNETES_MASTER>[?<KUBERNETES_OPTIONS>]"
 
 If you're running Heapster in a Kubernetes pod you can use the following flag:
 
-	--source=kubernetes
+	--source="kubernetes"
 
 Heapster requires an authentication token to connect with the apiserver securely. By default, Heapster will use the inClusterConfig system to configure the secure connection. This requires kubernetes version `v1.0.3` or higher and a couple extra kubernetes configuration steps. Firstly, for your apiserver you must create an SSL certificate pair with a SAN that includes the ClusterIP of the kubernetes service. Look [here](https://github.com/kubernetes/kubernetes/blob/e4fde6d2cae2d924a4eb72d1e3b2639f057bb8c1/cluster/gce/util.sh#L497-L559) for an example of how to properly generate certs. Secondly, you need to pass the `ca.crt` that you generated to the `--root-ca-file` option of the controller-manager. This will distribute the root CA to `/var/run/secrets/kubernetes.io/serviceaccount/` of all pods. If you are using `ABAC` authorization (as opposed to `AllowAll` which is the default), you will also need to give the `system:serviceaccount:<namespace-of-heapster>:default` readonly access to the cluster (look [here](https://github.com/kubernetes/kubernetes/blob/master/docs/admin/authorization.md#a-quick-note-on-service-accounts) for more info).
 
 If you don't want to setup inClusterConfig, you can still use Heapster! To run without auth, use the following config:
 
-	--source=kubernetes:http://<address-of-kubernetes-master>:<http-port>?inClusterConfig=false
+	--source="kubernetes:http://<address-of-kubernetes-master>:<http-port>?inClusterConfig=false"
 
 This requires the apiserver to be setup completely without auth, which can be done by binding the insecure port to all interfaces (see the apiserver `--insecure-bind-address` option) but *WARNING* be aware of the security repercussions. Only do this if you trust *EVERYONE* on your network.
 
@@ -83,5 +83,5 @@ The following options are available:
 
 There is also a sub-source for metrics - `kubernetes.summary_api` - that uses a slightly different, memory-efficient API for passing data from Kubelet/cAdvisor to Heapster. It supports the same set of options as `kubernetes`. Sample usage:
 ```
- - --source=kubernetes.summary_api:''
+ - --source="kubernetes.summary_api:''"
 ```


### PR DESCRIPTION
I'm not sure if this proposal is correct. 
In my test, if I place more than 1 query parameter in the --source flag, such as --source=kubernetes:http://localhost:8080?inClusterConfig=false&useServiceAccount=false --sink=log, the command will not recognize the following --sink flag, and will not start the Metric Sink. But if using --source="kubernetes:http://localhost:8080?inClusterConfig=false&useServiceAccount=false" --sink=log, the command will start initializing the Metric Sink. So I think it's better to enclose the content of --source by double quotes.
Anyone test this before?