### PR TITLE
Hawkular-sink updates to definition cache handling

### DIFF
--- a/docs/sink-configuration.md
+++ b/docs/sink-configuration.md
@@ -88,6 +88,7 @@ The following options are available:
 * `batchSize`- How many metrics are sent in each request to Hawkular-Metrics (default is 1000)
 * `concurrencyLimit`- How many concurrent requests are used to send data to the Hawkular-Metrics (default is 5)
 * `labelTagPrefix` - A prefix to be placed in front of each label when stored as a tag for the metric (default is `labels.`)
+* `disablePreCache` - Disable cache initialization by fetching metric definitions from Hawkular-Metrics
 
 A combination of `insecure` / `caCert` / `auth` is not supported, only a single of these parameters is allowed at once. Also, combination of `useServiceAccount` and `user` + `pass` is not supported. To increase the performance of Hawkular sink in case of multiple instances of Hawkular-Metrics (such as scaled scenario in OpenShift) modify the parameters of batchSize and concurrencyLimit to balance the load on Hawkular-Metrics instances.
 

--- a/metrics/sinks/hawkular/client.go
+++ b/metrics/sinks/hawkular/client.go
@@ -17,6 +17,7 @@ package hawkular
 import (
 	"fmt"
 	"math"
+	"reflect"
 	"regexp"
 	"strings"
 	"sync"
@@ -52,6 +53,7 @@ func (h *hawkularSink) updateDefinitions(mt metrics.MetricType) error {
 			h.reg[p.Id] = p
 		}
 	}
+
 	return nil
 }
 
@@ -148,69 +150,79 @@ func (h *hawkularSink) nodeName(ms *core.MetricSet) string {
 	return ms.Labels[core.LabelNodename.Key]
 }
 
-func (h *hawkularSink) registerLabeledIfNecessary(ms *core.MetricSet, metric core.LabeledMetric, m ...metrics.Modifier) error {
-	key := h.idName(ms, metric.Name)
+func (h *hawkularSink) createDefinitionFromModel(ms *core.MetricSet, metric core.LabeledMetric) (*metrics.MetricDefinition, error) {
+	if md, f := h.models[metric.Name]; f {
+		// Copy the original map
+		mdd := *md
+		tags := make(map[string]string)
+		for k, v := range mdd.Tags {
+			tags[k] = v
+		}
+		mdd.Tags = tags
 
-	if resourceID, found := metric.Labels[core.LabelResourceID.Key]; found {
-		key = h.idName(ms, metric.Name+separator+resourceID)
-	}
-
-	h.regLock.Lock()
-	defer h.regLock.Unlock()
-
-	// If found, check it matches the current stored definition (could be old info from
-	// the stored metrics cache for example)
-	if _, found := h.reg[key]; !found {
-		// Register the metric descriptor here..
-		if md, f := h.models[metric.Name]; f {
-			// Copy the original map
-			mdd := *md
-			tags := make(map[string]string)
-			for k, v := range mdd.Tags {
-				tags[k] = v
-			}
-			mdd.Tags = tags
-
-			// Set tag values
-			for k, v := range ms.Labels {
-				mdd.Tags[k] = v
-				if k == core.LabelLabels.Key {
-					labels := strings.Split(v, ",")
-					for _, label := range labels {
-						labelKeyValue := strings.Split(label, ":")
-						if len(labelKeyValue) != 2 {
-							glog.V(4).Infof("Could not split the label %v into its key and value pair. This label will not be added as a tag in Hawkular Metrics.", label)
-						} else {
-							mdd.Tags[h.labelTagPrefix+labelKeyValue[0]] = labelKeyValue[1]
-						}
+		// Set tag values
+		for k, v := range ms.Labels {
+			mdd.Tags[k] = v
+			if k == core.LabelLabels.Key {
+				labels := strings.Split(v, ",")
+				for _, label := range labels {
+					labelKeyValue := strings.Split(label, ":")
+					if len(labelKeyValue) != 2 {
+						glog.V(4).Infof("Could not split the label %v into its key and value pair. This label will not be added as a tag in Hawkular Metrics.", label)
+					} else {
+						mdd.Tags[h.labelTagPrefix+labelKeyValue[0]] = labelKeyValue[1]
 					}
 				}
 			}
-
-			// Set the labeled values
-			for k, v := range metric.Labels {
-				mdd.Tags[k] = v
-			}
-
-			mdd.Tags[groupTag] = h.groupName(ms, metric.Name)
-			mdd.Tags[descriptorTag] = metric.Name
-
-			m = append(m, h.modifiers...)
-
-			// Create metric, use updateTags instead of Create because we know it is unique
-			if err := h.client.UpdateTags(heapsterTypeToHawkularType(metric.MetricType), key, mdd.Tags, m...); err != nil {
-				// Log error and don't add this key to the lookup table
-				glog.Errorf("Could not update tags: %s", err)
-				return err
-			}
-
-			// Add to the lookup table
-			h.reg[key] = &mdd
-		} else {
-			return fmt.Errorf("Could not find definition model with name %s", metric.Name)
 		}
+
+		// Set the labeled values
+		for k, v := range metric.Labels {
+			mdd.Tags[k] = v
+		}
+
+		mdd.Tags[groupTag] = h.groupName(ms, metric.Name)
+		mdd.Tags[descriptorTag] = metric.Name
+
+		return &mdd, nil
 	}
-	// TODO Compare the definition tags and update if necessary? Quite expensive operation..
+	return nil, fmt.Errorf("Could not find definition model with name %s", metric.Name)
+}
+
+func (h *hawkularSink) registerLabeledIfNecessary(ms *core.MetricSet, metric core.LabeledMetric, m ...metrics.Modifier) error {
+
+	var key string
+	if resourceID, found := metric.Labels[core.LabelResourceID.Key]; found {
+		key = h.idName(ms, metric.Name+separator+resourceID)
+	} else {
+		key = h.idName(ms, metric.Name)
+	}
+
+	mdd, err := h.createDefinitionFromModel(ms, metric)
+	if err != nil {
+		return err
+	}
+
+	h.regLock.RLock()
+	if _, found := h.reg[key]; !found || !reflect.DeepEqual(mdd.Tags, h.reg[key].Tags) {
+		// I'm going to release the lock to allow concurrent processing, even if that
+		// can cause dual updates (highly unlikely). The UpdateTags is idempotent in any case.
+		h.regLock.RUnlock()
+		m = append(m, h.modifiers...)
+
+		// Create metric, use updateTags instead of Create because we don't care about uniqueness
+		if err := h.client.UpdateTags(heapsterTypeToHawkularType(metric.MetricType), key, mdd.Tags, m...); err != nil {
+			// Log error and don't add this key to the lookup table
+			glog.Errorf("Could not update tags: %s", err)
+			return err
+		}
+
+		h.regLock.Lock()
+		h.reg[key] = mdd
+		h.regLock.Unlock()
+	} else {
+		h.regLock.RUnlock()
+	}
 
 	return nil
 }

--- a/metrics/sinks/hawkular/client.go
+++ b/metrics/sinks/hawkular/client.go
@@ -46,11 +46,11 @@ func (h *hawkularSink) updateDefinitions(mt metrics.MetricType) error {
 		// If no descriptorTag is found, this metric does not belong to Heapster
 		if mk, found := p.Tags[descriptorTag]; found {
 			if model, f := h.models[mk]; f && !h.recent(p, model) {
-				if err := h.client.UpdateTags(mt, p.Id, p.Tags, h.modifiers...); err != nil {
+				if err := h.client.UpdateTags(mt, p.ID, p.Tags, h.modifiers...); err != nil {
 					return err
 				}
 			}
-			h.reg[p.Id] = p
+			h.reg[p.ID] = p
 		}
 	}
 
@@ -88,7 +88,7 @@ func (h *hawkularSink) descriptorToDefinition(md *core.MetricDescriptor) metrics
 	tags[descriptorTag] = md.Name
 
 	hmd := metrics.MetricDefinition{
-		Id:   md.Name,
+		ID:   md.Name,
 		Tags: tags,
 		Type: heapsterTypeToHawkularType(md.Type),
 	}
@@ -287,11 +287,11 @@ func (h *hawkularSink) pointToLabeledMetricHeader(ms *core.MetricSet, metric cor
 
 	m := metrics.Datapoint{
 		Value:     value,
-		Timestamp: metrics.UnixMilli(timestamp),
+		Timestamp: timestamp,
 	}
 
 	mh := &metrics.MetricHeader{
-		Id:   name,
+		ID:   name,
 		Data: []metrics.Datapoint{m},
 		Type: heapsterTypeToHawkularType(metric.MetricType),
 	}

--- a/metrics/sinks/hawkular/driver.go
+++ b/metrics/sinks/hawkular/driver.go
@@ -58,12 +58,14 @@ func (h *hawkularSink) Register(mds []core.MetricDescriptor) error {
 		h.models[md.Name] = &hmd
 	}
 
-	// Fetch currently known metrics from Hawkular-Metrics and cache them
-	types := []metrics.MetricType{metrics.Gauge, metrics.Counter}
-	for _, t := range types {
-		err := h.updateDefinitions(t)
-		if err != nil {
-			return err
+	if !h.disablePreCaching {
+		// Fetch currently known metrics from Hawkular-Metrics and cache them
+		types := []metrics.MetricType{metrics.Gauge, metrics.Counter}
+		for _, t := range types {
+			err := h.updateDefinitions(t)
+			if err != nil {
+				return err
+			}
 		}
 	}
 
@@ -94,12 +96,15 @@ func (h *hawkularSink) ExportData(db *core.DataBatch) {
 
 		for _, ms := range db.MetricSets {
 
-			// // Transform ms.MetricValues to LabeledMetrics first
-			lms := metricValueToLabeledMetric(ms.MetricValues)
-			ms.LabeledMetrics = append(ms.LabeledMetrics, lms...)
+			// Transform ms.MetricValues to LabeledMetrics first
+			mvlms := metricValueToLabeledMetric(ms.MetricValues)
+			lms := make([]core.LabeledMetric, 0, len(mvlms)+len(ms.LabeledMetrics))
+
+			lms = append(lms, mvlms...)
+			lms = append(lms, ms.LabeledMetrics...)
 
 		Store:
-			for _, labeledMetric := range ms.LabeledMetrics {
+			for _, labeledMetric := range lms {
 
 				for _, filter := range h.filters {
 					if !filter(ms, labeledMetric.Name) {
@@ -319,6 +324,14 @@ func (h *hawkularSink) init() error {
 			return fmt.Errorf("Supplied batchSize value of %s is invalid", v[0])
 		}
 		h.batchSize = bs
+	}
+
+	if v, found := opts["disablePreCache"]; found {
+		dpc, err := strconv.ParseBool(v[0])
+		if err != nil {
+			return fmt.Errorf("disablePreCache parameter value %s is invalid", v[0])
+		}
+		h.disablePreCaching = dpc
 	}
 
 	c, err := metrics.NewHawkularClient(p)

--- a/metrics/sinks/hawkular/driver_test.go
+++ b/metrics/sinks/hawkular/driver_test.go
@@ -367,6 +367,23 @@ func TestRegister(t *testing.T) {
 	assert.True(t, definitionsCalled["gauge"], "Gauge definitions were not fetched")
 	assert.True(t, definitionsCalled["counter"], "Counter definitions were not fetched")
 	assert.True(t, updateTagsCalled, "Updating outdated tags was not called")
+
+	// Try without pre caching
+	definitionsCalled = make(map[string]bool)
+	updateTagsCalled = false
+
+	hSink, err = integSink(s.URL + "?tenant=test-heapster&disablePreCache=true")
+	assert.NoError(t, err)
+
+	err = hSink.Register(md)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 2, len(hSink.models))
+	assert.Equal(t, 0, len(hSink.reg))
+
+	assert.False(t, definitionsCalled["gauge"], "Gauge definitions were fetched")
+	assert.False(t, definitionsCalled["counter"], "Counter definitions were fetched")
+	assert.False(t, updateTagsCalled, "Updating outdated tags was called")
 }
 
 // Store timeseries with both gauges and cumulatives
@@ -381,7 +398,7 @@ func TestStoreTimeseries(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 
 		typ := r.RequestURI[strings.Index(r.RequestURI, "hawkular/metrics/")+17:]
-		typ = typ[:len(typ)-5]
+		typ = typ[:len(typ)-4]
 
 		switch typ {
 		case "counters":
@@ -460,6 +477,7 @@ func TestStoreTimeseries(t *testing.T) {
 func TestTags(t *testing.T) {
 	m := &sync.Mutex{}
 	calls := make([]string, 0, 2)
+	serverTags := make(map[string]string)
 	// how many times tags have been updated
 	tagsUpdated := 0
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -473,23 +491,8 @@ func TestTags(t *testing.T) {
 		assert.NoError(t, err)
 
 		if strings.HasSuffix(r.RequestURI, "/tags") {
-			tags := make(map[string]string)
-			err := json.Unmarshal(b, &tags)
+			err := json.Unmarshal(b, &serverTags)
 			assert.NoError(t, err)
-
-			assert.Equal(t, 10, len(tags))
-			assert.Equal(t, "test-label", tags["projectId"])
-			assert.Equal(t, "test-container", tags[core.LabelContainerName.Key])
-			assert.Equal(t, "test-podid", tags[core.LabelPodId.Key])
-			assert.Equal(t, "test-container/test/metric/A", tags["group_id"])
-			assert.Equal(t, "test/metric/A", tags["descriptor_name"])
-			assert.Equal(t, "XYZ", tags[core.LabelResourceID.Key])
-			assert.Equal(t, "bytes", tags["units"])
-
-			assert.Equal(t, "testLabelA:testValueA,testLabelB:testValueB", tags[core.LabelLabels.Key])
-			assert.Equal(t, "testValueA", tags["labels.testLabelA"])
-			assert.Equal(t, "testValueB", tags["labels.testLabelB"])
-
 			tagsUpdated++
 		}
 	}))
@@ -555,6 +558,35 @@ func TestTags(t *testing.T) {
 	assert.Equal(t, "testLabelA:testValueA,testLabelB:testValueB", tags[core.LabelLabels.Key])
 	assert.Equal(t, "testValueA", tags["labels.testLabelA"])
 	assert.Equal(t, "testValueB", tags["labels.testLabelB"])
+
+	assert.Equal(t, 10, len(serverTags))
+	assert.Equal(t, "test-label", serverTags["projectId"])
+	assert.Equal(t, "test-container", serverTags[core.LabelContainerName.Key])
+	assert.Equal(t, "test-podid", serverTags[core.LabelPodId.Key])
+	assert.Equal(t, "test-container/test/metric/A", serverTags["group_id"])
+	assert.Equal(t, "test/metric/A", serverTags["descriptor_name"])
+	assert.Equal(t, "XYZ", serverTags[core.LabelResourceID.Key])
+	assert.Equal(t, "bytes", serverTags["units"])
+
+	assert.Equal(t, "testLabelA:testValueA,testLabelB:testValueB", serverTags[core.LabelLabels.Key])
+	assert.Equal(t, "testValueA", serverTags["labels.testLabelA"])
+	assert.Equal(t, "testValueB", serverTags["labels.testLabelB"])
+
+	// Make modifications to the metrics and check that they're updated correctly
+
+	// First, no changes - no update should happen
+	hSink.registerLabeledIfNecessary(&metricSet, labeledMetric)
+	assert.Equal(t, 1, tagsUpdated)
+
+	// Now modify the labels and expect an update
+	metricSet.Labels[core.LabelLabels.Key] = "testLabelA:testValueA,testLabelB:testValueB,testLabelC:testValueC"
+	hSink.registerLabeledIfNecessary(&metricSet, labeledMetric)
+	assert.Equal(t, 2, tagsUpdated)
+
+	assert.Equal(t, "testLabelA:testValueA,testLabelB:testValueB,testLabelC:testValueC", serverTags[core.LabelLabels.Key])
+	assert.Equal(t, "testValueA", serverTags["labels.testLabelA"])
+	assert.Equal(t, "testValueB", serverTags["labels.testLabelB"])
+	assert.Equal(t, "testValueC", serverTags["labels.testLabelC"])
 }
 
 func TestUserPass(t *testing.T) {
@@ -594,7 +626,7 @@ func TestFiltering(t *testing.T) {
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		m.Lock()
 		defer m.Unlock()
-		if strings.Contains(r.RequestURI, "data") {
+		if strings.Contains(r.RequestURI, "raw") {
 			defer r.Body.Close()
 			b, err := ioutil.ReadAll(r.Body)
 			assert.NoError(t, err)

--- a/metrics/sinks/hawkular/driver_test.go
+++ b/metrics/sinks/hawkular/driver_test.go
@@ -57,7 +57,7 @@ func TestDescriptorTransform(t *testing.T) {
 
 	md := hSink.descriptorToDefinition(&smd)
 
-	assert.Equal(t, smd.Name, md.Id)
+	assert.Equal(t, smd.Name, md.ID)
 	assert.Equal(t, 3, len(md.Tags)) // descriptorTag, unitsTag, typesTag, k1
 
 	assert.Equal(t, smd.Units.String(), md.Tags[unitsTag])
@@ -122,7 +122,7 @@ func TestMetricTransform(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, fmt.Sprintf("%s/%s/%s", metricSet.Labels[core.LabelContainerName.Key],
-		metricSet.Labels[core.LabelPodId.Key], metricName), m.Id)
+		metricSet.Labels[core.LabelPodId.Key], metricName), m.ID)
 
 	assert.Equal(t, 1, len(m.Data))
 	_, ok := m.Data[0].Value.(float64)
@@ -134,7 +134,7 @@ func TestMetricTransform(t *testing.T) {
 	m, err = hSink.pointToLabeledMetricHeader(&metricSet, metricSet.LabeledMetrics[2], now)
 	assert.NoError(t, err)
 
-	assert.Equal(t, fmt.Sprintf("%s/%s/%s", metricSet.Labels[core.LabelContainerName.Key], metricSet.Labels[core.LabelNodename.Key], metricName), m.Id)
+	assert.Equal(t, fmt.Sprintf("%s/%s/%s", metricSet.Labels[core.LabelContainerName.Key], metricSet.Labels[core.LabelNodename.Key], metricName), m.ID)
 
 	//
 	m, err = hSink.pointToLabeledMetricHeader(&metricSet, metricSet.LabeledMetrics[0], now)
@@ -142,13 +142,13 @@ func TestMetricTransform(t *testing.T) {
 
 	assert.Equal(t, fmt.Sprintf("%s/%s/%s/%s", metricSet.Labels[core.LabelContainerName.Key],
 		metricSet.Labels[core.LabelNodename.Key], labeledMetricNameA,
-		metricSet.LabeledMetrics[0].Labels[core.LabelResourceID.Key]), m.Id)
+		metricSet.LabeledMetrics[0].Labels[core.LabelResourceID.Key]), m.ID)
 
 	//
 	m, err = hSink.pointToLabeledMetricHeader(&metricSet, metricSet.LabeledMetrics[1], now)
 	assert.NoError(t, err)
 	assert.Equal(t, fmt.Sprintf("%s/%s/%s", metricSet.Labels[core.LabelContainerName.Key],
-		metricSet.Labels[core.LabelNodename.Key], labeledMetricNameB), m.Id)
+		metricSet.Labels[core.LabelNodename.Key], labeledMetricNameB), m.ID)
 }
 
 func TestMetricIds(t *testing.T) {
@@ -181,43 +181,43 @@ func TestMetricIds(t *testing.T) {
 	//
 	m, err := hSink.pointToLabeledMetricHeader(&metricSet, metricSet.LabeledMetrics[0], now)
 	assert.NoError(t, err)
-	assert.Equal(t, fmt.Sprintf("%s/%s/%s", metricSet.Labels[core.LabelContainerName.Key], metricSet.Labels[core.LabelPodId.Key], metricName), m.Id)
+	assert.Equal(t, fmt.Sprintf("%s/%s/%s", metricSet.Labels[core.LabelContainerName.Key], metricSet.Labels[core.LabelPodId.Key], metricName), m.ID)
 
 	//
 	metricSet.Labels[core.LabelMetricSetType.Key] = core.MetricSetTypeNode
 	m, err = hSink.pointToLabeledMetricHeader(&metricSet, metricSet.LabeledMetrics[0], now)
 	assert.NoError(t, err)
-	assert.Equal(t, fmt.Sprintf("%s/%s/%s", "machine", metricSet.Labels[core.LabelNodename.Key], metricName), m.Id)
+	assert.Equal(t, fmt.Sprintf("%s/%s/%s", "machine", metricSet.Labels[core.LabelNodename.Key], metricName), m.ID)
 
 	//
 	metricSet.Labels[core.LabelMetricSetType.Key] = core.MetricSetTypePod
 	m, err = hSink.pointToLabeledMetricHeader(&metricSet, metricSet.LabeledMetrics[0], now)
 	assert.NoError(t, err)
-	assert.Equal(t, fmt.Sprintf("%s/%s/%s", core.MetricSetTypePod, metricSet.Labels[core.LabelPodId.Key], metricName), m.Id)
+	assert.Equal(t, fmt.Sprintf("%s/%s/%s", core.MetricSetTypePod, metricSet.Labels[core.LabelPodId.Key], metricName), m.ID)
 
 	//
 	metricSet.Labels[core.LabelMetricSetType.Key] = core.MetricSetTypePodContainer
 	m, err = hSink.pointToLabeledMetricHeader(&metricSet, metricSet.LabeledMetrics[0], now)
 	assert.NoError(t, err)
-	assert.Equal(t, fmt.Sprintf("%s/%s/%s", metricSet.Labels[core.LabelContainerName.Key], metricSet.Labels[core.LabelPodId.Key], metricName), m.Id)
+	assert.Equal(t, fmt.Sprintf("%s/%s/%s", metricSet.Labels[core.LabelContainerName.Key], metricSet.Labels[core.LabelPodId.Key], metricName), m.ID)
 
 	//
 	metricSet.Labels[core.LabelMetricSetType.Key] = core.MetricSetTypeSystemContainer
 	m, err = hSink.pointToLabeledMetricHeader(&metricSet, metricSet.LabeledMetrics[0], now)
 	assert.NoError(t, err)
-	assert.Equal(t, fmt.Sprintf("%s/%s/%s/%s", core.MetricSetTypeSystemContainer, metricSet.Labels[core.LabelContainerName.Key], metricSet.Labels[core.LabelPodId.Key], metricName), m.Id)
+	assert.Equal(t, fmt.Sprintf("%s/%s/%s/%s", core.MetricSetTypeSystemContainer, metricSet.Labels[core.LabelContainerName.Key], metricSet.Labels[core.LabelPodId.Key], metricName), m.ID)
 
 	//
 	metricSet.Labels[core.LabelMetricSetType.Key] = core.MetricSetTypeCluster
 	m, err = hSink.pointToLabeledMetricHeader(&metricSet, metricSet.LabeledMetrics[0], now)
 	assert.NoError(t, err)
-	assert.Equal(t, fmt.Sprintf("%s/%s", core.MetricSetTypeCluster, metricName), m.Id)
+	assert.Equal(t, fmt.Sprintf("%s/%s", core.MetricSetTypeCluster, metricName), m.ID)
 
 	//
 	metricSet.Labels[core.LabelMetricSetType.Key] = core.MetricSetTypeNamespace
 	m, err = hSink.pointToLabeledMetricHeader(&metricSet, metricSet.LabeledMetrics[0], now)
 	assert.NoError(t, err)
-	assert.Equal(t, fmt.Sprintf("%s/%s/%s", core.MetricSetTypeNamespace, metricSet.Labels[core.LabelNamespaceName.Key], metricName), m.Id)
+	assert.Equal(t, fmt.Sprintf("%s/%s/%s", core.MetricSetTypeNamespace, metricSet.Labels[core.LabelNamespaceName.Key], metricName), m.ID)
 
 }
 
@@ -232,7 +232,7 @@ func TestRecentTest(t *testing.T) {
 	modelT["hep"+descriptionTag] = "n"
 
 	model := metrics.MetricDefinition{
-		Id:   id,
+		ID:   id,
 		Tags: modelT,
 	}
 
@@ -242,7 +242,7 @@ func TestRecentTest(t *testing.T) {
 	}
 
 	live := metrics.MetricDefinition{
-		Id:   "test/" + id,
+		ID:   "test/" + id,
 		Tags: liveT,
 	}
 
@@ -421,7 +421,7 @@ func TestStoreTimeseries(t *testing.T) {
 
 		assert.Equal(t, 1, len(mH))
 
-		ids = append(ids, mH[0].Id)
+		ids = append(ids, mH[0].ID)
 	}))
 	defer s.Close()
 
@@ -753,7 +753,7 @@ func TestBatchingTimeseries(t *testing.T) {
 		assert.NoError(t, err)
 
 		for _, v := range mH {
-			ids = append(ids, v.Id)
+			ids = append(ids, v.ID)
 		}
 
 		calls++

--- a/metrics/sinks/hawkular/types.go
+++ b/metrics/sinks/hawkular/types.go
@@ -48,7 +48,7 @@ func (f FilterType) From(s string) FilterType {
 type hawkularSink struct {
 	client  *metrics.Client
 	models  map[string]*metrics.MetricDefinition // Model definitions
-	regLock sync.Mutex
+	regLock sync.RWMutex
 	reg     map[string]*metrics.MetricDefinition // Real definitions
 
 	uri *url.URL
@@ -59,7 +59,8 @@ type hawkularSink struct {
 	modifiers      []metrics.Modifier
 	filters        []Filter
 
-	batchSize int
+	disablePreCaching bool
+	batchSize         int
 }
 
 func heapsterTypeToHawkularType(t core.MetricType) metrics.MetricType {

--- a/vendor/github.com/hawkular/hawkular-client-go/metrics/helpers.go
+++ b/vendor/github.com/hawkular/hawkular-client-go/metrics/helpers.go
@@ -75,9 +75,14 @@ func ConvertToFloat64(v interface{}) (float64, error) {
 	}
 }
 
-// UnixMilli Returns milliseconds since epoch
-func UnixMilli(t time.Time) int64 {
-	return t.UnixNano() / 1e6
+// ToUnixMilli returns milliseconds since epoch from time.Time
+func ToUnixMilli(t time.Time) int64 {
+	return t.UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond))
+}
+
+// FromUnixMilli returns time.Time from milliseconds since epoch
+func FromUnixMilli(milli int64) time.Time {
+	return time.Unix(0, milli*int64(time.Millisecond))
 }
 
 // Prepend Helper function to insert modifier in the beginning of slice

--- a/vendor/github.com/hawkular/hawkular-client-go/metrics/types.go
+++ b/vendor/github.com/hawkular/hawkular-client-go/metrics/types.go
@@ -1,5 +1,5 @@
 /*
-   Copyright 2015-2016 Red Hat, Inc. and/or its affiliates
+   Copyright 2015-2017 Red Hat, Inc. and/or its affiliates
    and other contributors.
 
    Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,9 +20,10 @@ package metrics
 import (
 	"crypto/tls"
 	"encoding/json"
-	"fmt"
+	// "fmt"
 	"net/http"
 	"net/url"
+	"time"
 )
 
 // HawkularClientError Extracted error information from Hawkular-Metrics server
@@ -31,22 +32,27 @@ type HawkularClientError struct {
 	Code int
 }
 
-// Parameters Initialization parameters to the client
+// Parameters is a struct used as initialization parameters to the client
 type Parameters struct {
 	Tenant      string // Technically optional, but requires setting Tenant() option everytime
 	Url         string
 	TLSConfig   *tls.Config
+	Username    string
+	Password    string
 	Token       string
 	Concurrency int
+	AdminToken  string
 }
 
-// Client HawkularClient's data structure
+// Client is HawkularClient's internal data structure
 type Client struct {
-	Tenant string
-	url    *url.URL
-	client *http.Client
-	Token  string
-	pool   chan (*poolRequest)
+	Tenant      string
+	url         *url.URL
+	client      *http.Client
+	Credentials string // base64 encoded username/password for Basic header
+	Token       string // authentication token for Bearer header
+	AdminToken  string // authentication for items behind admin token
+	pool        chan (*poolRequest)
 }
 
 type poolRequest struct {
@@ -59,7 +65,7 @@ type poolResponse struct {
 	resp *http.Response
 }
 
-// HawkularClient HawkularClient base type to define available functions..
+// HawkularClient is a base type to define available functions of the client
 type HawkularClient interface {
 	Send(*http.Request) (*http.Response, error)
 }
@@ -74,128 +80,125 @@ type Filter func(r *http.Request)
 type Endpoint func(u *url.URL)
 
 // MetricType restrictions
-type MetricType int
+type MetricType string
 
 const (
-	Gauge = iota
-	Availability
-	Counter
-	Generic
+	Gauge        MetricType = "gauge"
+	Availability            = "availability"
+	Counter                 = "counter"
+	Generic                 = "metrics"
+	String                  = "string"
 )
 
-var longForm = []string{
-	"gauges",
-	"availability",
-	"counters",
-	"metrics",
-}
-
-var shortForm = []string{
-	"gauge",
-	"availability",
-	"counter",
-	"metrics",
-}
-
-func (mt MetricType) validate() error {
-	if int(mt) > len(longForm) && int(mt) > len(shortForm) {
-		return fmt.Errorf("Given MetricType value %d is not valid", mt)
-	}
-	return nil
-}
-
-// String Get string representation of type
-func (mt MetricType) String() string {
-	if err := mt.validate(); err != nil {
-		return "unknown"
-	}
-	return longForm[mt]
-}
-
-func (mt MetricType) shortForm() string {
-	if err := mt.validate(); err != nil {
-		return "unknown"
-	}
-	return shortForm[mt]
-}
-
-// UnmarshalJSON Custom unmarshaller for MetricType
-func (mt *MetricType) UnmarshalJSON(b []byte) error {
-	var f interface{}
-	err := json.Unmarshal(b, &f)
-	if err != nil {
-		return err
-	}
-
-	if str, ok := f.(string); ok {
-		for i, v := range shortForm {
-			if str == v {
-				*mt = MetricType(i)
-				break
-			}
-		}
-	}
-
-	return nil
-}
-
-// MarshalJSON Custom marshaller for MetricType
-func (mt MetricType) MarshalJSON() ([]byte, error) {
-	return json.Marshal(mt.String())
-}
-
-// Hawkular-Metrics external structs
-// Do I need external.. hmph.
-
+// MetricHeader is the header struct for time series, which has identifiers (tenant, type, id) for uniqueness
+// and []Datapoint to describe the actual time series values.
 type MetricHeader struct {
 	Tenant string      `json:"-"`
 	Type   MetricType  `json:"-"`
-	Id     string      `json:"id"`
+	ID     string      `json:"id"`
 	Data   []Datapoint `json:"data"`
 }
 
-// Datapoint Value should be convertible to float64 for numeric values, Timestamp is milliseconds since epoch
+// Datapoint is a struct that represents a single time series value.
+// Value should be convertible to float64 for gauge/counter series.
+// Timestamp accuracy is milliseconds since epoch
 type Datapoint struct {
-	Timestamp int64             `json:"timestamp"`
+	Timestamp time.Time         `json:"-"`
 	Value     interface{}       `json:"value"`
 	Tags      map[string]string `json:"tags,omitempty"`
 }
 
-// HawkularError Return payload from Hawkular-Metrics if processing failed
+// MarshalJSON is modified JSON marshalling for Datapoint object to modify time.Time to milliseconds since epoch
+func (d Datapoint) MarshalJSON() ([]byte, error) {
+	b, err := json.Marshal(map[string]interface{}{
+		"timestamp": ToUnixMilli(d.Timestamp),
+		"value":     d.Value,
+	})
+
+	return b, err
+}
+
+// To avoid recursion in UnmarshalJSON
+type datapoint Datapoint
+
+type datapointJSON struct {
+	datapoint
+	Ts int64 `json:"timestamp"`
+}
+
+// UnmarshalJSON is a custom unmarshaller for Datapoint for timestamp modifications
+func (d *Datapoint) UnmarshalJSON(b []byte) error {
+	dp := datapointJSON{}
+	err := json.Unmarshal(b, &dp)
+	if err != nil {
+		return err
+	}
+
+	*d = Datapoint(dp.datapoint)
+	d.Timestamp = FromUnixMilli(dp.Ts)
+
+	return nil
+}
+
+// HawkularError is the return payload from Hawkular-Metrics if processing failed
 type HawkularError struct {
 	ErrorMsg string `json:"errorMsg"`
 }
 
+// MetricDefinition is a struct that describes the stored definition of a time serie
 type MetricDefinition struct {
 	Tenant        string            `json:"-"`
 	Type          MetricType        `json:"type,omitempty"`
-	Id            string            `json:"id"`
+	ID            string            `json:"id"`
 	Tags          map[string]string `json:"tags,omitempty"`
 	RetentionTime int               `json:"dataRetention,omitempty"`
 }
 
 // TODO Fix the Start & End to return a time.Time
 
-// Bucketpoint Return structure for bucketed data
+// Bucketpoint is a return structure for bucketed data requests (stats endpoint)
 type Bucketpoint struct {
-	Start       int64        `json:"start"`
-	End         int64        `json:"end"`
+	Start       time.Time    `json:"-"`
+	End         time.Time    `json:"-"`
 	Min         float64      `json:"min"`
 	Max         float64      `json:"max"`
 	Avg         float64      `json:"avg"`
 	Median      float64      `json:"median"`
 	Empty       bool         `json:"empty"`
-	Samples     int64        `json:"samples"`
+	Samples     uint64       `json:"samples"`
 	Percentiles []Percentile `json:"percentiles"`
 }
 
-// Percentile Hawkular-Metrics calculated percentiles representation
+type bucketpoint Bucketpoint
+
+type bucketpointJSON struct {
+	bucketpoint
+	StartTs int64 `json:"start"`
+	EndTs   int64 `json:"end"`
+}
+
+// UnmarshalJSON is a custom unmarshaller to transform int64 timestamps to time.Time
+func (b *Bucketpoint) UnmarshalJSON(payload []byte) error {
+	bp := bucketpointJSON{}
+	err := json.Unmarshal(payload, &bp)
+	if err != nil {
+		return err
+	}
+
+	*b = Bucketpoint(bp.bucketpoint)
+	b.Start = FromUnixMilli(bp.StartTs)
+	b.End = FromUnixMilli(bp.EndTs)
+
+	return nil
+}
+
+// Percentile is Hawkular-Metrics' estimated (not exact) percentile
 type Percentile struct {
 	Quantile float64 `json:"quantile"`
 	Value    float64 `json:"value"`
 }
 
-// Order Basetype for selecting the sorting of datapoints
+// Order is a basetype for selecting the sorting of requested datapoints
 type Order int
 
 const (
@@ -205,7 +208,7 @@ const (
 	DESC
 )
 
-// String Get string representation of type
+// String returns a string representation of type
 func (o Order) String() string {
 	switch o {
 	case ASC:
@@ -214,4 +217,10 @@ func (o Order) String() string {
 		return "DESC"
 	}
 	return ""
+}
+
+// TenantDefinition is the structure that defines a tenant
+type TenantDefinition struct {
+	ID         string             `json:"id"`
+	Retentions map[MetricType]int `json:"retentions"`
 }


### PR DESCRIPTION
* disablePreCache parameter set to true will prevent initial fetch of definitions from the metrics server (instead building it from the scratch when storing datapoints)
* Each time datapoint is stored, the tags are compared to see if there's an update (such as labels)
* Increase concurrency of registerLabeledIfNecessary with changes the mutexes (they only prevent concurrent cache modification now)

cc @mwringe 