### PR TITLE
Rebase heapster image on scratch & don't run as root

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,22 +29,6 @@ TEST_NAMESPACE=heapster-e2e-tests
 
 HEAPSTER_LDFLAGS=-w -X k8s.io/heapster/version.HeapsterVersion=$(VERSION) -X k8s.io/heapster/version.GitCommit=$(GIT_COMMIT)
 
-ifeq ($(ARCH),amd64)
-	BASEIMAGE?=busybox
-endif
-ifeq ($(ARCH),arm)
-	BASEIMAGE?=armhf/busybox
-endif
-ifeq ($(ARCH),arm64)
-	BASEIMAGE?=aarch64/busybox
-endif
-ifeq ($(ARCH),ppc64le)
-	BASEIMAGE?=ppc64le/busybox
-endif
-ifeq ($(ARCH),s390x)
-	BASEIMAGE?=s390x/busybox
-endif
-
 fmt:
 	find . -type f -name "*.go" | grep -v "./vendor*" | xargs gofmt -s -w
 

--- a/Makefile
+++ b/Makefile
@@ -75,8 +75,6 @@ container:
 		&& GOARCH=$(ARCH) CGO_ENABLED=0 go build -ldflags \"$(HEAPSTER_LDFLAGS)\" -o /build/eventer k8s.io/heapster/events"
 
 	cp deploy/docker/Dockerfile $(TEMP_DIR)
-	cd $(TEMP_DIR) && sed -i -e "s|BASEIMAGE|$(BASEIMAGE)|g" Dockerfile
-
 	docker build --pull -t $(PREFIX)/heapster-$(ARCH):$(VERSION) $(TEMP_DIR)
 ifneq ($(OVERRIDE_IMAGE_NAME),)
 	docker tag -f $(PREFIX)/heapster-$(ARCH):$(VERSION) $(OVERRIDE_IMAGE_NAME)

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -3,4 +3,6 @@ FROM scratch
 COPY heapster eventer /
 COPY ca-certificates.crt /etc/ssl/certs/
 
+#   nobody:nobody
+USER 65534:65534
 ENTRYPOINT ["/heapster"]

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM BASEIMAGE
+FROM scratch
 
 COPY heapster eventer /
 COPY ca-certificates.crt /etc/ssl/certs/


### PR DESCRIPTION
As part of the effort behind https://github.com/kubernetes/kubernetes/issues/40248, I'm cutting out unnecessary dependencies from system containers by rebasing them on scratch (for containers without any external dependencies). In addition, heapster does not require any elevated privileges, so run as the `nobody` user instead of root.

For debugging scratch containers, see https://github.com/kubernetes/contrib/pull/2372

/cc @ixdy 