### PR TITLE
GCM: check err when parsing config URL

### DIFF
--- a/metrics/sinks/gcm/gcm.go
+++ b/metrics/sinks/gcm/gcm.go
@@ -306,6 +306,9 @@ func CreateGCMSink(uri *url.URL) (core.DataSink, error) {
 	}
 
 	opts, err := url.ParseQuery(uri.RawQuery)
+	if err != nil {
+		return nil, err
+	}
 
 	metrics := "all"
 	if len(opts["metrics"]) > 0 {


### PR DESCRIPTION
In CreateGCMSink function, check err when parsing raw query string, make sure the ***opts*** is valid.
Like in [NewKafkaClient](https://github.com/kubernetes/heapster/blob/master/common/kafka/kafka.go#L125), [CreateElasticSearchService](https://github.com/kubernetes/heapster/blob/master/common/elasticsearch/elasticsearch.go#L109).



Signed-off-by: yupengzte <yu.peng36@zte.com.cn>