### PR TITLE
add healthz to eventer

### DIFF
--- a/events/api/api.go
+++ b/events/api/api.go
@@ -1,0 +1,28 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apiserver/pkg/server/healthz"
+)
+
+func init() {
+	healthz.InstallHandler(http.DefaultServeMux, healthzChecker())
+
+	http.Handle("/metrics", prometheus.UninstrumentedHandler())
+}

--- a/events/api/handler.go
+++ b/events/api/handler.go
@@ -1,0 +1,47 @@
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/golang/glog"
+	"k8s.io/apiserver/pkg/server/healthz"
+	"k8s.io/heapster/events/manager"
+)
+
+const (
+	// MaxEventsScrapeDelay should be larger than `frequency` command line argument.
+	MaxEventsScrapeDelay = 3 * time.Minute
+)
+
+func healthzChecker() healthz.HealthzChecker {
+	return healthz.NamedCheck("healthz", func(r *http.Request) error {
+		if time.Since(manager.LatestScrapeTime) > MaxEventsScrapeDelay {
+			msg := fmt.Sprintf(
+				"No event batch within %s (latest: %s)",
+				MaxEventsScrapeDelay,
+				manager.LatestScrapeTime,
+			)
+			glog.Warning(msg)
+			return errors.New(msg)
+		}
+
+		return nil
+	})
+}

--- a/events/manager/manager.go
+++ b/events/manager/manager.go
@@ -31,6 +31,9 @@ var (
 			Name:      "last_time_seconds",
 			Help:      "Last time of eventer housekeep since unix epoch in seconds.",
 		})
+
+	// Time of latest scrape operation
+	LatestScrapeTime = time.Now()
 )
 
 func init() {
@@ -88,6 +91,8 @@ func (rm *realManager) Housekeep() {
 
 func (rm *realManager) housekeep() {
 	defer lastHousekeepTimestamp.Set(float64(time.Now().Unix()))
+
+	LatestScrapeTime = time.Now()
 
 	// No parallelism. Assumes that the events are pushed to Heapster. Add parallelism
 	// when this stops to be true.

--- a/events/sources/kubernetes/kubernetes_source.go
+++ b/events/sources/kubernetes/kubernetes_source.go
@@ -96,6 +96,7 @@ event_loop:
 	}
 
 	totalEventsNum.Add(float64(len(result.Events)))
+
 	return &result
 }
 


### PR DESCRIPTION
Fix #1293 .

This PR adds `/healthz` and `/metrics` http service to eventer.
* healthz endpoint currently only checks latest scrape time, if `LatestScrapeTime` is 3 minutes later than now, healthz endpoint will return with http response code being 500.
* metrics endpoint is used for Prometheus.

Note: **This PR needs to be merged after #1539 because newly added file's boilerplate is 2017. :). Currently this PR will not pass successfully, i will rebase this PR once #1539 is merged.**

/cc @AlmogBaku @DirectXMan12 @piosz @kubernetes/heapster-reviewers 