### PR TITLE
add filesystem inode metrics

### DIFF
--- a/docs/storage-schema.md
+++ b/docs/storage-schema.md
@@ -15,6 +15,8 @@ Heapster exports the following metrics to its backends.
 | filesystem/usage | Total number of bytes consumed on a filesystem. |
 | filesystem/limit | The total size of filesystem in bytes. |
 | filesystem/available | The number of available bytes remaining in a the filesystem |
+| filesystem/inodes | The number of available inodes in a the filesystem |
+| filesystem/inodes_free | The number of free inodes remaining in a the filesystem |
 | memory/limit | Memory hard limit in bytes. |
 | memory/major_page_faults | Number of major page faults. |
 | memory/major_page_faults_rate | Number of major page faults per second. |

--- a/integration/heapster_api_test.go
+++ b/integration/heapster_api_test.go
@@ -350,7 +350,9 @@ func runMetricExportTest(fm kubeFramework, svc *kube_api.Service) error {
 		explicitRequirement := map[string][]string{
 			core.MetricFilesystemUsage.MetricDescriptor.Name: {core.LabelResourceID.Key},
 			core.MetricFilesystemLimit.MetricDescriptor.Name: {core.LabelResourceID.Key},
-			core.MetricFilesystemAvailable.Name:              {core.LabelResourceID.Key}}
+			core.MetricFilesystemAvailable.Name:              {core.LabelResourceID.Key},
+			core.MetricFilesystemInodes.Name:                 {core.LabelResourceID.Key},
+			core.MetricFilesystemInodesFree.Name:             {core.LabelResourceID.Key}}
 
 		for metricName, points := range ts.Metrics {
 			md, exists := mdMap[metricName]

--- a/metrics/core/metrics.go
+++ b/metrics/core/metrics.go
@@ -67,6 +67,8 @@ var LabeledMetrics = []Metric{
 	MetricFilesystemUsage,
 	MetricFilesystemLimit,
 	MetricFilesystemAvailable,
+	MetricFilesystemInodes,
+	MetricFilesystemInodesFree,
 }
 
 var NodeAutoscalingMetrics = []Metric{
@@ -94,6 +96,8 @@ var FilesystemMetrics = []Metric{
 	MetricFilesystemAvailable,
 	MetricFilesystemLimit,
 	MetricFilesystemUsage,
+	MetricFilesystemInodes,
+	MetricFilesystemInodesFree,
 }
 var MemoryMetrics = []Metric{
 	MetricMemoryLimit,
@@ -606,6 +610,72 @@ var MetricFilesystemAvailable = Metric{
 		ValueType:   ValueInt64,
 		Units:       UnitsBytes,
 		Labels:      metricLabels,
+	},
+}
+
+var MetricFilesystemInodes = Metric{
+	MetricDescriptor: MetricDescriptor{
+		Name:        "filesystem/inodes",
+		Description: "Total number of inodes on a filesystem",
+		Type:        MetricGauge,
+		ValueType:   ValueInt64,
+		Units:       UnitsBytes,
+		Labels:      metricLabels,
+	},
+	HasLabeledMetric: func(spec *cadvisor.ContainerSpec) bool {
+		return spec.HasFilesystem
+	},
+	GetLabeledMetric: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) []LabeledMetric {
+		result := []LabeledMetric{}
+		for _, fs := range stat.Filesystem {
+			if fs.HasInodes {
+				result = append(result, LabeledMetric{
+					Name: "filesystem/inodes",
+					Labels: map[string]string{
+						LabelResourceID.Key: fs.Device,
+					},
+					MetricValue: MetricValue{
+						ValueType:  ValueInt64,
+						MetricType: MetricGauge,
+						IntValue:   int64(fs.Inodes),
+					},
+				})
+			}
+		}
+		return result
+	},
+}
+
+var MetricFilesystemInodesFree = Metric{
+	MetricDescriptor: MetricDescriptor{
+		Name:        "filesystem/inodes_free",
+		Description: "Free number of inodes on a filesystem",
+		Type:        MetricGauge,
+		ValueType:   ValueInt64,
+		Units:       UnitsBytes,
+		Labels:      metricLabels,
+	},
+	HasLabeledMetric: func(spec *cadvisor.ContainerSpec) bool {
+		return spec.HasFilesystem
+	},
+	GetLabeledMetric: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) []LabeledMetric {
+		result := []LabeledMetric{}
+		for _, fs := range stat.Filesystem {
+			if fs.HasInodes {
+				result = append(result, LabeledMetric{
+					Name: "filesystem/inodes_free",
+					Labels: map[string]string{
+						LabelResourceID.Key: fs.Device,
+					},
+					MetricValue: MetricValue{
+						ValueType:  ValueInt64,
+						MetricType: MetricGauge,
+						IntValue:   int64(fs.InodesFree),
+					},
+				})
+			}
+		}
+		return result
 	},
 }
 


### PR DESCRIPTION
This PR adds filesystem inode metrics:
* `filesystem/inodes`: The number of available inodes in a the filesystem
* `filesystem/inodes_free`: The number of free inodes remaining in a the filesystem

/cc @DirectXMan12  @piosz @kubernetes/heapster-reviewers  