### PR TITLE
update "v1.3.0-beta.0" image tag with "v1.3.0-beta.1"

### DIFF
--- a/deploy/kube-config/influxdb/heapster-deployment.yaml
+++ b/deploy/kube-config/influxdb/heapster-deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: heapster
-        image: gcr.io/google_containers/heapster-amd64:v1.3.0-beta.0
+        image: gcr.io/google_containers/heapster-amd64:v1.3.0-beta.1
         imagePullPolicy: IfNotPresent
         command:
         - /heapster


### PR DESCRIPTION
"gcr.io/google_containers/heapster-amd64:v1.3.0-beta.0" image is not available.

Use "beta.1" image according to @luxas comment:
<https://github.com/kubernetes/heapster/issues/1518#issuecomment-279180306>

edited by @piosz
fix #1518