### PR TITLE
Export rss memory in summary source

### DIFF
--- a/metrics/sources/summary/summary.go
+++ b/metrics/sources/summary/summary.go
@@ -251,6 +251,7 @@ func (this *summaryMetricsSource) decodeMemoryStats(metrics *MetricSet, memory *
 
 	this.addIntMetric(metrics, &MetricMemoryUsage, memory.UsageBytes)
 	this.addIntMetric(metrics, &MetricMemoryWorkingSet, memory.WorkingSetBytes)
+	this.addIntMetric(metrics, &MetricMemoryRSS, memory.RSSBytes)
 	this.addIntMetric(metrics, &MetricMemoryPageFaults, memory.PageFaults)
 	this.addIntMetric(metrics, &MetricMemoryMajorPageFaults, memory.MajorPageFaults)
 }

--- a/metrics/sources/summary/summary_test.go
+++ b/metrics/sources/summary/summary_test.go
@@ -38,6 +38,7 @@ const (
 	offsetMemPageFaults
 	offsetMemMajorPageFaults
 	offsetMemUsageBytes
+	offsetMemRSSBytes
 	offsetMemWorkingSetBytes
 	offsetNetRxBytes
 	offsetNetRxErrors
@@ -268,6 +269,7 @@ func TestDecodeSummaryMetrics(t *testing.T) {
 		if e.memory {
 			checkIntMetric(t, m, e.key, core.MetricMemoryUsage, e.seed+offsetMemUsageBytes)
 			checkIntMetric(t, m, e.key, core.MetricMemoryWorkingSet, e.seed+offsetMemWorkingSetBytes)
+			checkIntMetric(t, m, e.key, core.MetricMemoryRSS, e.seed+offsetMemRSSBytes)
 			checkIntMetric(t, m, e.key, core.MetricMemoryPageFaults, e.seed+offsetMemPageFaults)
 			checkIntMetric(t, m, e.key, core.MetricMemoryMajorPageFaults, e.seed+offsetMemMajorPageFaults)
 		}
@@ -316,6 +318,7 @@ func genTestSummaryMemory(seed int) *stats.MemoryStats {
 		Time:            metav1.NewTime(scrapeTime),
 		UsageBytes:      uint64Val(seed, offsetMemUsageBytes),
 		WorkingSetBytes: uint64Val(seed, offsetMemWorkingSetBytes),
+		RSSBytes:        uint64Val(seed, offsetMemRSSBytes),
 		PageFaults:      uint64Val(seed, offsetMemPageFaults),
 		MajorPageFaults: uint64Val(seed, offsetMemMajorPageFaults),
 	}


### PR DESCRIPTION
**Description**
Export rss memory in summary source

`UsageBytes` includes cached memory. We need a metrics that take into acount cached memory in the metric summary.

Some common used cases will fail if we do not take into account that cached memory is reclaimable. For example for alerts based on memory usage, the resident memory (rss) is more important than the total usage.
 