### PR TITLE
update heapster-amd64 image to the right version

### DIFF
--- a/deploy/kube-config/influxdb/heapster-deployment.yaml
+++ b/deploy/kube-config/influxdb/heapster-deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: heapster
-        image: gcr.io/google_containers/heapster-amd64:v1.3.0-beta.0
+        image: gcr.io/google_containers/heapster-amd64:v1.3.0-beta.1
         imagePullPolicy: IfNotPresent
         command:
         - /heapster


### PR DESCRIPTION
the image `gcr.io/google_containers/heapster-amd64:v1.3.0-beta.0` no longer exists update to beta.1 works

```
Failed to pull image "gcr.io/google_containers/heapster-amd64:v1.3.0-beta.0": image pull failed for gcr.io/google_containers/heapster-amd64:v1.3.0-beta.0, this may be because there are no credentials on this reques
```