### PR TITLE
Wavefront sink: filter out tags with blank values

### DIFF
--- a/metrics/sinks/wavefront/wavefront.go
+++ b/metrics/sinks/wavefront/wavefront.go
@@ -78,8 +78,8 @@ func (wfSink *wavefrontSink) sendPoint(metricName string, metricValStr string, t
 func tagsToString(tags map[string]string) string {
 	tagStr := ""
 	for k, v := range tags {
-		//if k != "hostname" {
-		if excludeTag(k) == false {
+		// ignore tags with empty values as well so the data point doesn't fail validation
+		if excludeTag(k) == false && len(v) > 0 { 
 			tagStr += k + "=\"" + v + "\" "
 		}
 	}

--- a/metrics/sinks/wavefront/wavefront.go
+++ b/metrics/sinks/wavefront/wavefront.go
@@ -79,7 +79,7 @@ func tagsToString(tags map[string]string) string {
 	tagStr := ""
 	for k, v := range tags {
 		// ignore tags with empty values as well so the data point doesn't fail validation
-		if excludeTag(k) == false && len(v) > 0 { 
+		if excludeTag(k) == false && len(v) > 0 {
 			tagStr += k + "=\"" + v + "\" "
 		}
 	}


### PR DESCRIPTION
Blank tag values are not valid in Wavefront data format and fail the data point entirely, so we need to filter them out before sending 