### PR TITLE
pod-container-level rest APIs are not available before v1.2.0

### DIFF
--- a/docs/model.md
+++ b/docs/model.md
@@ -54,11 +54,11 @@ pairs for the requested namespace-level metric, within the time range specified 
 `/api/v1/model/namespaces/{namespace-name}/pods/{pod-name}/metrics/{metric-name}?start=X&end=Y`: Returns a set of (Timestamp, Value) 
 pairs for the requested pod-level metric, within the time range specified by `start` and `end`. 
 
-### Container-level Metrics
+### Container-level Metrics 
 Container metrics and stats are accessible for both containers that belong to
 pods, as well as for free containers running in each node.
 
-`/api/v1/model/namespaces/{namespace-name}/pods/{pod-name}/containers/`: Returns a list of all available containers under a given pod.
+`/api/v1/model/namespaces/{namespace-name}/pods/{pod-name}/containers/`: Returns a list of all available containers under a given pod. Note: Not Supported only in V1.2.0.
 
 `/api/v1/model/namespaces/{namespace-name}/pods/{pod-name}/containers/{container-name}/metrics/`: Returns a list of available container-level metrics
 


### PR DESCRIPTION
In my test, I deployed heapster v1.2.0 and found that the pod-container-level rest apis were not supported, such as "/api/v1/model/namespaces/{namespace-name}/pods/{pod-name}/containers/" just returned 404 not found.
So I propose deviding the specifications about containers into pod-container-level and free-container-level, explaining the pod-container-level only supported since V1.3.0.