### PR TITLE
Updated deploy configuration to use Heapster 1.4.2

### DIFF
--- a/deploy/kube-config/google/heapster.yaml
+++ b/deploy/kube-config/google/heapster.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: heapster
       containers:
       - name: heapster
-        image: gcr.io/google_containers/heapster-amd64:v1.4.0
+        image: gcr.io/google_containers/heapster-amd64:v1.4.2
         imagePullPolicy: IfNotPresent
         command:
         - /heapster

--- a/deploy/kube-config/influxdb/heapster.yaml
+++ b/deploy/kube-config/influxdb/heapster.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: heapster
       containers:
       - name: heapster
-        image: gcr.io/google_containers/heapster-amd64:v1.4.0
+        image: gcr.io/google_containers/heapster-amd64:v1.4.2
         imagePullPolicy: IfNotPresent
         command:
         - /heapster

--- a/deploy/kube-config/standalone-test/heapster-controller.yaml
+++ b/deploy/kube-config/standalone-test/heapster-controller.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: heapster-test
-        image: gcr.io/google_containers/heapster-amd64:v1.4.0
+        image: gcr.io/google_containers/heapster-amd64:v1.4.2
         imagePullPolicy: Always
         command:
         - /heapster

--- a/deploy/kube-config/standalone-test/heapster-summary-controller.yaml
+++ b/deploy/kube-config/standalone-test/heapster-summary-controller.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: heapster-test
-        image: gcr.io/google_containers/heapster-amd64:v1.4.0
+        image: gcr.io/google_containers/heapster-amd64:v1.4.2
         imagePullPolicy: Always
         command:
         - /heapster
@@ -28,7 +28,7 @@ spec:
           mountPath: /etc/ssl/certs
           readOnly: true
       - name: eventer-test
-        image: gcr.io/google_containers/heapster-amd64:v1.4.0
+        image: gcr.io/google_containers/heapster-amd64:v1.4.2
         imagePullPolicy: Always
         command:
         - /eventer

--- a/deploy/kube-config/standalone-with-apiserver/heapster-deployment.yaml
+++ b/deploy/kube-config/standalone-with-apiserver/heapster-deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: heapster
-        image: gcr.io/google_containers/heapster-amd64:v1.4.0
+        image: gcr.io/google_containers/heapster-amd64:v1.4.2
         command:
         - /heapster
         - --source=kubernetes.summary_api:''

--- a/deploy/kube-config/standalone/heapster-controller.yaml
+++ b/deploy/kube-config/standalone/heapster-controller.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: heapster
       containers:
       - name: heapster
-        image: gcr.io/google_containers/heapster-amd64:v1.4.0
+        image: gcr.io/google_containers/heapster-amd64:v1.4.2
         imagePullPolicy: IfNotPresent
         command:
         - /heapster


### PR DESCRIPTION
A new version of heapster released https://github.com/kubernetes/heapster/releases/tag/v1.4.2.

Closes #1787