### PR TITLE
Associate system:heapster cluster role to heapster service account in influxdb deploy configuration

### DIFF
--- a/deploy/kube-config/influxdb/heapster-cluster-role-binding.yml
+++ b/deploy/kube-config/influxdb/heapster-cluster-role-binding.yml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: heapster
+subjects:
+- kind: ServiceAccount
+  name: heapster
+  namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: system:heapster
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/kube-config/influxdb/heapster-deployment.yaml
+++ b/deploy/kube-config/influxdb/heapster-deployment.yaml
@@ -19,3 +19,5 @@ spec:
         - /heapster
         - --source=kubernetes:https://kubernetes.default
         - --sink=influxdb:http://monitoring-influxdb:8086
+      serviceAccount: heapster
+      serviceAccountName: heapster

--- a/deploy/kube-config/influxdb/heapster-service-account.yaml
+++ b/deploy/kube-config/influxdb/heapster-service-account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: heapster
+  namespace: kube-system


### PR DESCRIPTION
For the influxdb deployment configuration, there is no creation of service account and cluster role binding to associate heapster with cluster role system:heapster (created during installation by kubeadm version 1.6.1). This lead to various errors in heapsters logs (heapster cannot get nodes, pods, namespaces, etc.).

This commit add a service account named heapster and a cluster role binding to associate the service account to the cluster role system:heapster.

It is possible that other deploy configuration need this.
