### PR TITLE
Wavefront Sink - moved type tag to metric namespace + unit test

### DIFF
--- a/metrics/sinks/wavefront/driver_test.go
+++ b/metrics/sinks/wavefront/driver_test.go
@@ -70,6 +70,16 @@ func TestName(t *testing.T) {
 	assert.Equal(t, name, "Wavefront Sink")
 }
 
+func TestNewMetricName(t *testing.T) {
+	fakeSink := NewFakeWavefrontSink()
+	batch := generateFakeBatch()
+	fakeSink.ExportData(batch)
+	name := "cpu/usage"
+	mtype := "pod_container"
+	newName := fakeSink.cleanMetricName(mtype, name)
+	assert.Equal(t, "pod_container.cpu.usage", newName)
+}
+
 func TestValidateLines(t *testing.T) {
 	fakeSink := NewFakeWavefrontSink()
 	batch := generateFakeBatch()


### PR DESCRIPTION
We made a decision to move the "type" tag into the metric name space (i.e. `pod.cpu.usage` instead of `cpu.usage type=pod` for the Wavefront output plugin.