### PR TITLE
delete pod_namespace && decrease influxdb labels

### DIFF
--- a/metrics/core/labels.go
+++ b/metrics/core/labels.go
@@ -36,11 +36,6 @@ var (
 		Key:         "pod_name",
 		Description: "The name of the pod",
 	}
-	// Deprecated label
-	LabelPodNamespace = LabelDescriptor{
-		Key:         "pod_namespace",
-		Description: "The namespace of the pod",
-	}
 	LabelNamespaceName = LabelDescriptor{
 		Key:         "namespace_name",
 		Description: "The name of the namespace",
@@ -114,7 +109,6 @@ var containerLabels = []LabelDescriptor{
 var podLabels = []LabelDescriptor{
 	LabelPodName,
 	LabelPodId,
-	LabelPodNamespace,
 	LabelPodNamespaceUID,
 	LabelLabels,
 }

--- a/metrics/processors/pod_aggregator.go
+++ b/metrics/processors/pod_aggregator.go
@@ -25,7 +25,6 @@ import (
 var LabelsToPopulate = []core.LabelDescriptor{
 	core.LabelPodId,
 	core.LabelPodName,
-	core.LabelPodNamespace,
 	core.LabelNamespaceName,
 	core.LabelPodNamespaceUID,
 	core.LabelHostname,

--- a/metrics/processors/pod_based_enricher.go
+++ b/metrics/processors/pod_based_enricher.go
@@ -103,7 +103,6 @@ func addContainerInfo(key string, containerMs *core.MetricSet, pod *kube_api.Pod
 				Labels: map[string]string{
 					core.LabelMetricSetType.Key: core.MetricSetTypePod,
 					core.LabelNamespaceName.Key: namespace,
-					core.LabelPodNamespace.Key:  namespace,
 					core.LabelPodName.Key:       podName,
 					core.LabelNodename.Key:      containerMs.Labels[core.LabelNodename.Key],
 					core.LabelHostname.Key:      containerMs.Labels[core.LabelHostname.Key],
@@ -133,7 +132,6 @@ func addPodInfo(key string, podMs *core.MetricSet, pod *kube_api.Pod, batch *cor
 					Labels: map[string]string{
 						core.LabelMetricSetType.Key:      core.MetricSetTypePodContainer,
 						core.LabelNamespaceName.Key:      pod.Namespace,
-						core.LabelPodNamespace.Key:       pod.Namespace,
 						core.LabelPodName.Key:            pod.Name,
 						core.LabelContainerName.Key:      container.Name,
 						core.LabelContainerBaseImage.Key: container.Image,

--- a/metrics/sinks/metric/metric_sink_test.go
+++ b/metrics/sinks/metric/metric_sink_test.go
@@ -30,7 +30,6 @@ func makeBatches(now time.Time, key, otherKey string) (core.DataBatch, core.Data
 			key: {
 				Labels: map[string]string{
 					core.LabelMetricSetType.Key: core.MetricSetTypePod,
-					core.LabelPodNamespace.Key:  "ns1",
 				},
 				MetricValues: map[string]core.MetricValue{
 					"m1": {
@@ -54,7 +53,6 @@ func makeBatches(now time.Time, key, otherKey string) (core.DataBatch, core.Data
 			key: {
 				Labels: map[string]string{
 					core.LabelMetricSetType.Key: core.MetricSetTypePod,
-					core.LabelPodNamespace.Key:  "ns1",
 				},
 				MetricValues: map[string]core.MetricValue{
 					"m1": {
@@ -98,7 +96,6 @@ func makeBatches(now time.Time, key, otherKey string) (core.DataBatch, core.Data
 			key: {
 				Labels: map[string]string{
 					core.LabelMetricSetType.Key: core.MetricSetTypePod,
-					core.LabelPodNamespace.Key:  "ns1",
 				},
 				MetricValues: map[string]core.MetricValue{
 					"m1": {
@@ -136,7 +133,6 @@ func makeBatches(now time.Time, key, otherKey string) (core.DataBatch, core.Data
 			otherKey: {
 				Labels: map[string]string{
 					core.LabelMetricSetType.Key: core.MetricSetTypePod,
-					core.LabelPodNamespace.Key:  "ns1",
 				},
 				MetricValues: map[string]core.MetricValue{
 					"m1": {
@@ -223,7 +219,6 @@ func TestGetNames(t *testing.T) {
 			key: {
 				Labels: map[string]string{
 					core.LabelMetricSetType.Key: core.MetricSetTypePod,
-					core.LabelPodNamespace.Key:  "ns1",
 					core.LabelNamespaceName.Key: "ns1",
 					core.LabelPodName.Key:       "pod1",
 				},
@@ -243,7 +238,6 @@ func TestGetNames(t *testing.T) {
 			otherKey: {
 				Labels: map[string]string{
 					core.LabelMetricSetType.Key: core.MetricSetTypePod,
-					core.LabelPodNamespace.Key:  "ns2",
 					core.LabelNamespaceName.Key: "ns2",
 					core.LabelPodName.Key:       "pod2",
 				},

--- a/metrics/sources/kubelet/kubelet.go
+++ b/metrics/sources/kubelet/kubelet.go
@@ -113,8 +113,6 @@ func (this *kubeletMetricsSource) handleKubernetesContainer(cName, ns, podName s
 	cMetrics.Labels[LabelPodId.Key] = c.Spec.Labels[kubernetesPodUID]
 	cMetrics.Labels[LabelPodName.Key] = podName
 	cMetrics.Labels[LabelNamespaceName.Key] = ns
-	// Needed for backward compatibility
-	cMetrics.Labels[LabelPodNamespace.Key] = ns
 	return metricSetKey
 }
 

--- a/metrics/sources/summary/summary.go
+++ b/metrics/sources/summary/summary.go
@@ -184,8 +184,6 @@ func (this *summaryMetricsSource) decodePodStats(metrics map[string]*MetricSet, 
 	podMetrics.Labels[LabelPodId.Key] = ref.UID
 	podMetrics.Labels[LabelPodName.Key] = ref.Name
 	podMetrics.Labels[LabelNamespaceName.Key] = ref.Namespace
-	// Needed for backward compatibility
-	podMetrics.Labels[LabelPodNamespace.Key] = ref.Namespace
 
 	this.decodeUptime(podMetrics, pod.StartTime.Time)
 	this.decodeNetworkStats(podMetrics, pod.Network)


### PR DESCRIPTION
Fix #1654 

What does this PR do: 
* delete `pod_namespace` label
* remove `pod_id`, `namespace_id` and `hostname`.

/cc @kubernetes/heapster-maintainers @piosz @DirectXMan12 