### PR TITLE
fixing elasticsearch and adding tests

### DIFF
--- a/common/elasticsearch/elasticsearch.go
+++ b/common/elasticsearch/elasticsearch.go
@@ -127,8 +127,8 @@ func CreateElasticSearchService(uri *url.URL) (*ElasticSearchService, error) {
 	var startupFns []elastic.ClientOptionFunc
 	if len(opts["nodes"]) > 0 {
 		startupFns = append(startupFns, elastic.SetURL(opts["nodes"]...))
-	} else if uri.Opaque != "" {
-		startupFns = append(startupFns, elastic.SetURL(uri.Opaque))
+	} else if uri.Scheme != "" && uri.Host != "" {
+		startupFns = append(startupFns, elastic.SetURL(uri.Scheme+"://"+uri.Host))
 	} else {
 		return nil, fmt.Errorf("There is no node assigned for connecting ES cluster")
 	}

--- a/common/elasticsearch/elasticsearch_test.go
+++ b/common/elasticsearch/elasticsearch_test.go
@@ -96,3 +96,53 @@ func TestCreateElasticSearchServiceForDefaultClusterName(t *testing.T) {
 		t.Fatalf("cluster name is not equal. Expected: %s, Got: %s", ESClusterName, esSvc.ClusterName)
 	}
 }
+
+func TestCreateElasticSearchServiceSingleDnsEntrypoint(t *testing.T) {
+	clusterName := "sandbox"
+	esURI := fmt.Sprintf("https://foo.com:9200?"+
+		"esUserName=test&esUserSecret=password&maxRetries=10&startupHealthcheckTimeout=30&"+
+		"sniff=false&healthCheck=false&cluster_name=%s", clusterName)
+
+	url, err := url.Parse(esURI)
+	if err != nil {
+		t.Fatalf("Error when parsing URL: %s", err.Error())
+	}
+
+	esSvc, err := CreateElasticSearchService(url)
+	if err != nil {
+		t.Fatalf("Error when creating config: %s", err.Error())
+	}
+
+	expectedClient, err := elastic.NewClient(
+		elastic.SetURL("https://foo.com:9200"),
+		elastic.SetBasicAuth("test", "password"),
+		elastic.SetMaxRetries(10),
+		elastic.SetHealthcheckTimeoutStartup(30*time.Second),
+		elastic.SetSniff(false), elastic.SetHealthcheck(false))
+
+	if err != nil {
+		t.Fatalf("Error when creating client: %s", err.Error())
+	}
+
+	actualClientRefl := reflect.ValueOf(esSvc.EsClient).Elem()
+	expectedClientRefl := reflect.ValueOf(expectedClient).Elem()
+
+	if actualClientRefl.FieldByName("basicAuthUsername").String() != expectedClientRefl.FieldByName("basicAuthUsername").String() {
+		t.Fatal("basicAuthUsername is not equal")
+	}
+	if actualClientRefl.FieldByName("maxRetries").Int() != expectedClientRefl.FieldByName("maxRetries").Int() {
+		t.Fatal("maxRetries is not equal")
+	}
+	if actualClientRefl.FieldByName("healthcheckTimeoutStartup").Int() != expectedClientRefl.FieldByName("healthcheckTimeoutStartup").Int() {
+		t.Fatal("healthcheckTimeoutStartup is not equal")
+	}
+	if actualClientRefl.FieldByName("snifferEnabled").Bool() != expectedClientRefl.FieldByName("snifferEnabled").Bool() {
+		t.Fatal("snifferEnabled is not equal")
+	}
+	if actualClientRefl.FieldByName("healthcheckEnabled").Bool() != expectedClientRefl.FieldByName("healthcheckEnabled").Bool() {
+		t.Fatal("healthcheckEnabled is not equal")
+	}
+	if esSvc.ClusterName != clusterName {
+		t.Fatal("cluster name is not equal")
+	}
+}

--- a/docs/sink-configuration.md
+++ b/docs/sink-configuration.md
@@ -166,6 +166,11 @@ additional node in the cluster. For example:
 ```
 (*) Notice that using the `?nodes` notation will override the `ES_SERVER_URL`
 
+If you run your ElasticSearch cluster behind a loadbalancer (or otherwise do
+not want to specify multiple nodes) then you can do the following:
+```
+  --sink=elasticsearch:http://elasticsearch.example.com:9200?sniff=false
+```
 
 Besides this, the following options can be set in query string:
 


### PR DESCRIPTION
fixes [1211](https://github.com/kubernetes/heapster/issues/1211) and adds a test so it doesn't happen again.

Root cause:
Opaque would work if it was set, but uri.Parse does not actually set Opaque.