### PR TITLE
Image pull errors, removing amd64 fixes it

### DIFF
--- a/deploy/kube-config/influxdb/heapster-deployment.yaml
+++ b/deploy/kube-config/influxdb/heapster-deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: heapster
-        image: gcr.io/google_containers/heapster-amd64:v1.3.0-beta.0
+        image: gcr.io/google_containers/heapster:v1.3.0-beta.0
         imagePullPolicy: IfNotPresent
         command:
         - /heapster


### PR DESCRIPTION
The image `gcr.io/google_containers/heapster-amd64:v1.3.0-beta` doesn't seem to exist and I get an `ErrImagePull` when using the manifest. Removing the `-amd64` specification seems to work, although a better fix might be to actually create the image with `-amd64` if there is other images available than amd64 ones.