### PR TITLE
Allow GCL sink to authenticate with private key on AWS

### DIFF
--- a/events/sinks/gcl/gcl.go
+++ b/events/sinks/gcl/gcl.go
@@ -23,7 +23,6 @@ import (
 	gce_util "k8s.io/heapster/common/gce"
 	"k8s.io/heapster/events/core"
 
-	gce "cloud.google.com/go/compute/metadata"
 	"github.com/golang/glog"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
@@ -80,21 +79,21 @@ func (sink *gclSink) Stop() {
 }
 
 func CreateGCLSink(uri *url.URL) (core.EventSink, error) {
-	if err := gce_util.EnsureOnGCE(); err != nil {
-		return nil, err
-	}
-
-	// Detect project ID
-	projectId, err := gce.ProjectID()
+	client, err := google.DefaultClient(oauth2.NoContext, gcl.LoggingWriteScope)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error creating oauth2 client: %v", err)
 	}
 
 	// Create Google Cloud Logging service.
-	client := oauth2.NewClient(oauth2.NoContext, google.ComputeTokenSource(""))
 	gclService, err := gcl.New(client)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error creating GCM service: %v", err)
+	}
+
+	// Detect project ID
+	projectId, err := gce_util.GetProjectId()
+	if err != nil {
+		return nil, fmt.Errorf("error getting GCP project ID: %v", err)
 	}
 
 	sink := &gclSink{project: projectId, gclService: gclService}

--- a/events/sinks/gcl/gcl.go
+++ b/events/sinks/gcl/gcl.go
@@ -87,7 +87,7 @@ func CreateGCLSink(uri *url.URL) (core.EventSink, error) {
 	// Create Google Cloud Logging service.
 	gclService, err := gcl.New(client)
 	if err != nil {
-		return nil, fmt.Errorf("error creating GCM service: %v", err)
+		return nil, fmt.Errorf("error creating GCL service: %v", err)
 	}
 
 	// Detect project ID


### PR DESCRIPTION
Inspired by: a831b80cc381d08afc47dbffc04880e725ac40db

This allows us to capture Kubernetes events in Google/Stackdriver Logging with a Kubernetes cluster running in AWS. The env var GOOGLE_APPLICATION_CREDENTIALS refers to the service account private key mounted in the pod as per the following example:

```
apiVersion: extensions/v1beta1                                                                                            
kind: Deployment                                                                                                          
metadata:                                                                                                                 
  name: heapster                                                                                                          
  namespace: XXXXXXXXXXXXXXXXX                                                                                         
spec:                                                                                                                     
  replicas: 1                                                                                                             
  template:                                                                                                               
    metadata:                                                                                                             
      labels:                                                                                                             
        task: monitoring                                                                                                  
        k8s-app: heapster                                                                                                 
    spec:                                                                                                                 
      imagePullSecrets:                                                                                                   
        - name: XXXXXXXXXXXXXXXXX                                                                                      
      containers:                                                                                                         
      - name: heapster                                                                                                    
        image: XXXXXXXXXXXXXXXXX                                                              
        imagePullPolicy: Always                                                                                           
        env:                                                                                                              
        - name: GOOGLE_APPLICATION_CREDENTIALS                                                                            
          value: /etc/google/auth/application_default_credentials.json                                                    
        command:                                                                                                          
        - /heapster                                                                                                       
        - --source=kubernetes                                                                                             
        - --sink=gcm                                                                                                      
        - --metric_resolution=60s                                                                                         
        volumeMounts:                                                                                                     
        - name: credentials                                                                                               
          readOnly: true                                                                                                  
          mountPath: /etc/google/auth                                                                                     
      - name: eventer                                                                                                     
        image: XXXXXXXXXXXXXXXXX                                                              
        imagePullPolicy: Always                                                                                           
        env:                                                                                                              
        - name: GOOGLE_APPLICATION_CREDENTIALS                                                                            
          value: /etc/google/auth/application_default_credentials.json                                                    
        command:                                                                                                          
        - /eventer                                                                                                        
        - --source=kubernetes                                                                                             
        - --sink=gcl                                                                                                      
        volumeMounts:                                                                                                     
        - name: credentials                                                                                               
          readOnly: true                                                                                                  
          mountPath: /etc/google/auth                                                                                     
      volumes:                                                                                                            
      - name: credentials                                                                                                 
        secret:                                                                                                           
          secretName: XXXXXXXXXXXXXXXXX  
```

Tested on Kubernetes 1.7.2 in AWS.