### PR TITLE
Print the name of the sink if failed

### DIFF
--- a/metrics/sinks/factory.go
+++ b/metrics/sinks/factory.go
@@ -81,7 +81,7 @@ func (this *SinkFactory) BuildAll(uris flags.Uris, historicalUri string) (*metri
 	for _, uri := range uris {
 		sink, err := this.Build(uri)
 		if err != nil {
-			glog.Errorf("Failed to create sink: %v", err)
+			glog.Errorf("Failed to create %s sink: %v", sink.Name(), err)
 			continue
 		}
 		if uri.Key == "metric" {

--- a/metrics/sinks/kafka/driver.go
+++ b/metrics/sinks/kafka/driver.go
@@ -36,6 +36,10 @@ type kafkaSink struct {
 	sync.RWMutex
 }
 
+func (sink *kafkaSink) Name() string {
+	return "kafka"
+}
+
 func (sink *kafkaSink) ExportData(dataBatch *core.DataBatch) {
 	sink.Lock()
 	defer sink.Unlock()


### PR DESCRIPTION
* Kafka did not implemented core.DataSink Name function.
* Factory now prints the name of the sink failed.