### PR TITLE
Fix retention policy configuration

### DIFF
--- a/common/influxdb/dummy_influxdb.go
+++ b/common/influxdb/dummy_influxdb.go
@@ -26,11 +26,12 @@ type PointSavedToInfluxdb struct {
 }
 
 type FakeInfluxDBClient struct {
-	Pnts []PointSavedToInfluxdb
+	Pnts    []PointSavedToInfluxdb
+	Queries []influxdb.Query
 }
 
 func NewFakeInfluxDBClient() *FakeInfluxDBClient {
-	return &FakeInfluxDBClient{[]PointSavedToInfluxdb{}}
+	return &FakeInfluxDBClient{[]PointSavedToInfluxdb{}, []influxdb.Query{}}
 }
 
 func (client *FakeInfluxDBClient) Write(bps influxdb.BatchPoints) (*influxdb.Response, error) {
@@ -41,6 +42,8 @@ func (client *FakeInfluxDBClient) Write(bps influxdb.BatchPoints) (*influxdb.Res
 }
 
 func (client *FakeInfluxDBClient) Query(q influxdb.Query) (*influxdb.Response, error) {
+	client.Queries = append(client.Queries, q)
+
 	numQueries := strings.Count(q.Command, ";")
 
 	// return an empty result for each separate query
@@ -56,9 +59,10 @@ func (client *FakeInfluxDBClient) Ping() (time.Duration, string, error) {
 var Client = NewFakeInfluxDBClient()
 
 var Config = InfluxdbConfig{
-	User:     "root",
-	Password: "root",
-	Host:     "localhost:8086",
-	DbName:   "k8s",
-	Secure:   false,
+	User:            "root",
+	Password:        "root",
+	Host:            "localhost:8086",
+	DbName:          "k8s",
+	Secure:          false,
+	RetentionPolicy: "1d",
 }

--- a/events/sinks/influxdb/influxdb.go
+++ b/events/sinks/influxdb/influxdb.go
@@ -189,36 +189,18 @@ func (sink *influxdbSink) createDatabase() error {
 	}
 
 	q := influxdb.Query{
-		Command: fmt.Sprintf(`CREATE DATABASE %s WITH NAME "default"`, sink.c.DbName),
+		Command: fmt.Sprintf(`CREATE DATABASE %s WITH DURATION %s REPLICATION 1 NAME "default"`, sink.c.DbName, sink.c.RetentionPolicy),
 	}
 
-	if resp, err := sink.client.Query(q); err != nil {
-		// We want to return error only if it is not "already exists" error.
-		if !(resp != nil && resp.Err != nil && strings.Contains(resp.Err.Error(), "existing policy")) {
-			err := sink.createRetentionPolicy()
-			if err != nil {
-				return err
-			}
+	if resp, err := sink.client.Query(q); err != nil || resp.Error() != nil {
+		if err != nil {
+			return err
+		} else {
+			return resp.Error()
 		}
 	}
 
 	sink.dbExists = true
-	glog.Infof("Created database %q on influxDB server at %q", sink.c.DbName, sink.c.Host)
-	return nil
-}
-
-func (sink *influxdbSink) createRetentionPolicy() error {
-	q := influxdb.Query{
-		Command: fmt.Sprintf(`CREATE RETENTION POLICY "default" ON %s DURATION 0d REPLICATION 1 DEFAULT`, sink.c.DbName),
-	}
-
-	if resp, err := sink.client.Query(q); err != nil {
-		// We want to return error only if it is not "already exists" error.
-		if !(resp != nil && resp.Err != nil && strings.Contains(resp.Err.Error(), "already exists")) {
-			return fmt.Errorf("Retention policy creation failed: %v", err)
-		}
-	}
-
 	glog.Infof("Created database %q on influxDB server at %q", sink.c.DbName, sink.c.Host)
 	return nil
 }

--- a/events/sinks/influxdb/influxdb_test.go
+++ b/events/sinks/influxdb/influxdb_test.go
@@ -15,6 +15,7 @@
 package influxdb
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -42,6 +43,15 @@ func NewFakeSink() fakeInfluxDBEventSink {
 		},
 		influxdb_common.Client,
 	}
+}
+
+func TestRetentionConfiguredOnDatabase(t *testing.T) {
+	fakeSink := NewFakeSink()
+	eventBatch := core.EventBatch{}
+	fakeSink.ExportEvents(&eventBatch)
+	retentionParameters := fmt.Sprintf("DURATION %s", influxdb_common.Config.RetentionPolicy)
+	databaseCreationQuery := fakeSink.fakeDbClient.Queries[0]
+	assert.Contains(t, databaseCreationQuery.Command, retentionParameters)
 }
 
 func TestStoreDataEmptyInput(t *testing.T) {

--- a/metrics/sinks/influxdb/influxdb_test.go
+++ b/metrics/sinks/influxdb/influxdb_test.go
@@ -55,6 +55,15 @@ func TestStoreDataEmptyInput(t *testing.T) {
 	assert.Equal(t, 0, len(fakeSink.fakeDbClient.Pnts))
 }
 
+func TestRetentionConfiguredOnDatabase(t *testing.T) {
+	fakeSink := NewFakeSink()
+	dataBatch := core.DataBatch{}
+	fakeSink.ExportData(&dataBatch)
+	retentionParameters := fmt.Sprintf("DURATION %s", influxdb_common.Config.RetentionPolicy)
+	databaseCreationQuery := fakeSink.fakeDbClient.Queries[0]
+	assert.Contains(t, databaseCreationQuery.Command, retentionParameters)
+}
+
 func TestStoreMultipleDataInput(t *testing.T) {
 	fakeSink := NewFakeSink()
 	timestamp := time.Now()


### PR DESCRIPTION
This pull request fixes several issues with the current code used to configure retention:
 - createRetentionPolicy only being called in case of errors at database creation time,
 - retention policy name conflict with the default policy,
 - retention policy configuration not implemented for events which use the same database.
