### PR TITLE
add status label to node metrics

### DIFF
--- a/metrics/core/labels.go
+++ b/metrics/core/labels.go
@@ -85,6 +85,14 @@ var (
 		Key:         "resource_type",
 		Description: "Resource types for nodes specific for GCE.",
 	}
+	LabelNodeReady = LabelDescriptor{
+		Key:         "ready",
+		Description: "Node ready status.",
+	}
+	LabelNodeSchedulable = LabelDescriptor{
+		Key:         "schedulable",
+		Description: "Node schedulable status.",
+	}
 )
 
 type LabelDescriptor struct {


### PR DESCRIPTION
This PR add a `ready` and `schedulable` label to node metrics, such as `cpu/node_capacity` or `cpu/node_allocatable` with values like below:

|label|value|
|-----|-----------|
| ready | true/false/unknown |
|schedulable| true/false |

When nodes in `unschedulable` status or `notready` condition, `usability` label value will be  `not_usable`. For nodes not in `unschedulable` or `notready` status, `status` label value will be `usable`.

The reason for adding `usability` label to node metrics is:
* Currently, heapster will auto filter out `notready` nodes. We can not get the metrics from `notready` nodes when the node is marked as `notready` and kubelet evict the pods on them. IIRC, this will default to 5 minutes. By adding a `notready` status, we can get all the metrics for `notready` nodes even they have been marked `notready`. If we want to filter out `notready` nodes, we can query based on `usability = "not_usable"`.
*  As for `unschedulable` nodes, we should also filter out them when altering on the percent of remain resource and available resource. Currently, we can not do this as we can not judge the nodes in `unschedulable` status.

Backward Incompatibility:
* As we have added a `ready` and `schedulable` labels to node metrics. Queries for all available resource, we should filter with `ready  = true AND schedulable = true`. This may be incompatible with existing queries for all available resource without `ready  = true AND schedulable = true`  using the old node metric shcema.

/cc @DirectXMan12 @piosz 