### PR TITLE
fix network metric value for multiple interfaces

### DIFF
--- a/metrics/core/metrics.go
+++ b/metrics/core/metrics.go
@@ -324,10 +324,15 @@ var MetricNetworkRx = Metric{
 		return spec.HasNetwork
 	},
 	GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) MetricValue {
+		var rxBytes uint64 = 0
+		for _, interfaceStat := range stat.Network.Interfaces {
+			rxBytes += interfaceStat.RxBytes
+		}
 		return MetricValue{
 			ValueType:  ValueInt64,
 			MetricType: MetricCumulative,
-			IntValue:   int64(stat.Network.RxBytes)}
+			IntValue:   int64(rxBytes),
+		}
 	},
 }
 
@@ -343,10 +348,15 @@ var MetricNetworkRxErrors = Metric{
 		return spec.HasNetwork
 	},
 	GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) MetricValue {
+		var rxErrors uint64 = 0
+		for _, interfaceStat := range stat.Network.Interfaces {
+			rxErrors += interfaceStat.RxErrors
+		}
 		return MetricValue{
 			ValueType:  ValueInt64,
 			MetricType: MetricCumulative,
-			IntValue:   int64(stat.Network.RxErrors)}
+			IntValue:   int64(rxErrors),
+		}
 	},
 }
 
@@ -362,10 +372,15 @@ var MetricNetworkTx = Metric{
 		return spec.HasNetwork
 	},
 	GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) MetricValue {
+		var txBytes uint64 = 0
+		for _, interfaceStat := range stat.Network.Interfaces {
+			txBytes += interfaceStat.TxBytes
+		}
 		return MetricValue{
 			ValueType:  ValueInt64,
 			MetricType: MetricCumulative,
-			IntValue:   int64(stat.Network.TxBytes)}
+			IntValue:   int64(txBytes),
+		}
 	},
 }
 
@@ -381,10 +396,15 @@ var MetricNetworkTxErrors = Metric{
 		return spec.HasNetwork
 	},
 	GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) MetricValue {
+		var txErrors uint64 = 0
+		for _, interfaceStat := range stat.Network.Interfaces {
+			txErrors += interfaceStat.TxErrors
+		}
 		return MetricValue{
 			ValueType:  ValueInt64,
 			MetricType: MetricCumulative,
-			IntValue:   int64(stat.Network.TxErrors)}
+			IntValue:   int64(txErrors),
+		}
 	},
 }
 


### PR DESCRIPTION
Fix #1058 

This PR will fix the network metric values when there are multiple interface available for a container. Currently, heapster will use the first one(index 0) interface stats as the value for network metrics. This will be wrong when there are more than one network interface available for a container.

What we should do is to summarize all the network interface values instead of only picking up only one.

/cc @DirectXMan12 @piosz @ckleban @CBR09 @xiangpengzhao 