### PR TITLE
add rss and cache

### DIFF
--- a/docs/storage-schema.md
+++ b/docs/storage-schema.md
@@ -26,6 +26,8 @@ Heapster exports the following metrics to its backends.
 | memory/page_faults_rate | Number of page faults per second. |
 | memory/request | Memory request (the guaranteed amount of resources) in bytes. |
 | memory/usage | Total memory usage. |
+| memory/cache | Cache memory usage. |
+| memory/rss | RSS memory usage. |
 | memory/working_set | Total working set usage. Working set is the memory being used and not easily dropped by the kernel. |
 | network/rx | Cumulative number of bytes received over the network. |
 | network/rx_errors | Cumulative number of errors while receiving over the network. |

--- a/metrics/core/metrics.go
+++ b/metrics/core/metrics.go
@@ -29,6 +29,8 @@ var StandardMetrics = []Metric{
 	MetricUptime,
 	MetricCpuUsage,
 	MetricMemoryUsage,
+	MetricMemoryRSS,
+	MetricMemoryCache,
 	MetricMemoryWorkingSet,
 	MetricMemoryPageFaults,
 	MetricMemoryMajorPageFaults,
@@ -103,6 +105,8 @@ var MemoryMetrics = []Metric{
 	MetricMemoryPageFaultsRate,
 	MetricMemoryRequest,
 	MetricMemoryUsage,
+	MetricMemoryRSS,
+	MetricMemoryCache,
 	MetricMemoryWorkingSet,
 	MetricNodeMemoryAllocatable,
 	MetricNodeMemoryCapacity,
@@ -206,6 +210,44 @@ var MetricMemoryUsage = Metric{
 			ValueType:  ValueInt64,
 			MetricType: MetricGauge,
 			IntValue:   int64(stat.Memory.Usage)}
+	},
+}
+
+var MetricMemoryCache = Metric{
+	MetricDescriptor: MetricDescriptor{
+		Name:        "memory/cache",
+		Description: "Cache memory",
+		Type:        MetricGauge,
+		ValueType:   ValueInt64,
+		Units:       UnitsBytes,
+	},
+	HasValue: func(spec *cadvisor.ContainerSpec) bool {
+		return spec.HasMemory
+	},
+	GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) MetricValue {
+		return MetricValue{
+			ValueType:  ValueInt64,
+			MetricType: MetricGauge,
+			IntValue:   int64(stat.Memory.Cache)}
+	},
+}
+
+var MetricMemoryRSS = Metric{
+	MetricDescriptor: MetricDescriptor{
+		Name:        "memory/rss",
+		Description: "RSS memory",
+		Type:        MetricGauge,
+		ValueType:   ValueInt64,
+		Units:       UnitsBytes,
+	},
+	HasValue: func(spec *cadvisor.ContainerSpec) bool {
+		return spec.HasMemory
+	},
+	GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) MetricValue {
+		return MetricValue{
+			ValueType:  ValueInt64,
+			MetricType: MetricGauge,
+			IntValue:   int64(stat.Memory.RSS)}
 	},
 }
 


### PR DESCRIPTION
This PR adds RSS(`memory/rss`) and cache(`memory/cache`) memory metrics.

Currently, `memory/usage` contains both RSS and cache, we can not know what exactly each uses. There are situations that `memory/usage` is the same as `memory/limit` with containers running normally.

This will make it difficult to distinguish whether we should enlarge memory limit in order to make containers live normally instead of OOM killed. We should use `memory/RSS` and `memory/limit` as the judgement metrics, i.e., when `memory/RSS` is approximate to `memory/limit`, we need to enlarge memory limit. This is also compatible with usage behavior in bare machine.

/cc @piosz @DirectXMan12 @AlmogBaku @kubernetes/heapster-reviewers 