### PR TITLE
add schedulable label to node metric

### DIFF
--- a/metrics/core/labels.go
+++ b/metrics/core/labels.go
@@ -85,6 +85,10 @@ var (
 		Key:         "resource_type",
 		Description: "Resource types for nodes specific for GCE.",
 	}
+	LabelNodeSchedulable = LabelDescriptor{
+		Key:         "schedulable",
+		Description: "Node schedulable status.",
+	}
 )
 
 type LabelDescriptor struct {

--- a/metrics/sources/kubelet/kubelet_test.go
+++ b/metrics/sources/kubelet/kubelet_test.go
@@ -466,3 +466,34 @@ func TestScrapeMetrics(t *testing.T) {
 	assert.Equal(t, res.MetricSets["node:/container:docker-daemon"].Labels["container_name"], "docker-daemon")
 
 }
+
+func TestGetNodeSchedulableStatus(t *testing.T) {
+	metas := []struct {
+		Node   *kube_api.Node
+		Wanted string
+	}{
+		{
+			Node: &kube_api.Node{
+				Spec: kube_api.NodeSpec{
+					Unschedulable: false,
+				},
+			},
+			Wanted: "true",
+		},
+		{
+			Node: &kube_api.Node{
+				Spec: kube_api.NodeSpec{
+					Unschedulable: true,
+				},
+			},
+			Wanted: "false",
+		},
+	}
+
+	for _, meta := range metas {
+		got := getNodeSchedulableStatus(meta.Node)
+		if got != meta.Wanted {
+			t.Errorf("get node schedulable status error. wanted: %s, got: %s", meta.Wanted, got)
+		}
+	}
+}


### PR DESCRIPTION
This is a sub-pr for #1746 about adding `schedulable` label to node metrics.

/cc @piosz @DirectXMan12 