### PR TITLE
Storing and/or ignoring user-provided labels

### DIFF
--- a/docs/storage-schema.md
+++ b/docs/storage-schema.md
@@ -84,6 +84,7 @@ nodename=127.0.0.1
 labels=labels:beta.kubernetes.io/arch:amd64,beta.kubernetes.io/os.linux,kubernetes.io/hostname:127.0.0.1
 ```
 This will make bosun confused and panic with something like "panic: opentsdb: bad tag: beta.kubernetes.io/os:linux".
+  * User-provided labels can be stored additionally as separate labels with Heapster `--store-label`. Similarily, using `--ignore-label`, labels can be ommited in concatenated labels.
 
 ## Aggregates
 

--- a/metrics/heapster.go
+++ b/metrics/heapster.go
@@ -68,6 +68,8 @@ func main() {
 	defer logs.FlushLogs()
 
 	setLabelSeperator(opt)
+	setStoredLabels(opt)
+	setIgnoredLabels(opt)
 	setMaxProcs(opt)
 	glog.Infof(strings.Join(os.Args, " "))
 	glog.Infof("Heapster version %v", version.HeapsterVersion)
@@ -356,4 +358,12 @@ func setMaxProcs(opt *options.HeapsterRunOptions) {
 
 func setLabelSeperator(opt *options.HeapsterRunOptions) {
 	util.SetLabelSeperator(opt.LabelSeperator)
+}
+
+func setStoredLabels(opt *options.HeapsterRunOptions) {
+	util.SetStoredLabels(opt.StoredLabels)
+}
+
+func setIgnoredLabels(opt *options.HeapsterRunOptions) {
+	util.SetIgnoredLabels(opt.IgnoredLabels)
 }

--- a/metrics/heapster.go
+++ b/metrics/heapster.go
@@ -67,9 +67,11 @@ func main() {
 	logs.InitLogs()
 	defer logs.FlushLogs()
 
-	setLabelSeperator(opt)
-	setStoredLabels(opt)
-	setIgnoredLabels(opt)
+	labelCopier, err := util.NewLabelCopier(opt.LabelSeperator, opt.StoredLabels, opt.IgnoredLabels)
+	if err != nil {
+		glog.Fatalf("Failed to initialize label copier: %v", err)
+	}
+
 	setMaxProcs(opt)
 	glog.Infof(strings.Join(os.Args, " "))
 	glog.Infof("Heapster version %v", version.HeapsterVersion)
@@ -85,7 +87,7 @@ func main() {
 	sinkManager, metricSink, historicalSource := createAndInitSinksOrDie(opt.Sinks, opt.HistoricalSource)
 
 	podLister, nodeLister := getListersOrDie(kubernetesUrl)
-	dataProcessors := createDataProcessorsOrDie(kubernetesUrl, podLister)
+	dataProcessors := createDataProcessorsOrDie(kubernetesUrl, podLister, labelCopier)
 
 	man, err := manager.NewManager(sourceManager, dataProcessors, sinkManager,
 		opt.MetricResolution, manager.DefaultScrapeOffset, manager.DefaultMaxParallelism)
@@ -226,13 +228,13 @@ func createKubeClientOrDie(kubernetesUrl *url.URL) *kube_client.Clientset {
 	return kube_client.NewForConfigOrDie(kubeConfig)
 }
 
-func createDataProcessorsOrDie(kubernetesUrl *url.URL, podLister v1listers.PodLister) []core.DataProcessor {
+func createDataProcessorsOrDie(kubernetesUrl *url.URL, podLister v1listers.PodLister, labelCopier *util.LabelCopier) []core.DataProcessor {
 	dataProcessors := []core.DataProcessor{
 		// Convert cumulative to rate
 		processors.NewRateCalculator(core.RateMetricsMapping),
 	}
 
-	podBasedEnricher, err := processors.NewPodBasedEnricher(podLister)
+	podBasedEnricher, err := processors.NewPodBasedEnricher(podLister, labelCopier)
 	if err != nil {
 		glog.Fatalf("Failed to create PodBasedEnricher: %v", err)
 	}
@@ -273,7 +275,7 @@ func createDataProcessorsOrDie(kubernetesUrl *url.URL, podLister v1listers.PodLi
 			MetricsToAggregate: metricsToAggregate,
 		})
 
-	nodeAutoscalingEnricher, err := processors.NewNodeAutoscalingEnricher(kubernetesUrl)
+	nodeAutoscalingEnricher, err := processors.NewNodeAutoscalingEnricher(kubernetesUrl, labelCopier)
 	if err != nil {
 		glog.Fatalf("Failed to create NodeAutoscalingEnricher: %v", err)
 	}
@@ -354,16 +356,4 @@ func setMaxProcs(opt *options.HeapsterRunOptions) {
 	if actualNumProcs != numProcs {
 		glog.Warningf("Specified max procs of %d but using %d", numProcs, actualNumProcs)
 	}
-}
-
-func setLabelSeperator(opt *options.HeapsterRunOptions) {
-	util.SetLabelSeperator(opt.LabelSeperator)
-}
-
-func setStoredLabels(opt *options.HeapsterRunOptions) {
-	util.SetStoredLabels(opt.StoredLabels)
-}
-
-func setIgnoredLabels(opt *options.HeapsterRunOptions) {
-	util.SetIgnoredLabels(opt.IgnoredLabels)
 }

--- a/metrics/options/options.go
+++ b/metrics/options/options.go
@@ -47,6 +47,8 @@ type HeapsterRunOptions struct {
 	HistoricalSource    string
 	Version             bool
 	LabelSeperator      string
+	IgnoredLabels       []string
+	StoredLabels        []string
 	DisableMetricExport bool
 }
 
@@ -83,5 +85,7 @@ func (h *HeapsterRunOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&h.HistoricalSource, "historical_source", "", "which source type to use for the historical API (should be exactly the same as one of the sink URIs), or empty to disable the historical API")
 	fs.BoolVar(&h.Version, "version", false, "print version info and exit")
 	fs.StringVar(&h.LabelSeperator, "label_seperator", ",", "seperator used for joining labels")
+	fs.StringSliceVar(&h.IgnoredLabels, "ignore_label", []string{}, "ignore this label when joining labels")
+	fs.StringSliceVar(&h.StoredLabels, "store_label", []string{}, "store this label separately from joined labels with the same name (name) or with different name (newName=name)")
 	fs.BoolVar(&h.DisableMetricExport, "disable_export", false, "Disable exporting metrics in api/v1/metric-export")
 }

--- a/metrics/processors/node_autoscaling_enricher.go
+++ b/metrics/processors/node_autoscaling_enricher.go
@@ -43,7 +43,7 @@ func (this *NodeAutoscalingEnricher) Process(batch *core.DataBatch) (*core.DataB
 	}
 	for _, node := range nodes {
 		if metricSet, found := batch.MetricSets[core.NodeKey(node.Name)]; found {
-			metricSet.Labels[core.LabelLabels.Key] = util.LabelsToString(node.Labels)
+			util.CopyLabels(node.Labels, metricSet.Labels)
 			capacityCpu, _ := node.Status.Capacity[kube_api.ResourceCPU]
 			capacityMem, _ := node.Status.Capacity[kube_api.ResourceMemory]
 			allocatableCpu, _ := node.Status.Allocatable[kube_api.ResourceCPU]

--- a/metrics/processors/pod_based_enricher.go
+++ b/metrics/processors/pod_based_enricher.go
@@ -87,7 +87,7 @@ func addContainerInfo(key string, containerMs *core.MetricSet, pod *kube_api.Pod
 	}
 
 	containerMs.Labels[core.LabelPodId.Key] = string(pod.UID)
-	containerMs.Labels[core.LabelLabels.Key] = util.LabelsToString(pod.Labels)
+	util.CopyLabels(pod.Labels, containerMs.Labels)
 
 	namespace := containerMs.Labels[core.LabelNamespaceName.Key]
 	podName := containerMs.Labels[core.LabelPodName.Key]
@@ -119,7 +119,7 @@ func addPodInfo(key string, podMs *core.MetricSet, pod *kube_api.Pod, batch *cor
 
 	// Add UID to pod
 	podMs.Labels[core.LabelPodId.Key] = string(pod.UID)
-	podMs.Labels[core.LabelLabels.Key] = util.LabelsToString(pod.Labels)
+	util.CopyLabels(pod.Labels, podMs.Labels)
 
 	// Add cpu/mem requests and limits to containers
 	for _, container := range pod.Spec.Containers {
@@ -136,12 +136,12 @@ func addPodInfo(key string, podMs *core.MetricSet, pod *kube_api.Pod, batch *cor
 						core.LabelContainerName.Key:      container.Name,
 						core.LabelContainerBaseImage.Key: container.Image,
 						core.LabelPodId.Key:              string(pod.UID),
-						core.LabelLabels.Key:             util.LabelsToString(pod.Labels),
 						core.LabelNodename.Key:           podMs.Labels[core.LabelNodename.Key],
 						core.LabelHostname.Key:           podMs.Labels[core.LabelHostname.Key],
 						core.LabelHostID.Key:             podMs.Labels[core.LabelHostID.Key],
 					},
 				}
+				util.CopyLabels(pod.Labels, containerMs.Labels)
 				updateContainerResourcesAndLimits(containerMs, container)
 				newMs[containerKey] = containerMs
 			}

--- a/metrics/processors/pod_based_enricher.go
+++ b/metrics/processors/pod_based_enricher.go
@@ -27,7 +27,8 @@ import (
 )
 
 type PodBasedEnricher struct {
-	podLister v1listers.PodLister
+	podLister   v1listers.PodLister
+	labelCopier *util.LabelCopier
 }
 
 func (this *PodBasedEnricher) Name() string {
@@ -46,7 +47,7 @@ func (this *PodBasedEnricher) Process(batch *core.DataBatch) (*core.DataBatch, e
 				glog.V(3).Infof("Failed to get pod %s from cache: %v", core.PodKey(namespace, podName), err)
 				continue
 			}
-			addPodInfo(k, v, pod, batch, newMs)
+			this.addPodInfo(k, v, pod, batch, newMs)
 		case core.MetricSetTypePodContainer:
 			namespace := v.Labels[core.LabelNamespaceName.Key]
 			podName := v.Labels[core.LabelPodName.Key]
@@ -55,7 +56,7 @@ func (this *PodBasedEnricher) Process(batch *core.DataBatch) (*core.DataBatch, e
 				glog.V(3).Infof("Failed to get pod %s from cache: %v", core.PodKey(namespace, podName), err)
 				continue
 			}
-			addContainerInfo(k, v, pod, batch, newMs)
+			this.addContainerInfo(k, v, pod, batch, newMs)
 		}
 	}
 	for k, v := range newMs {
@@ -75,7 +76,7 @@ func (this *PodBasedEnricher) getPod(namespace, name string) (*kube_api.Pod, err
 	return pod, nil
 }
 
-func addContainerInfo(key string, containerMs *core.MetricSet, pod *kube_api.Pod, batch *core.DataBatch, newMs map[string]*core.MetricSet) {
+func (this *PodBasedEnricher) addContainerInfo(key string, containerMs *core.MetricSet, pod *kube_api.Pod, batch *core.DataBatch, newMs map[string]*core.MetricSet) {
 	for _, container := range pod.Spec.Containers {
 		if key == core.PodContainerKey(pod.Namespace, pod.Name, container.Name) {
 			updateContainerResourcesAndLimits(containerMs, container)
@@ -87,7 +88,7 @@ func addContainerInfo(key string, containerMs *core.MetricSet, pod *kube_api.Pod
 	}
 
 	containerMs.Labels[core.LabelPodId.Key] = string(pod.UID)
-	util.CopyLabels(pod.Labels, containerMs.Labels)
+	this.labelCopier.Copy(pod.Labels, containerMs.Labels)
 
 	namespace := containerMs.Labels[core.LabelNamespaceName.Key]
 	podName := containerMs.Labels[core.LabelPodName.Key]
@@ -110,16 +111,16 @@ func addContainerInfo(key string, containerMs *core.MetricSet, pod *kube_api.Pod
 				},
 			}
 			newMs[podKey] = podMs
-			addPodInfo(podKey, podMs, pod, batch, newMs)
+			this.addPodInfo(podKey, podMs, pod, batch, newMs)
 		}
 	}
 }
 
-func addPodInfo(key string, podMs *core.MetricSet, pod *kube_api.Pod, batch *core.DataBatch, newMs map[string]*core.MetricSet) {
+func (this *PodBasedEnricher) addPodInfo(key string, podMs *core.MetricSet, pod *kube_api.Pod, batch *core.DataBatch, newMs map[string]*core.MetricSet) {
 
 	// Add UID to pod
 	podMs.Labels[core.LabelPodId.Key] = string(pod.UID)
-	util.CopyLabels(pod.Labels, podMs.Labels)
+	this.labelCopier.Copy(pod.Labels, podMs.Labels)
 
 	// Add cpu/mem requests and limits to containers
 	for _, container := range pod.Spec.Containers {
@@ -141,7 +142,7 @@ func addPodInfo(key string, podMs *core.MetricSet, pod *kube_api.Pod, batch *cor
 						core.LabelHostID.Key:             podMs.Labels[core.LabelHostID.Key],
 					},
 				}
-				util.CopyLabels(pod.Labels, containerMs.Labels)
+				this.labelCopier.Copy(pod.Labels, containerMs.Labels)
 				updateContainerResourcesAndLimits(containerMs, container)
 				newMs[containerKey] = containerMs
 			}
@@ -183,8 +184,9 @@ func intValue(value int64) core.MetricValue {
 	}
 }
 
-func NewPodBasedEnricher(podLister v1listers.PodLister) (*PodBasedEnricher, error) {
+func NewPodBasedEnricher(podLister v1listers.PodLister, labelCopier *util.LabelCopier) (*PodBasedEnricher, error) {
 	return &PodBasedEnricher{
-		podLister: podLister,
+		podLister:   podLister,
+		labelCopier: labelCopier,
 	}, nil
 }

--- a/metrics/processors/pod_based_enricher_test.go
+++ b/metrics/processors/pod_based_enricher_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"k8s.io/heapster/metrics/core"
+	"k8s.io/heapster/metrics/util"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -122,9 +123,14 @@ func TestPodEnricher(t *testing.T) {
 	store := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 	podLister := v1listers.NewPodLister(store)
 	store.Add(&pod)
-	podBasedEnricher := PodBasedEnricher{podLister: podLister}
+	labelCopier, err := util.NewLabelCopier(",", []string{}, []string{})
+	assert.NoError(t, err)
 
-	var err error
+	podBasedEnricher := PodBasedEnricher{
+		podLister:   podLister,
+		labelCopier: labelCopier,
+	}
+
 	for _, batch := range batches {
 		batch, err = podBasedEnricher.Process(batch)
 		assert.NoError(t, err)

--- a/metrics/util/label_copier.go
+++ b/metrics/util/label_copier.go
@@ -1,0 +1,85 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"fmt"
+	"k8s.io/heapster/metrics/core"
+	"sort"
+	"strings"
+)
+
+// LabelCopier maps kubernetes objects' labels to metrics
+type LabelCopier struct {
+	// labelSeperator contains seperator used to join labels into "labels" label
+	labelSeperator string
+	// storedLabels maps source label names to their destination names used in metrics
+	storedLabels map[string]string
+	// ignoredLabels contains labels to be skipped during concatenation
+	ignoredLabels map[string]string
+}
+
+// Copy copies the given set of pod labels into a set of metric labels, using the following logic:
+// - all labels, unless found in ignoredLabels, are concatenated into a Seperator-seperated key:value pairs and stored under core.LabelLabels.Key
+// - labels found in storedLabels are additionally stored under key provided
+func (this *LabelCopier) Copy(in map[string]string, out map[string]string) {
+	labels := make([]string, 0, len(in))
+
+	for key, value := range in {
+		if mappedKey, exists := this.storedLabels[key]; exists {
+			out[mappedKey] = value
+		}
+
+		if _, exists := this.ignoredLabels[key]; !exists {
+			labels = append(labels, fmt.Sprintf("%s:%s", key, value))
+		}
+	}
+
+	sort.Strings(labels)
+	out[core.LabelLabels.Key] = strings.Join(labels, this.labelSeperator)
+}
+
+// makeStoredLabels converts labels into a map for quicker retrieval.
+// Incoming labels, if desired, may contain mappings in format "newName=oldName"
+func makeStoredLabels(labels []string) map[string]string {
+	storedLabels := make(map[string]string)
+	for _, s := range labels {
+		split := strings.SplitN(s, "=", 2)
+		if len(split) == 1 {
+			storedLabels[split[0]] = split[0]
+		} else {
+			storedLabels[split[1]] = split[0]
+		}
+	}
+	return storedLabels
+}
+
+// makeIgnoredLabels converts label slice into a map for later use.
+func makeIgnoredLabels(labels []string) map[string]string {
+	ignoredLabels := make(map[string]string)
+	for _, s := range labels {
+		ignoredLabels[s] = ""
+	}
+	return ignoredLabels
+}
+
+// NewLabelCopier creates a new instance of LabelCopier type
+func NewLabelCopier(seperator string, storedLabels, ignoredLabels []string) (*LabelCopier, error) {
+	return &LabelCopier{
+		labelSeperator: seperator,
+		storedLabels:   makeStoredLabels(storedLabels),
+		ignoredLabels:  makeIgnoredLabels(ignoredLabels),
+	}, nil
+}

--- a/metrics/util/label_copier_test.go
+++ b/metrics/util/label_copier_test.go
@@ -1,0 +1,117 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/heapster/metrics/core"
+)
+
+func TestDefault(t *testing.T) {
+	actual := initializeAndCopy(t,
+		",",
+		[]string{},
+		[]string{})
+
+	expected := map[string]string{
+		core.LabelLabels.Key: "colour:red," + core.LabelLabels.Key + ":preorder;configurable,name:bike,price:too_high,weight:10kg",
+		"somelabel":          "somevalue",
+	}
+	assert.Equal(t, expected, actual)
+}
+
+func TestSeperator(t *testing.T) {
+	actual := initializeAndCopy(t,
+		"-",
+		[]string{},
+		[]string{})
+
+	expected := map[string]string{
+		core.LabelLabels.Key: "colour:red-" + core.LabelLabels.Key + ":preorder;configurable-name:bike-price:too_high-weight:10kg",
+		"somelabel":          "somevalue",
+	}
+	assert.Equal(t, expected, actual)
+}
+
+func TestStoredLabels(t *testing.T) {
+	actual := initializeAndCopy(t,
+		",",
+		[]string{"name", "price", "copiedlabels=" + core.LabelLabels.Key, "unknown"},
+		[]string{})
+
+	expected := map[string]string{
+		"name":               "bike",
+		"price":              "too_high",
+		"copiedlabels":       "preorder;configurable",
+		core.LabelLabels.Key: "colour:red," + core.LabelLabels.Key + ":preorder;configurable,name:bike,price:too_high,weight:10kg",
+		"somelabel":          "somevalue",
+	}
+	assert.Equal(t, expected, actual)
+}
+
+func TestIgnoredLabels(t *testing.T) {
+	actual := initializeAndCopy(t,
+		",",
+		[]string{},
+		[]string{"colour", "weight", "unknown"})
+
+	expected := map[string]string{
+		core.LabelLabels.Key: core.LabelLabels.Key + ":preorder;configurable,name:bike,price:too_high",
+		"somelabel":          "somevalue",
+	}
+	assert.Equal(t, expected, actual)
+}
+
+func TestAll(t *testing.T) {
+	actual := initializeAndCopy(t,
+		"-",
+		[]string{"name", "colour", "copiedlabels=" + core.LabelLabels.Key, "price", "weight", "unknown"},
+		[]string{"colour", core.LabelLabels.Key, "price", "unknown"})
+
+	expected := map[string]string{
+		"name":               "bike",
+		"colour":             "red",
+		"price":              "too_high",
+		"weight":             "10kg",
+		"copiedlabels":       "preorder;configurable",
+		core.LabelLabels.Key: "name:bike-weight:10kg",
+		"somelabel":          "somevalue",
+	}
+	assert.Equal(t, expected, actual)
+}
+
+func initializeAndCopy(t *testing.T, seperator string, storedLabels []string, ignoredLabels []string) map[string]string {
+	lc, err := NewLabelCopier(seperator, storedLabels, ignoredLabels)
+	if err != nil {
+		t.Fatalf("Could not create LabelCopier: %v", err)
+	}
+
+	labels := map[string]string{
+		"name":               "bike",
+		"colour":             "red",
+		"price":              "too_high",
+		"weight":             "10kg",
+		core.LabelLabels.Key: "preorder;configurable",
+	}
+
+	out := map[string]string{
+		"somelabel": "somevalue",
+	}
+
+	lc.Copy(labels, out)
+	return out
+}

--- a/metrics/util/util.go
+++ b/metrics/util/util.go
@@ -15,64 +15,13 @@
 package util
 
 import (
-	"fmt"
 	"k8s.io/apimachinery/pkg/fields"
 	kube_client "k8s.io/client-go/kubernetes"
 	v1listers "k8s.io/client-go/listers/core/v1"
 	kube_api "k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/heapster/metrics/core"
-	"sort"
-	"strings"
 	"time"
 )
-
-var labelSeperator string
-var storedLabels map[string]string
-var ignoredLabels map[string]string
-
-// Copies labels from input map to output:
-// - all labels, unless found in ignoredLabels, are concatenated into a Seperator-seperated key:value pairs and stored under core.LabelLabels.Key
-// - labels found in storedLabels are additionally stored under key provided
-func CopyLabels(in map[string]string, out map[string]string) {
-	labels := make([]string, 0, len(in))
-
-	for key, value := range in {
-		if mappedKey, exists := storedLabels[key]; exists {
-			out[mappedKey] = value
-		}
-
-		if _, exists := ignoredLabels[key]; !exists {
-			labels = append(labels, fmt.Sprintf("%s:%s", key, value))
-		}
-	}
-
-	sort.Strings(labels)
-	out[core.LabelLabels.Key] = strings.Join(labels, labelSeperator)
-}
-
-func SetLabelSeperator(seperator string) {
-	labelSeperator = seperator
-}
-
-func SetStoredLabels(labels []string) {
-	storedLabels = make(map[string]string)
-	for _, s := range labels {
-		split := strings.SplitN(s, "=", 2)
-		if len(split) == 1 {
-			storedLabels[split[0]] = split[0]
-		} else {
-			storedLabels[split[1]] = split[0]
-		}
-	}
-}
-
-func SetIgnoredLabels(labels []string) {
-	ignoredLabels = make(map[string]string)
-	for _, s := range labels {
-		ignoredLabels[s] = ""
-	}
-}
 
 func GetNodeLister(kubeClient *kube_client.Clientset) (v1listers.NodeLister, *cache.Reflector, error) {
 	lw := cache.NewListWatchFromClient(kubeClient.Core().RESTClient(), "nodes", kube_api.NamespaceAll, fields.Everything())


### PR DESCRIPTION
This PR resolves #807.

There are two new options:
- `--store-label` stores label as separate label/tag in addition to concatenated one
- `--ignore-label` allows to prevent label from being used in concatenation

Custom tags allow for more efficient data retrieval from InfluxDB. Ignoring labels reduces redundancy.
Using both options in order allows for seamless transition from old (regexp based) to new (exact match) retrievals.
