### PR TITLE
bump grafana version

### DIFF
--- a/grafana/Makefile
+++ b/grafana/Makefile
@@ -19,12 +19,12 @@
 
 all: build
 
-VERSION?=v4.0.2
+VERSION?=v4.1.2
 PREFIX?=gcr.io/google_containers
 ARCH?=amd64
 TEMP_DIR:=$(shell mktemp -d)
 LDFLAGS=-w -X main.version=$(VERSION) -X main.commit=unknown-dev -X main.timestamp=0 -extldflags '-static'
-DEB_BUILD=4.0.2-1481203731
+DEB_BUILD=4.1.2-1486989747
 KUBE_CROSS_IMAGE=gcr.io/google_containers/kube-cross:v1.7.3-0
 
 # s390x


### PR DESCRIPTION
This new version has VictorOps support and other fixes.

Changelogs:
 
- https://github.com/grafana/grafana/releases/tag/v4.1.0
- https://github.com/grafana/grafana/releases/tag/v4.1.1
- https://github.com/grafana/grafana/releases/tag/v4.1.2