### PR TITLE
[Hawkular] Add labels as individual tags

### DIFF
--- a/docs/sink-configuration.md
+++ b/docs/sink-configuration.md
@@ -86,6 +86,7 @@ The following options are available:
   * `name` - The syntax is `name(regexp)` where MetricName is matched (such as `cpu/usage`) with a `regexp` filter
 * `batchSize`- How many metrics are sent in each request to Hawkular-Metrics (default is 1000)
 * `concurrencyLimit`- How many concurrent requests are used to send data to the Hawkular-Metrics (default is 5)
+* `labelTagPrefix` - A prefix to be placed in front of each label when stored as a tag for the metric (default is `labels.`)
 
 A combination of `insecure` / `caCert` / `auth` is not supported, only a single of these parameters is allowed at once. Also, combination of `useServiceAccount` and `user` + `pass` is not supported. To increase the performance of Hawkular sink in case of multiple instances of Hawkular-Metrics (such as scaled scenario in OpenShift) modify the parameters of batchSize and concurrencyLimit to balance the load on Hawkular-Metrics instances.
 

--- a/metrics/sinks/hawkular/client.go
+++ b/metrics/sinks/hawkular/client.go
@@ -174,6 +174,17 @@ func (h *hawkularSink) registerLabeledIfNecessary(ms *core.MetricSet, metric cor
 			// Set tag values
 			for k, v := range ms.Labels {
 				mdd.Tags[k] = v
+				if k == core.LabelLabels.Key {
+					labels := strings.Split(v, ",")
+					for _, label := range labels {
+						labelKeyValue := strings.Split(label, ":")
+						if len(labelKeyValue) != 2 {
+							glog.V(4).Infof("Could not split the label %v into its key and value pair. This label will not be added as a tag in Hawkular Metrics.", label)
+						} else {
+							mdd.Tags[h.labelTagPrefix+labelKeyValue[0]] = labelKeyValue[1]
+						}
+					}
+				}
 			}
 
 			// Set the labeled values

--- a/metrics/sinks/hawkular/driver.go
+++ b/metrics/sinks/hawkular/driver.go
@@ -43,6 +43,9 @@ const (
 
 	nodeId string = "labelNodeId"
 
+	labelTagPrefixOpts    = "labelTagPrefix"
+	labelTagPrefixDefault = "labels."
+
 	defaultServiceAccountFile = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 )
 
@@ -210,6 +213,12 @@ func (h *hawkularSink) init() error {
 
 	if v, found := opts["labelToTenant"]; found {
 		h.labelTenant = v[0]
+	}
+
+	if v, found := opts[labelTagPrefixOpts]; found {
+		h.labelTagPrefix = v[0]
+	} else {
+		h.labelTagPrefix = labelTagPrefixDefault
 	}
 
 	if v, found := opts[nodeId]; found {

--- a/metrics/sinks/hawkular/types.go
+++ b/metrics/sinks/hawkular/types.go
@@ -53,10 +53,11 @@ type hawkularSink struct {
 
 	uri *url.URL
 
-	labelTenant string
-	labelNodeId string
-	modifiers   []metrics.Modifier
-	filters     []Filter
+	labelTenant    string
+	labelNodeId    string
+	labelTagPrefix string
+	modifiers      []metrics.Modifier
+	filters        []Filter
 
 	batchSize int
 }


### PR DESCRIPTION
Update to include labels as individual tags in Hawkular Metrics. This will make querying based on labels from Hawkular Metrics easier to use. The existing 'labels' tag which includes the comma separated list will still be stored.