### PR TITLE
Validate metric resolution

### DIFF
--- a/metrics/heapster.go
+++ b/metrics/heapster.go
@@ -67,6 +67,8 @@ func main() {
 	logs.InitLogs()
 	defer logs.FlushLogs()
 
+	validateOptionsOrDie(opt)
+
 	setLabelSeperator(opt)
 	setMaxProcs(opt)
 	glog.Infof(strings.Join(os.Args, " "))
@@ -356,4 +358,12 @@ func setMaxProcs(opt *options.HeapsterRunOptions) {
 
 func setLabelSeperator(opt *options.HeapsterRunOptions) {
 	util.SetLabelSeperator(opt.LabelSeperator)
+}
+func validateOptionsOrDie(opts *options.HeapsterRunOptions) {
+	// if we allow user to specify scrapeOffset in the future, we should compare to max(manager.MinMetricResolution,user-specified-scrapeOffset)
+	if opts.MetricResolution < manager.MinMetricResolution {
+		glog.Fatalf(
+			"Option metric_resolution must be equal to or greater than %d seconds, metric_resolution:%v",
+			manager.MinMetricResolution/time.Second, opts.MetricResolution)
+	}
 }

--- a/metrics/manager/manager.go
+++ b/metrics/manager/manager.go
@@ -26,6 +26,10 @@ import (
 const (
 	DefaultScrapeOffset   = 5 * time.Second
 	DefaultMaxParallelism = 3
+
+	// MinMetricResolution is the minimum value of metric resolution.
+	// should always be equal to or greater than DefaultScrapeOffset.
+	MinMetricResolution = 30 * time.Second
 )
 
 var (


### PR DESCRIPTION
this PR fixes a bug when metric_resolution is less than DefaultScrapeOffset. When metric_resolution is less than DefaultScrapeOffset, some MetricSets will not be scraped from sources

in `Housekeep()` function ( `manager.go` ) , let's assume:
1. we ignore execution time of one iteration of `Housekeep()` function
2. metric_resolution: `4s`
3. now time in first iteration:  `13:03` ( format  minutes : seconds)

then in first iteration:
start : `13:00`
end: `13:04`

and then the second iteration:
now: `13:09`
start: `13:08`
end: `13:12`

we can see MetricSets between 13:04 and 13:08 will not be scraped.

if metric_resolution is equal to or greater than scrapeOffset, this case will not happen.
 
