### PR TITLE
Rebased #1700: Fix grafana

### DIFF
--- a/deploy/kube-config/influxdb/grafana.yaml
+++ b/deploy/kube-config/influxdb/grafana.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -14,7 +13,7 @@ spec:
     spec:
       containers:
       - name: grafana
-        image: gcr.io/google_containers/heapster-grafana-amd64:v4.4.1
+        image: gcr.io/google_containers/heapster-grafana-amd64:v4.4.3
         ports:
         - containerPort: 3000
           protocol: TCP

--- a/deploy/kube-config/influxdb/heapster.yaml
+++ b/deploy/kube-config/influxdb/heapster.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/deploy/kube-config/influxdb/influxdb.yaml
+++ b/deploy/kube-config/influxdb/influxdb.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -14,7 +13,7 @@ spec:
     spec:
       containers:
       - name: influxdb
-        image: gcr.io/google_containers/heapster-influxdb-amd64:v1.1.1
+        image: gcr.io/google_containers/heapster-influxdb-amd64:v1.3.3
         volumeMounts:
         - mountPath: /data
           name: influxdb-storage

--- a/grafana/Makefile
+++ b/grafana/Makefile
@@ -19,12 +19,13 @@
 
 all: build
 
-VERSION?=v4.4.1
+VERSION?=v4.4.3
+DEB_VERSION?=4.4.3
+
 PREFIX?=gcr.io/google_containers
 ARCH?=amd64
 TEMP_DIR:=$(shell mktemp -d)
 LDFLAGS=-w -X main.version=$(VERSION) -X main.commit=unknown-dev -X main.timestamp=0 -extldflags '-static'
-DEB_BUILD=4.4.1
 KUBE_CROSS_IMAGE=gcr.io/google_containers/kube-cross:v1.8.3-2
 
 ALL_ARCHITECTURES=amd64 arm arm64 ppc64le s390x
@@ -35,9 +36,9 @@ ifeq ($(ARCH),amd64)
 	BASEIMAGE?=busybox
 	CC=gcc
 endif
-ifeq ($(ARCH),armhfrm)
+ifeq ($(ARCH),arm)
 	BASEIMAGE?=armhf/busybox
-	CC=arm-linux-gnueabi-gcc
+	CC=arm-linux-gnueabihf-gcc
 endif
 ifeq ($(ARCH),arm64)
 	BASEIMAGE?=aarch64/busybox
@@ -63,7 +64,7 @@ build:
 	# Lastly, it compiles the go helper
 	docker run --rm -it -v $(TEMP_DIR):/build -w /go/src/github.com/grafana/grafana $(KUBE_CROSS_IMAGE) /bin/bash -c "\
 		curl -sSL https://github.com/grafana/grafana/archive/$(VERSION).tar.gz | tar -xz --strip-components=1 \
-		&& curl -sSL https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana_$(DEB_BUILD)_amd64.deb > /tmp/grafana.deb \
+		&& curl -sSL https://s3-us-west-2.amazonaws.com/grafana-releases/release/grafana_$(DEB_VERSION)_amd64.deb > /tmp/grafana.deb \
 		&& mkdir /tmp/grafanarootfs && dpkg -x /tmp/grafana.deb /tmp/grafanarootfs \
 		&& cp /tmp/grafanarootfs/usr/share/grafana/conf/sample.ini /tmp/grafanarootfs/etc/grafana/grafana.ini \
 		&& cp /tmp/grafanarootfs/usr/share/grafana/conf/ldap.toml /tmp/grafanarootfs/etc/grafana/ldap.toml \

--- a/grafana/run.sh
+++ b/grafana/run.sh
@@ -8,9 +8,14 @@ export GF_SERVER_PROTOCOL=${GF_SERVER_PROTOCOL:-http}
 echo "Starting a utility program that will configure Grafana"
 setup_grafana >/dev/stdout 2>/dev/stderr &
 
+if [ ! -f /etc/grafana/grafana.ini ]; then
+	touch /etc/grafana/grafana.ini
+fi
+
 echo "Starting Grafana in foreground mode"
 exec /usr/sbin/grafana-server \
   --homepath=/usr/share/grafana \
   --config=/etc/grafana/grafana.ini \
+  cfg:default.log.mode="console" \
   cfg:default.paths.data=/var/lib/grafana \
   cfg:default.paths.logs=/var/log/grafana

--- a/influxdb/Makefile
+++ b/influxdb/Makefile
@@ -19,7 +19,7 @@
 
 all: build
 
-VERSION?=v1.1.1
+VERSION?=v1.3.3
 PREFIX?=gcr.io/google_containers
 ARCH?=amd64
 GOLANG_VERSION=1.8
@@ -69,7 +69,7 @@ push: gcr-login $(addprefix sub-push-,$(ALL_ARCHITECTURES))
 
 sub-push-%:
 	$(MAKE) ARCH=$* PREFIX=$(PREFIX) VERSION=$(VERSION) build
-	docker push $(PREFIX)/heapster-influxdb-$(ARCH):$(VERSION)
+	docker push $(PREFIX)/heapster-influxdb-$*:$(VERSION)
 
 gcr-login:
 ifeq ($(findstring gcr.io,$(PREFIX)),gcr.io)

--- a/influxdb/config.toml
+++ b/influxdb/config.toml
@@ -1,5 +1,5 @@
 reporting-disabled = true
-bind-address = ":8088"
+bind-address = "localhost:8088"
 
 [meta]
   dir = "/data/meta"
@@ -30,12 +30,6 @@ bind-address = ":8088"
 [retention]
   enabled = true
   check-interval = "30m0s"
-
-[admin]
-  enabled = false
-  bind-address = ":8083"
-  https-enabled = false
-  https-certificate = "/etc/ssl/influxdb.pem"
 
 [shard-precreation]
   enabled = true


### PR DESCRIPTION
Rebased version of https://github.com/kubernetes/heapster/pull/1700 to have recent inflxudb asap

Original description:
```
Updates grafana to v4.3.2 and influxdb to v1.3.0
fixes #1698 as a consequence
```
Updates grafana 4.4.3 and influxdb to v1.3.3
