### PR TITLE
Support NodeExternalIP

### DIFF
--- a/metrics/sources/kubelet/kubelet.go
+++ b/metrics/sources/kubelet/kubelet.go
@@ -323,6 +323,9 @@ func getNodeHostnameAndIP(node *kube_api.Node) (string, string, error) {
 		if addr.Type == kube_api.NodeLegacyHostIP && addr.Address != "" && ip == "" {
 			ip = addr.Address
 		}
+		if addr.Type == kube_api.NodeExternalIP && addr.Address != "" && ip == "" {
+			ip = addr.Address
+		}
 	}
 	if ip != "" {
 		return hostname, ip, nil

--- a/metrics/sources/kubelet/kubelet_test.go
+++ b/metrics/sources/kubelet/kubelet_test.go
@@ -375,6 +375,29 @@ var nodes = []kube_api.Node{
 			},
 		},
 	},
+	{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "testNode",
+		},
+		Status: kube_api.NodeStatus{
+			Conditions: []kube_api.NodeCondition{
+				{
+					Type:   "NotReady",
+					Status: kube_api.ConditionTrue,
+				},
+			},
+			Addresses: []kube_api.NodeAddress{
+				{
+					Type:    kube_api.NodeHostName,
+					Address: "testNode",
+				},
+				{
+					Type:    kube_api.NodeExternalIP,
+					Address: "127.0.0.1",
+				},
+			},
+		},
+	},
 }
 
 func TestGetNodeHostnameAndIP(t *testing.T) {

--- a/metrics/sources/summary/summary.go
+++ b/metrics/sources/summary/summary.go
@@ -430,6 +430,9 @@ func (this *summaryProvider) getNodeInfo(node *kube_api.Node) (NodeInfo, error) 
 		if addr.Type == kube_api.NodeLegacyHostIP && addr.Address != "" && info.IP == "" {
 			info.IP = addr.Address
 		}
+		if addr.Type == kube_api.NodeExternalIP && addr.Address != "" && info.IP == "" {
+			info.IP = addr.Address
+		}
 	}
 
 	if info.IP == "" {


### PR DESCRIPTION
Support nodes that look like:
```
  status:
    addresses:
    - address: 10.0.0.1
      type: ExternalIP
    - address: kubernetes-node-1
      type: Hostname
```