### PR TITLE
Update heapster image tag

### DIFF
--- a/deploy/kube-config/google/heapster-controller.yaml
+++ b/deploy/kube-config/google/heapster-controller.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: heapster
-        image: gcr.io/google_containers/heapster-amd64:v1.3.0-beta.0
+        image: gcr.io/google_containers/heapster-amd64:v1.3.0-alpha.1
         imagePullPolicy: Always
         command:
         - /heapster

--- a/deploy/kube-config/google/heapster-controller.yaml
+++ b/deploy/kube-config/google/heapster-controller.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: heapster
-        image: gcr.io/google_containers/heapster-amd64:v1.3.0-alpha.1
+        image: gcr.io/google_containers/heapster-amd64:v1.3.0-beta.1
         imagePullPolicy: Always
         command:
         - /heapster

--- a/deploy/kube-config/influxdb/heapster-deployment.yaml
+++ b/deploy/kube-config/influxdb/heapster-deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: heapster
-        image: gcr.io/google_containers/heapster-amd64:v1.3.0-beta.0
+        image: gcr.io/google_containers/heapster-amd64:v1.3.0-alpha.1
         imagePullPolicy: IfNotPresent
         command:
         - /heapster

--- a/deploy/kube-config/influxdb/heapster-deployment.yaml
+++ b/deploy/kube-config/influxdb/heapster-deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: heapster
-        image: gcr.io/google_containers/heapster-amd64:v1.3.0-alpha.1
+        image: gcr.io/google_containers/heapster-amd64:v1.3.0-beta.1
         imagePullPolicy: IfNotPresent
         command:
         - /heapster

--- a/deploy/kube-config/standalone-test/heapster-controller.yaml
+++ b/deploy/kube-config/standalone-test/heapster-controller.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: heapster-test
-        image: gcr.io/google_containers/heapster-amd64:v1.3.0-alpha.1
+        image: gcr.io/google_containers/heapster-amd64:v1.3.0-beta.1
         imagePullPolicy: Always
         command:
         - /heapster

--- a/deploy/kube-config/standalone-test/heapster-controller.yaml
+++ b/deploy/kube-config/standalone-test/heapster-controller.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: heapster-test
-        image: gcr.io/google_containers/heapster-amd64:v1.3.0-beta.0
+        image: gcr.io/google_containers/heapster-amd64:v1.3.0-alpha.1
         imagePullPolicy: Always
         command:
         - /heapster

--- a/deploy/kube-config/standalone-test/heapster-summary-controller.yaml
+++ b/deploy/kube-config/standalone-test/heapster-summary-controller.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: heapster-test
-        image: gcr.io/google_containers/heapster-amd64:v1.3.0-beta.0
+        image: gcr.io/google_containers/heapster-amd64:v1.3.0-alpha.1
         imagePullPolicy: Always
         command:
         - /heapster
@@ -28,7 +28,7 @@ spec:
           mountPath: /etc/ssl/certs
           readOnly: true
       - name: eventer-test
-        image: gcr.io/google_containers/heapster-amd64:v1.3.0-beta.0
+        image: gcr.io/google_containers/heapster-amd64:v1.3.0-alpha.1
         imagePullPolicy: Always
         command:
         - /eventer

--- a/deploy/kube-config/standalone-test/heapster-summary-controller.yaml
+++ b/deploy/kube-config/standalone-test/heapster-summary-controller.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: heapster-test
-        image: gcr.io/google_containers/heapster-amd64:v1.3.0-alpha.1
+        image: gcr.io/google_containers/heapster-amd64:v1.3.0-beta.1
         imagePullPolicy: Always
         command:
         - /heapster
@@ -28,7 +28,7 @@ spec:
           mountPath: /etc/ssl/certs
           readOnly: true
       - name: eventer-test
-        image: gcr.io/google_containers/heapster-amd64:v1.3.0-alpha.1
+        image: gcr.io/google_containers/heapster-amd64:v1.3.0-beta.1
         imagePullPolicy: Always
         command:
         - /eventer

--- a/deploy/kube-config/standalone-with-apiserver/heapster-deployment.yaml
+++ b/deploy/kube-config/standalone-with-apiserver/heapster-deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: heapster
-        image: gcr.io/google_containers/heapster-amd64:v1.3.0-beta.0
+        image: gcr.io/google_containers/heapster-amd64:v1.3.0-alpha.1
         command:
         - /heapster
         - --source=kubernetes.summary_api:''

--- a/deploy/kube-config/standalone-with-apiserver/heapster-deployment.yaml
+++ b/deploy/kube-config/standalone-with-apiserver/heapster-deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: heapster
-        image: gcr.io/google_containers/heapster-amd64:v1.3.0-alpha.1
+        image: gcr.io/google_containers/heapster-amd64:v1.3.0-beta.1
         command:
         - /heapster
         - --source=kubernetes.summary_api:''

--- a/deploy/kube-config/standalone/heapster-controller.yaml
+++ b/deploy/kube-config/standalone/heapster-controller.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: heapster
-        image: gcr.io/google_containers/heapster-amd64:v1.3.0-beta.0
+        image: gcr.io/google_containers/heapster-amd64:v1.3.0-alpha.1
         imagePullPolicy: Always
         command:
         - /heapster

--- a/deploy/kube-config/standalone/heapster-controller.yaml
+++ b/deploy/kube-config/standalone/heapster-controller.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: heapster
-        image: gcr.io/google_containers/heapster-amd64:v1.3.0-alpha.1
+        image: gcr.io/google_containers/heapster-amd64:v1.3.0-beta.1
         imagePullPolicy: Always
         command:
         - /heapster


### PR DESCRIPTION
Deploy its not working because tag not longer exist:

    Failed to pull image "gcr.io/google_containers/heapster-amd64:v1.3.0-beta.0": image pull failed for gcr.io/google_containers/heapster-amd64:v1.3.0-beta.0
    this may be because there are no credentials on this request. details: (Tag v1.3.0-beta.0 not found in repository gcr.io/google_containers/heapster-amd64)

I just updated to the alpha version and tested successfully:

    Successfully pulled image "gcr.io/google_containers/heapster-amd64:v1.3.0-alpha.1"