### PR TITLE
fix nits in log

### DIFF
--- a/common/elasticsearch/elasticsearch.go
+++ b/common/elasticsearch/elasticsearch.go
@@ -127,7 +127,7 @@ func CreateElasticSearchService(uri *url.URL) (*ElasticSearchService, error) {
 	var esSvc ElasticSearchService
 	opts, err := url.ParseQuery(uri.RawQuery)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to parser url's query string: %s", err)
+		return nil, fmt.Errorf("Failed to parse url's query string: %s", err)
 	}
 
 	version := 5

--- a/common/kafka/kafka.go
+++ b/common/kafka/kafka.go
@@ -124,7 +124,7 @@ func getTopic(opts map[string][]string, topicType string) (string, error) {
 func NewKafkaClient(uri *url.URL, topicType string) (KafkaClient, error) {
 	opts, err := url.ParseQuery(uri.RawQuery)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parser url's query string: %s", err)
+		return nil, fmt.Errorf("failed to parse url's query string: %s", err)
 	}
 	glog.V(3).Infof("kafka sink option: %v", opts)
 


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

What this PR did:
1. fix some nits in log, I think `failed to parse` is better than `failed to parser`.