### PR TITLE
fix docs&&misc about delete pod_namespace

### DIFF
--- a/common/elasticsearch/mapping.go
+++ b/common/elasticsearch/mapping.go
@@ -140,15 +140,6 @@ func customMetricTypeSchema(typeName string, customSchema string) string {
             }
           }
         },
-        "pod_namespace": {
-          "type": "string",
-          "fields": {
-            "raw": {
-              "type": "string",
-              "index": "not_analyzed"
-            }
-          }
-        },
         "resource_id": {
           "type": "string",
           "index": "not_analyzed"

--- a/docs/storage-schema.md
+++ b/docs/storage-schema.md
@@ -51,14 +51,15 @@ Heapster tags each metric with the following labels.
 |----------------|-------------------------------------------------------------------------------|
 | pod_id         | Unique ID of a Pod                                                            |
 | pod_name       | User-provided name of a Pod                                                   |
-| pod_namespace  | The namespace of a Pod                                                        |
-| container_base_image | Base image for the container |  
+| container_base_image | Base image for the container |
 | container_name | User-provided name of the container or full cgroup name for system containers |
 | host_id        | Cloud-provider specified or user specified Identifier of a node               |
 | hostname       | Hostname where the container ran                                              |
+| nodename       | Nodename where the container ran                                              |
 | labels         | Comma-separated(Default) list of user-provided labels. Format is 'key:value'  |
 | namespace_id   | UID of the namespace of a Pod                                                 |
-| resource_id    | A unique identifier used to differentiate multiple metrics of the same type. e.x. Fs partitions under filesystem/usage | 
+| namespace_name | User-provided name of a Namespace                                             |
+| resource_id    | A unique identifier used to differentiate multiple metrics of the same type. e.x. Fs partitions under filesystem/usage |
 
 **Note**
   * Label separator can be configured with Heapster `--label-seperator`. Comma-seperated label pairs is fine until we use [Bosun](http://bosun.org) as alert system and use `group by labels` to search for labels.

--- a/grafana/dashboards/influxdb_withfields/pods.json
+++ b/grafana/dashboards/influxdb_withfields/pods.json
@@ -1041,7 +1041,7 @@
               "selected": false
             }
           ],
-          "query": "SHOW TAG VALUES FROM \"uptime\" WITH KEY = \"pod_name\" WHERE \"pod_namespace\" =~ /$namespace$/",
+          "query": "SHOW TAG VALUES FROM \"uptime\" WITH KEY = \"pod_name\" WHERE \"namespace_name\" =~ /$namespace$/",
           "refresh": true,
           "regex": "",
           "type": "query"

--- a/grafana/dashboards/pods.json
+++ b/grafana/dashboards/pods.json
@@ -1041,7 +1041,7 @@
               "selected": false
             }
           ],
-          "query": "SHOW TAG VALUES FROM \"uptime\" WITH KEY = \"pod_name\" WHERE \"pod_namespace\" =~ /$namespace$/",
+          "query": "SHOW TAG VALUES FROM \"uptime\" WITH KEY = \"pod_name\" WHERE \"namespace_name\" =~ /$namespace$/",
           "refresh": true,
           "regex": "",
           "type": "query"

--- a/metrics/sinks/opentsdb/driver_test.go
+++ b/metrics/sinks/opentsdb/driver_test.go
@@ -35,7 +35,6 @@ var (
 		"name": "redis",
 		"io.kubernetes.pod.name": "default/redis-test",
 		"pod_id":                 fakePodUid,
-		"pod_namespace":          "default",
 		"pod_name":               fakePodName,
 		"container_name":         "redis",
 		"container_base_image":   "kubernetes/redis:v1",


### PR DESCRIPTION
This PR is followed by #1659.

I have forgot to grep `pod_namespace` usage instead of `LabelPodNamespace`. This PR will clean the usage about `pod_namespace`.

/ping @kubernetes/heapster-maintainers @piosz @DirectXMan12 

This also change code with ES, so @AlmogBaku PTAL.