### PR TITLE
Fix typo in docs/maintenance.md

### DIFF
--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -18,7 +18,7 @@ non-sink-specific pull requests.
 
 ### Labels ###
 
-Each issue and pull request should be assinged one of:
+Each issue and pull request should be assigned one of:
 
 - bug
 - enhancement


### PR DESCRIPTION
In docs/maintenance.md，word 'assinged' should be `assigned`, so I fix it. 