### PR TITLE
fix incorrect expression in heapster flag validation log

### DIFF
--- a/metrics/heapster.go
+++ b/metrics/heapster.go
@@ -326,7 +326,7 @@ func getPodLister(kubeClient *kube_client.Clientset) (v1listers.PodLister, error
 
 func validateFlags(opt *options.HeapsterRunOptions) error {
 	if opt.MetricResolution < 5*time.Second {
-		return fmt.Errorf("metric resolution needs to be greater than 5 seconds - %d", opt.MetricResolution)
+		return fmt.Errorf("metric resolution should not be less than 5 seconds - %d", opt.MetricResolution)
 	}
 	if (len(opt.TLSCertFile) > 0 && len(opt.TLSKeyFile) == 0) || (len(opt.TLSCertFile) == 0 && len(opt.TLSKeyFile) > 0) {
 		return fmt.Errorf("both TLS certificate & key are required to enable TLS serving")


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

I found that in heapster flag validation there is incorrect issue. When I input a value of 5s, it will show the no error, while with a value less than 5s, it shows `metric resolution needs to be greater than 5 seconds`.

And I think the error does not take 5s into consideration, ad we need to update this line of log.

What this PR did:
1. fix incorrect expression in heapster flag validation log