### PR TITLE
It's possible to cat kube-config and apply together

### DIFF
--- a/deploy/kube-config/influxdb/grafana.yaml
+++ b/deploy/kube-config/influxdb/grafana.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:

--- a/deploy/kube-config/influxdb/heapster.yaml
+++ b/deploy/kube-config/influxdb/heapster.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/deploy/kube-config/influxdb/influxdb.yaml
+++ b/deploy/kube-config/influxdb/influxdb.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:


### PR DESCRIPTION
If you want to programmatically edit the config files
for kubectl, then the config files needs to begin
with three dashes.

This change makes it possible to do

```sh
cat deploy/kube-config/influxdb/* \
  | sed 's/amd64/arm/g' \
  | kubectl create -f -
```