### PR TITLE
Add additional logging around points of failure

### DIFF
--- a/metrics/sources/kubelet/kubelet_client.go
+++ b/metrics/sources/kubelet/kubelet_client.go
@@ -26,6 +26,7 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/golang/glog"
 	cadvisor "github.com/google/cadvisor/info/v1"
 	kubelet_client "k8s.io/heapster/metrics/sources/kubelet/util"
 	"k8s.io/kubernetes/pkg/kubelet/api/v1alpha1/stats"
@@ -77,6 +78,13 @@ func (self *KubeletClient) postRequestAndGetValue(client *http.Client, req *http
 	} else if response.StatusCode != http.StatusOK {
 		return fmt.Errorf("request failed - %q, response: %q", response.Status, string(body))
 	}
+
+	kubeletAddr := "[unknown]"
+	if req.URL != nil {
+		kubeletAddr = req.URL.Host
+	}
+	glog.V(10).Infof("Raw response from Kubelet at %s: %s", kubeletAddr, string(body))
+
 	err = json.Unmarshal(body, value)
 	if err != nil {
 		return fmt.Errorf("failed to parse output. Response: %q. Error: %v", string(body), err)

--- a/metrics/sources/summary/summary.go
+++ b/metrics/sources/summary/summary.go
@@ -117,6 +117,7 @@ var systemNameMap = map[string]string{
 
 // decodeSummary translates the kubelet stats.Summary API into the flattened heapster MetricSet API.
 func (this *summaryMetricsSource) decodeSummary(summary *stats.Summary) map[string]*MetricSet {
+	glog.V(9).Infof("Begin summary decode")
 	result := map[string]*MetricSet{}
 
 	labels := map[string]string{
@@ -130,6 +131,7 @@ func (this *summaryMetricsSource) decodeSummary(summary *stats.Summary) map[stri
 		this.decodePodStats(result, labels, &pod)
 	}
 
+	glog.V(9).Infof("End summary decode")
 	return result
 }
 
@@ -143,6 +145,7 @@ func (this *summaryMetricsSource) cloneLabels(labels map[string]string) map[stri
 }
 
 func (this *summaryMetricsSource) decodeNodeStats(metrics map[string]*MetricSet, labels map[string]string, node *stats.NodeStats) {
+	glog.V(9).Infof("Decoding node stats for node %s...", node.NodeName)
 	nodeMetrics := &MetricSet{
 		Labels:         this.cloneLabels(labels),
 		MetricValues:   map[string]MetricValue{},
@@ -168,6 +171,7 @@ func (this *summaryMetricsSource) decodeNodeStats(metrics map[string]*MetricSet,
 }
 
 func (this *summaryMetricsSource) decodePodStats(metrics map[string]*MetricSet, nodeLabels map[string]string, pod *stats.PodStats) {
+	glog.V(9).Infof("Decoding pod stats for pod %s/%s (%s)...", pod.PodRef.Namespace, pod.PodRef.Name, pod.PodRef.UID)
 	podMetrics := &MetricSet{
 		Labels:         this.cloneLabels(nodeLabels),
 		MetricValues:   map[string]MetricValue{},
@@ -197,6 +201,7 @@ func (this *summaryMetricsSource) decodePodStats(metrics map[string]*MetricSet, 
 }
 
 func (this *summaryMetricsSource) decodeContainerStats(podLabels map[string]string, container *stats.ContainerStats) *MetricSet {
+	glog.V(9).Infof("Decoding container stats stats for container %s...", container.Name)
 	containerMetrics := &MetricSet{
 		Labels:         this.cloneLabels(podLabels),
 		MetricValues:   map[string]MetricValue{},
@@ -219,6 +224,7 @@ func (this *summaryMetricsSource) decodeContainerStats(podLabels map[string]stri
 
 func (this *summaryMetricsSource) decodeUptime(metrics *MetricSet, startTime time.Time) {
 	if startTime.IsZero() {
+		glog.V(9).Infof("missing start time!")
 		return
 	}
 
@@ -228,6 +234,7 @@ func (this *summaryMetricsSource) decodeUptime(metrics *MetricSet, startTime tim
 
 func (this *summaryMetricsSource) decodeCPUStats(metrics *MetricSet, cpu *stats.CPUStats) {
 	if cpu == nil {
+		glog.V(9).Infof("missing cpu usage metric!")
 		return
 	}
 
@@ -236,6 +243,7 @@ func (this *summaryMetricsSource) decodeCPUStats(metrics *MetricSet, cpu *stats.
 
 func (this *summaryMetricsSource) decodeMemoryStats(metrics *MetricSet, memory *stats.MemoryStats) {
 	if memory == nil {
+		glog.V(9).Infof("missing memory metrics!")
 		return
 	}
 
@@ -247,6 +255,7 @@ func (this *summaryMetricsSource) decodeMemoryStats(metrics *MetricSet, memory *
 
 func (this *summaryMetricsSource) decodeNetworkStats(metrics *MetricSet, network *stats.NetworkStats) {
 	if network == nil {
+		glog.V(9).Infof("missing network metrics!")
 		return
 	}
 
@@ -258,6 +267,7 @@ func (this *summaryMetricsSource) decodeNetworkStats(metrics *MetricSet, network
 
 func (this *summaryMetricsSource) decodeFsStats(metrics *MetricSet, fsKey string, fs *stats.FsStats) {
 	if fs == nil {
+		glog.V(9).Infof("missing fs metrics!")
 		return
 	}
 
@@ -307,6 +317,7 @@ func (this *summaryMetricsSource) getScrapeTime(cpu *stats.CPUStats, memory *sta
 // addIntMetric is a convenience method for adding the metric and value to the metric set.
 func (this *summaryMetricsSource) addIntMetric(metrics *MetricSet, metric *Metric, value *uint64) {
 	if value == nil {
+		glog.V(9).Infof("skipping metric %s because the value was nil", metric.Name)
 		return
 	}
 	val := MetricValue{
@@ -320,6 +331,7 @@ func (this *summaryMetricsSource) addIntMetric(metrics *MetricSet, metric *Metri
 // addLabeledIntMetric is a convenience method for adding the labeled metric and value to the metric set.
 func (this *summaryMetricsSource) addLabeledIntMetric(metrics *MetricSet, metric *Metric, labels map[string]string, value *uint64) {
 	if value == nil {
+		glog.V(9).Infof("skipping labeled metric %s (%v) because the value was nil", metric.Name, labels)
 		return
 	}
 


### PR DESCRIPTION
This commit adds additional logging in the rate calculator and summary
source around potential points of failure.  Namely, additional logging
was introduced when the rate calculator skips calculation, and the
summary source was enhanced to log additional information about fetching
and processing data from the Kubelet at levels 9 and 10 (the latter of
which simply logs the entire response from the Kubelet).