### PR TITLE
Fix the link of image heapster-grafana-amd64

### DIFF
--- a/deploy/kube-config/influxdb/grafana.yaml
+++ b/deploy/kube-config/influxdb/grafana.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: grafana
-        image: gcr.io/google_containers/heapster-grafana-amd64:v4.2.0
+        image: gcr.io/google_containers/heapster-grafana-amd64:v4.0.2
         ports:
         - containerPort: 3000
           protocol: TCP


### PR DESCRIPTION
In gcr.io/google-containers repository, the image heapster-grafana-amd64 with tag v4.2.0 doesn't exist, there are only v4.0.2.