### PR TITLE
Fix grafana image version

### DIFF
--- a/deploy/kube-config/influxdb/grafana.yaml
+++ b/deploy/kube-config/influxdb/grafana.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: grafana
-        image: gcr.io/google_containers/heapster-grafana-amd64:v4.2.0
+        image: gcr.io/google_containers/heapster-grafana-amd64:v4.0.2
         ports:
         - containerPort: 3000
           protocol: TCP


### PR DESCRIPTION
`v4.2.0` is not available, i think it is a typo for `v4.0.2`.