### PR TITLE
Updated grafana image to current tag

### DIFF
--- a/deploy/kube-config/influxdb/grafana.yaml
+++ b/deploy/kube-config/influxdb/grafana.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: grafana
-        image: gcr.io/google_containers/heapster-grafana-amd64:v4.2.0
+        image: gcr.io/google_containers/heapster-grafana-amd64:v4.0.2
         ports:
         - containerPort: 3000
           protocol: TCP


### PR DESCRIPTION
Currently i only see the 4.0.2 in the repo:
https://console.cloud.google.com/gcr/images/google-containers/GLOBAL/heapster-grafana-amd64