### PR TITLE
Correct annotations of the "end time"

### DIFF
--- a/docs/model.md
+++ b/docs/model.md
@@ -8,7 +8,7 @@ It allows the extraction of up to 15 minutes of historical data for any Containe
 ## Usage
 
 The Heapster Model is enabled by default. The resolution of the model can be configured through
-the `-model_resolution` flag, which will cause the model to store historical data at the specified resolution. If the `-model_resolution` flag is not specified, the default resolution of 30 seconds will be used.
+the `-metric_resolution` flag, which will cause the model to store historical data at the specified resolution. If the `-metric_resolution` flag is not specified, the default resolution of 60 seconds will be used.
 
 ## API documentation
 

--- a/metrics/api/v1/historical_handlers.go
+++ b/metrics/api/v1/historical_handlers.go
@@ -832,7 +832,7 @@ func exportTimestampedAggregationValue(values []core.TimestampedAggregationValue
 // (or is zero, since many things in go use time.Time{} as an empty value) --
 // different sinks have different defaults, and certain sinks have issues if an actual
 // time of zero (i.e. the epoch) is used (because that would be too many data points
-// to consider in certain cases).  Require applications to pass an explicit end time
+// to consider in certain cases).  Require applications to pass an explicit start time
 // that they can deal with.
 func getStartEndTimeHistorical(request *restful.Request) (time.Time, time.Time, error) {
 	start, end, err := getStartEndTime(request)


### PR DESCRIPTION
The "end time" should be "start time" in fact.
Please check.