### PR TITLE
Use -race on amd64 only when running tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,11 @@ sanitize:
 	hooks/run_vet.sh
 
 test-unit: clean sanitize build
+ifeq ($(ARCH),amd64)
 	GOARCH=$(ARCH) go test --test.short -race ./... $(FLAGS)
+else
+	GOARCH=$(ARCH) go test --test.short ./... $(FLAGS)
+endif
 
 test-unit-cov: clean sanitize build
 	hooks/coverage.sh


### PR DESCRIPTION
Use -race on amd64 only, -race is only supported by go test on amd64

This will allow tests to be run on s390x.  This is a follow-up to https://github.com/kubernetes/heapster/pull/1357