### PR TITLE
Refresh namespace values at Pods dashboard

### DIFF
--- a/grafana/dashboards/pods.json
+++ b/grafana/dashboards/pods.json
@@ -974,7 +974,7 @@
             }
           ],
           "query": "SHOW TAG VALUES FROM \"uptime\" WITH KEY = \"namespace_name\"",
-          "refresh": false,
+          "refresh": true,
           "type": "query"
         },
         {


### PR DESCRIPTION
The current template for the Pods dashboard won't refresh the list of available namespace, leaving only `default` and `kube-system` as options. It took me some time to figure out why, because both _pod_ and _node_ selector (at the Cluster dashboard) were automatically reloading its values.