### PR TITLE
VPA Recommender Sink and Recommender JSON Client added.

### DIFF
--- a/common/vpa/json_client.go
+++ b/common/vpa/json_client.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vpa
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+)
+
+type httpJSONClient struct {
+	url string
+}
+
+type JSONClient interface {
+	SendJSON(object interface{}) ([]byte, error)
+}
+
+func CreateRecommenderClient(url string) JSONClient {
+	return &httpJSONClient{url: url}
+}
+
+func (c *httpJSONClient) SendJSON(object interface{}) ([]byte, error) {
+	data, err := json.Marshal(object)
+	if err != nil {
+		return nil, err
+	}
+
+	response, err := c.sendData(data, "application/json")
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+func (c *httpJSONClient) sendData(data []byte, dataType string) ([]byte, error) {
+	resp, err := http.Post(c.url, dataType, bytes.NewBuffer(data))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return body, nil
+}

--- a/common/vpa/json_client.go
+++ b/common/vpa/json_client.go
@@ -1,18 +1,16 @@
-/*
-Copyright 2017 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package vpa
 

--- a/common/vpa/json_client_test.go
+++ b/common/vpa/json_client_test.go
@@ -1,18 +1,16 @@
-/*
-Copyright 2017 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package vpa
 

--- a/common/vpa/json_client_test.go
+++ b/common/vpa/json_client_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vpa
+
+import (
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+const (
+	protocol        = "http://"
+	fakeAddress     = "localhost:8989"
+	fakeHandlerName = "/echo"
+)
+
+func spinOffFakeRecommenderServer() (io.Closer, error) {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc(fakeHandlerName, func(w http.ResponseWriter, r *http.Request) { // echo server
+		body, _ := ioutil.ReadAll(r.Body)
+		w.Write(body)
+	})
+
+	server := &http.Server{Addr: fakeAddress, Handler: mux}
+	listener, err := net.Listen("tcp", fakeAddress) //created manually, to be able to close server later
+	if err != nil {
+		return nil, err
+	}
+
+	go server.Serve(listener)
+
+	return listener, nil
+}
+
+func createFakeHTTPRecommenderClient() *httpJSONClient {
+	client := &httpJSONClient{url: protocol + fakeAddress + fakeHandlerName}
+	return client
+}
+
+func createFakeRecommenderClient() JSONClient {
+	client := CreateRecommenderClient(protocol + fakeAddress + fakeHandlerName)
+	return client
+}
+
+func TestSendJSON(t *testing.T) {
+	closer, err := spinOffFakeRecommenderServer()
+	if err != nil {
+		t.Fatalf("Unable to create server %s", err.Error())
+	}
+	defer closer.Close()
+
+	type SampleObject struct {
+		Name string
+		Body string
+		Time int64
+	}
+
+	obj := SampleObject{"Alice", "Hello", 1294706395881547000}
+	client := createFakeRecommenderClient()
+
+	response, err := client.SendJSON(obj)
+	if err != nil {
+		t.Fatalf("Unable to send JSON: %s", err.Error())
+	}
+	var returnedObj SampleObject
+	err = json.Unmarshal(response, &returnedObj)
+	if err != nil {
+		t.Fatalf("Unable to unmarshal JSON '%s' because of error: %s", string(response), err.Error())
+	}
+
+	if !reflect.DeepEqual(obj, returnedObj) {
+		t.Errorf("Returned object: %+v do not match object which was sent: %+v ", returnedObj, obj)
+	}
+}
+
+func TestSendData(t *testing.T) {
+	closer, err := spinOffFakeRecommenderServer()
+	if err != nil {
+		t.Fatalf("Unable to create server %s", err.Error())
+	}
+	defer closer.Close()
+
+	const requestBody = "fake request body"
+	requestData := []byte(requestBody)
+
+	client := createFakeHTTPRecommenderClient()
+	resp, err := client.sendData(requestData, "plain/text")
+
+	if err != nil {
+		t.Fatalf("Unable to process rqquest %s", err.Error())
+	}
+
+	if string(resp) != string(requestData) {
+		t.Errorf("Request body '%s' do not match response '%s'", requestData, resp)
+	}
+}

--- a/metrics/core/types.go
+++ b/metrics/core/types.go
@@ -117,14 +117,20 @@ func (this *LabeledMetric) GetValue() interface{} {
 	}
 }
 
+//all the metrics from single resource (like pod or container)
 type MetricSet struct {
-	CreateTime     time.Time
-	ScrapeTime     time.Time
-	MetricValues   map[string]MetricValue
-	Labels         map[string]string
+	//time when measured resource was created
+	CreateTime time.Time
+	ScrapeTime time.Time
+	//standard metrics of resource, mapped by metric name from metrics.go
+	MetricValues map[string]MetricValue
+	//labels for entire object (not single value)
+	Labels map[string]string
+	//metrics for sub-resources (like disks)
 	LabeledMetrics []LabeledMetric
 }
 
+//Representation of all the metrics from single "scrape"
 type DataBatch struct {
 	Timestamp time.Time
 	// Should use key functions from ms_keys.go

--- a/metrics/sinks/factory.go
+++ b/metrics/sinks/factory.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/heapster/metrics/sinks/opentsdb"
 	"k8s.io/heapster/metrics/sinks/riemann"
 	"k8s.io/heapster/metrics/sinks/stackdriver"
+	"k8s.io/heapster/metrics/sinks/vpa"
 	"k8s.io/heapster/metrics/sinks/wavefront"
 )
 
@@ -69,6 +70,8 @@ func (this *SinkFactory) Build(uri flags.Uri) (core.DataSink, error) {
 		return wavefront.NewWavefrontSink(&uri.Val)
 	case "riemann":
 		return riemann.CreateRiemannSink(&uri.Val)
+	case "vpa":
+		return vpa.CreateRecommenderSink(&uri.Val)
 	default:
 		return nil, fmt.Errorf("Sink not recognized: %s", uri.Key)
 	}

--- a/metrics/sinks/vpa/container_utilization.go
+++ b/metrics/sinks/vpa/container_utilization.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vpa
+
+import (
+	"github.com/pkg/errors"
+	"k8s.io/heapster/metrics/core"
+	"time"
+)
+
+type utilizationSnapshotSet struct {
+	Containers []*containerUtilizationSnapshot `json:"containers"`
+}
+
+func (set *utilizationSnapshotSet) addContainer(utilizationSnapshot *containerUtilizationSnapshot) {
+	set.Containers = append(set.Containers, utilizationSnapshot)
+}
+
+type containerUtilizationSnapshot struct {
+	CreateTime     time.Time `json:"createTime"`
+	ScrapTime      time.Time `json:"scrapTime"`
+	ContainerName  string    `json:"containerName"`
+	ContainerImage string    `json:"containerImage"`
+	PodId          string    `json:"podId"`
+	// Amount of requested memory.
+	// Units: Bytes.
+	MemoryRequest int64 `json:"memoryRequest"`
+	// Current, total memory usage
+	// Units: Bytes.
+	MemoryUsage int64 `json:"memoryUsage"`
+	// Guaranteed amount of CPU
+	// Units: Millicores.
+	CpuRequest int64 `json:"cpuRequest"`
+	// Avg CPU usage since last scrap time
+	// Units: Millicores.
+	CpuUsageRate int64 `json:"cpuUsageRate"`
+}
+
+func newContainerUtilizationSnapshot(metricSet *core.MetricSet) (*containerUtilizationSnapshot, error) {
+	err := validateMetricSet(metricSet)
+	if err != nil {
+		return nil, err
+	}
+
+	snapshot := containerUtilizationSnapshot{
+		CreateTime:     metricSet.CreateTime,
+		ScrapTime:      metricSet.ScrapeTime,
+		ContainerName:  metricSet.Labels[core.LabelContainerName.Key],
+		ContainerImage: metricSet.Labels[core.LabelContainerBaseImage.Key],
+		PodId:          metricSet.Labels[core.LabelPodId.Key],
+		MemoryRequest:  metricSet.MetricValues[core.MetricMemoryRequest.Name].IntValue,
+		MemoryUsage:    metricSet.MetricValues[core.MetricMemoryUsage.Name].IntValue,
+		CpuRequest:     metricSet.MetricValues[core.MetricCpuRequest.Name].IntValue,
+		CpuUsageRate:   metricSet.MetricValues[core.MetricCpuUsageRate.Name].IntValue,
+	}
+	return &snapshot, nil
+}
+
+func validateMetricSet(metricSet *core.MetricSet) error {
+	if metricSet.Labels == nil || metricSet.MetricValues == nil {
+		return errors.New("MetricSet needs both 'Labels' and 'MetricValues' not null")
+	}
+	if metricSet.Labels[core.LabelContainerName.Key] == "" ||
+		metricSet.Labels[core.LabelContainerBaseImage.Key] == "" ||
+		metricSet.Labels[core.LabelPodId.Key] == "" {
+
+		return errors.Errorf("MetricSet is missing one of the labels: %s, %s, %s", core.LabelContainerName.Key,
+			core.LabelContainerBaseImage.Key, core.LabelPodId.Key)
+	}
+
+	return nil
+}

--- a/metrics/sinks/vpa/container_utilization.go
+++ b/metrics/sinks/vpa/container_utilization.go
@@ -1,18 +1,16 @@
-/*
-Copyright 2017 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package vpa
 

--- a/metrics/sinks/vpa/recommender.go
+++ b/metrics/sinks/vpa/recommender.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vpa
+
+import (
+	"github.com/golang/glog"
+	"k8s.io/heapster/common/vpa"
+	"k8s.io/heapster/metrics/core"
+	"net/url"
+	"sync"
+)
+
+type recommenderSink struct {
+	recommenderClient vpa.JSONClient
+	sync.RWMutex
+}
+
+func CreateRecommenderSink(uri *url.URL) (core.DataSink, error) {
+	jsonClient := vpa.CreateRecommenderClient(uri.String())
+	recommenderSink := recommenderSink{recommenderClient: jsonClient}
+
+	return &recommenderSink, nil
+}
+
+func (sink *recommenderSink) ExportData(dataBatch *core.DataBatch) {
+	sink.Lock()
+	defer sink.Unlock()
+
+	snapshotSet := utilizationSnapshotSet{}
+	for _, metricSet := range dataBatch.MetricSets {
+		if !isContainerMetricSet(metricSet) {
+			continue //skip for non-container metrics
+		}
+		utilizationSnapshot, err := newContainerUtilizationSnapshot(metricSet)
+		if err == nil {
+			snapshotSet.addContainer(utilizationSnapshot)
+		} else {
+			glog.Warningf("Unable to create utilization snapshot, due to error: %s", err.Error())
+		}
+	}
+
+	sink.sendAllSnapshots(&snapshotSet)
+}
+
+func (sink *recommenderSink) sendAllSnapshots(set *utilizationSnapshotSet) {
+	if len(set.Containers) > 0 {
+		_, err := sink.recommenderClient.SendJSON(set)
+		if err != nil {
+			glog.Errorf("Unable to send utilization snapshot to VPA recommender, due to error: %s", err)
+		}
+	}
+}
+
+func (sink *recommenderSink) Name() string {
+	return "VPA Recommender Sink"
+}
+
+func (sink *recommenderSink) Stop() {
+	// nothing needs to be done.
+}
+
+func isContainerMetricSet(metricSet *core.MetricSet) bool {
+	return metricSet.Labels[core.LabelContainerName.Key] != "" && metricSet.Labels[core.LabelContainerBaseImage.Key] != ""
+}

--- a/metrics/sinks/vpa/recommender.go
+++ b/metrics/sinks/vpa/recommender.go
@@ -1,18 +1,16 @@
-/*
-Copyright 2017 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package vpa
 

--- a/metrics/sinks/vpa/recommender_test.go
+++ b/metrics/sinks/vpa/recommender_test.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vpa
+
+import (
+	"github.com/stretchr/testify/assert"
+	"k8s.io/heapster/metrics/core"
+	"reflect"
+	"testing"
+	"time"
+)
+
+type fakeJSONClient struct {
+	objectsSent []interface{}
+}
+
+func (client *fakeJSONClient) SendJSON(object interface{}) ([]byte, error) {
+	client.objectsSent = append(client.objectsSent, object)
+	return []byte{}, nil
+}
+
+func createFakeRecommenderSink() (core.DataSink, *fakeJSONClient) {
+	fakeJSONClient := &fakeJSONClient{objectsSent: make([]interface{}, 0, 10)}
+	return &recommenderSink{recommenderClient: fakeJSONClient}, fakeJSONClient
+}
+
+func createContainerMetricSet(containerName, containerImage, podId string, cpuUsageRate, memoryUsage int64) *core.MetricSet {
+	now := time.Now()
+	hourAgo := now.Add(-1 * time.Hour)
+
+	containerLabels := map[string]string{
+		core.LabelContainerName.Key:      containerName,
+		core.LabelContainerBaseImage.Key: containerImage,
+		core.LabelPodId.Key:              podId,
+		core.LabelNamespaceName.Key:      "default-namespace",
+	}
+
+	metricValues := createMetricValues(cpuUsageRate, memoryUsage, 1000, 2000)
+
+	return &core.MetricSet{
+		CreateTime:   hourAgo,
+		ScrapeTime:   now,
+		Labels:       containerLabels,
+		MetricValues: metricValues,
+	}
+}
+
+func createPodMetricSet(podId string, cpuUsageRate, memoryUsage int64) *core.MetricSet {
+	metricSet := createContainerMetricSet("", "", podId, cpuUsageRate, memoryUsage)
+
+	delete(metricSet.Labels, core.LabelContainerName.Key)
+	delete(metricSet.Labels, core.LabelContainerBaseImage.Key)
+
+	return metricSet
+}
+
+func createMetricValues(cpuUsageRate, memoryUsage, cpuRequest, memoryRequest int64) map[string]core.MetricValue {
+	return map[string]core.MetricValue{
+		core.MetricCpuUsageRate.Name: {
+			MetricType: core.MetricCpuUsageRate.Type,
+			ValueType:  core.MetricCpuUsageRate.ValueType,
+			IntValue:   cpuUsageRate,
+		},
+		core.MetricMemoryUsage.Name: {
+			MetricType: core.MetricMemoryUsage.Type,
+			ValueType:  core.MetricMemoryUsage.ValueType,
+			IntValue:   memoryUsage,
+		},
+		core.MetricMemoryRequest.Name: {
+			MetricType: core.MetricMemoryRequest.Type,
+			ValueType:  core.MetricMemoryRequest.ValueType,
+			IntValue:   memoryRequest,
+		},
+		core.MetricCpuRequest.Name: {
+			MetricType: core.MetricCpuRequest.Type,
+			ValueType:  core.MetricCpuRequest.ValueType,
+			IntValue:   cpuRequest,
+		},
+	}
+}
+
+func TestEmptyExportData(t *testing.T) {
+	sink, jsonClient := createFakeRecommenderSink()
+	batch := core.DataBatch{
+		Timestamp:  time.Now(),
+		MetricSets: map[string]*core.MetricSet{},
+	}
+
+	sink.ExportData(&batch)
+
+	assert.Empty(t, jsonClient.objectsSent)
+}
+
+func TestExportData(t *testing.T) {
+	sink, jsonClient := createFakeRecommenderSink()
+
+	containerSet1 := createContainerMetricSet("container1", "gcr.io/google_containers/image1", "123", 123, 456)
+	containerSet2 := createContainerMetricSet("container2", "gcr.io/google_containers/image2", "234", 234, 567)
+	containerSet3 := createContainerMetricSet("container3", "gcr.io/google_containers/image3", "345", 345, 678)
+
+	podSet1 := createPodMetricSet("pod1", 1234, 5678)
+	podSet2 := createPodMetricSet("pod2", 2345, 6789)
+
+	metricSets := map[string]*core.MetricSet{
+		"container1": containerSet1,
+		"container2": containerSet2,
+		"container3": containerSet3,
+		"pod1":       podSet1,
+		"pod2":       podSet2,
+	}
+
+	batch := core.DataBatch{
+		Timestamp:  time.Now(),
+		MetricSets: metricSets,
+	}
+
+	sink.ExportData(&batch)
+
+	assert.Equal(t, 1, len(jsonClient.objectsSent))
+
+	actualObjectType := reflect.TypeOf((*utilizationSnapshotSet)(nil)).Elem()
+	sentObjectType := reflect.TypeOf(jsonClient.objectsSent[0]).Elem()
+
+	assert.Equal(t, actualObjectType, sentObjectType, "Objects sent should be of 'containerUtilizationSnapshot' type")
+
+	set := jsonClient.objectsSent[0].(*utilizationSnapshotSet)
+	assert.Equal(t, 3, len(set.Containers))
+}
+
+const (
+	containerName  = "container"
+	containerImage = "gcr.io/google_containers/image1"
+	podId          = "123"
+	cpuUsageRate   = int64(123)
+	memoryUsage    = int64(456)
+)
+
+func TestContainerUtilizationSnapshotCreation(t *testing.T) {
+	metricSet := createContainerMetricSet(containerName, containerImage, podId, cpuUsageRate, memoryUsage)
+	snapshot, err := newContainerUtilizationSnapshot(metricSet)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, snapshot)
+	assert.Equal(t, containerName, snapshot.ContainerName)
+	assert.Equal(t, containerImage, snapshot.ContainerImage)
+	assert.Equal(t, podId, snapshot.PodId)
+	assert.Equal(t, cpuUsageRate, snapshot.CpuUsageRate)
+	assert.Equal(t, memoryUsage, snapshot.MemoryUsage)
+}
+
+func TestContainerUtilizationSnapshotCreationError(t *testing.T) {
+	metricSet := createContainerMetricSet("", containerImage, podId, cpuUsageRate, memoryUsage)
+	_, err := newContainerUtilizationSnapshot(metricSet)
+	assert.Error(t, err)
+
+	metricSet = createContainerMetricSet(containerName, "", podId, cpuUsageRate, memoryUsage)
+	_, err = newContainerUtilizationSnapshot(metricSet)
+	assert.Error(t, err)
+
+	metricSet = createContainerMetricSet(containerName, containerImage, "", cpuUsageRate, memoryUsage)
+	_, err = newContainerUtilizationSnapshot(metricSet)
+	assert.Error(t, err)
+
+	metricSet = createContainerMetricSet(containerName, containerImage, podId, cpuUsageRate, memoryUsage)
+	metricSet.Labels = nil
+	_, err = newContainerUtilizationSnapshot(metricSet)
+	assert.Error(t, err)
+}

--- a/metrics/sinks/vpa/recommender_test.go
+++ b/metrics/sinks/vpa/recommender_test.go
@@ -1,18 +1,16 @@
-/*
-Copyright 2017 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+// Copyright 2017 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package vpa
 


### PR DESCRIPTION
This is a DataSink implementation, which will be sending container utilization data to VPA Recommender, described in [Pull Request 338](https://github.com/kubernetes/community/pull/338)

@mwielgus @kgrygiel and @piosz please review.