### PR TITLE
remove host_id from influxdb

### DIFF
--- a/metrics/sinks/influxdb/influxdb.go
+++ b/metrics/sinks/influxdb/influxdb.go
@@ -39,6 +39,7 @@ var influxdbBlacklistLabels = map[string]struct{}{
 	core.LabelPodNamespaceUID.Key: {},
 	core.LabelPodId.Key:           {},
 	core.LabelHostname.Key:        {},
+	core.LabelHostID.Key:          {},
 }
 
 const (


### PR DESCRIPTION
According to [doc about `host_id`](https://github.com/kubernetes/heapster/blob/master/docs/storage-schema.md#labels), it is 
> Cloud-provider specified or user specified Identifier of a node

Since host_id is retrievable using the node name, host_id is redundant.

/cc @kubernetes/heapster-maintainers @piosz @DirectXMan12  