### PR TITLE
Fix heapster-grafana-amd64 version

### DIFF
--- a/deploy/kube-config/influxdb/grafana.yaml
+++ b/deploy/kube-config/influxdb/grafana.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: grafana
-        image: gcr.io/google_containers/heapster-grafana-amd64:v4.2.0
+        image: gcr.io/google_containers/heapster-grafana-amd64:v4.0.2
         ports:
         - containerPort: 3000
           protocol: TCP


### PR DESCRIPTION
The actual version of grafana image is v4.0.2