### PR TITLE
fast return when scrape error

### DIFF
--- a/metrics/core/types.go
+++ b/metrics/core/types.go
@@ -134,7 +134,7 @@ type DataBatch struct {
 // A place from where the metrics should be scraped.
 type MetricsSource interface {
 	Name() string
-	ScrapeMetrics(start, end time.Time) *DataBatch
+	ScrapeMetrics(start, end time.Time) (*DataBatch, error)
 }
 
 // Provider of list of sources to be scaped.

--- a/metrics/sources/kubelet/kubelet.go
+++ b/metrics/sources/kubelet/kubelet.go
@@ -233,17 +233,20 @@ metricloop:
 	return metricSetKey, cMetrics
 }
 
-func (this *kubeletMetricsSource) ScrapeMetrics(start, end time.Time) *DataBatch {
+func (this *kubeletMetricsSource) ScrapeMetrics(start, end time.Time) (*DataBatch, error) {
 	containers, err := this.scrapeKubelet(this.kubeletClient, this.host, start, end)
+
 	if err != nil {
-		glog.Errorf("error while getting containers from Kubelet %s: %v", this.host, err)
+		return nil, err
 	}
+
 	glog.V(2).Infof("successfully obtained stats from %s for %v containers", this.host, len(containers))
 
 	result := &DataBatch{
 		Timestamp:  end,
 		MetricSets: map[string]*MetricSet{},
 	}
+
 	for _, c := range containers {
 		name, metrics := this.decodeMetrics(&c)
 		if name == "" || metrics == nil {
@@ -251,7 +254,8 @@ func (this *kubeletMetricsSource) ScrapeMetrics(start, end time.Time) *DataBatch
 		}
 		result.MetricSets[name] = metrics
 	}
-	return result
+
+	return result, nil
 }
 
 func (this *kubeletMetricsSource) scrapeKubelet(client *KubeletClient, host Host, start, end time.Time) ([]cadvisor.ContainerInfo, error) {

--- a/metrics/sources/kubelet/kubelet_test.go
+++ b/metrics/sources/kubelet/kubelet_test.go
@@ -484,7 +484,8 @@ func TestScrapeMetrics(t *testing.T) {
 
 	start := time.Now()
 	end := start.Add(5 * time.Second)
-	res := mtrcSrc.ScrapeMetrics(start, end)
+	res, err := mtrcSrc.ScrapeMetrics(start, end)
+	assert.Nil(t, err, "scrape error")
 	assert.Equal(t, res.MetricSets["node:/container:docker-daemon"].Labels["type"], "sys_container")
 	assert.Equal(t, res.MetricSets["node:/container:docker-daemon"].Labels["container_name"], "docker-daemon")
 

--- a/metrics/sources/manager_test.go
+++ b/metrics/sources/manager_test.go
@@ -29,7 +29,10 @@ func TestAllSourcesReplyInTime(t *testing.T) {
 	manager, _ := NewSourceManager(metricsSourceProvider, time.Second*3)
 	now := time.Now()
 	end := now.Truncate(10 * time.Second)
-	dataBatch := manager.ScrapeMetrics(end.Add(-10*time.Second), end)
+	dataBatch, err := manager.ScrapeMetrics(end.Add(-10*time.Second), end)
+	if err != nil {
+		t.Fatalf("ScrapeMetrics error. %v", err)
+	}
 
 	elapsed := time.Now().Sub(now)
 	if elapsed > 3*time.Second {
@@ -58,7 +61,10 @@ func TestOneSourcesReplyInTime(t *testing.T) {
 	manager, _ := NewSourceManager(metricsSourceProvider, time.Second*3)
 	now := time.Now()
 	end := now.Truncate(10 * time.Second)
-	dataBatch := manager.ScrapeMetrics(end.Add(-10*time.Second), end)
+	dataBatch, err := manager.ScrapeMetrics(end.Add(-10*time.Second), end)
+	if err != nil {
+		t.Fatalf("ScrapeMetrics error. %v", err)
+	}
 	elapsed := time.Now().Sub(now)
 
 	if elapsed > 4*time.Second {
@@ -91,7 +97,10 @@ func TestNoSourcesReplyInTime(t *testing.T) {
 	manager, _ := NewSourceManager(metricsSourceProvider, time.Second*3)
 	now := time.Now()
 	end := now.Truncate(10 * time.Second)
-	dataBatch := manager.ScrapeMetrics(end.Add(-10*time.Second), end)
+	dataBatch, err := manager.ScrapeMetrics(end.Add(-10*time.Second), end)
+	if err != nil {
+		t.Fatalf("ScrapeMetrics error. %v", err)
+	}
 	elapsed := time.Now().Sub(now)
 
 	if elapsed > 4*time.Second {

--- a/metrics/sources/summary/summary.go
+++ b/metrics/sources/summary/summary.go
@@ -81,7 +81,7 @@ func (this *summaryMetricsSource) String() string {
 	return fmt.Sprintf("kubelet_summary:%s:%d", this.node.IP, this.node.Port)
 }
 
-func (this *summaryMetricsSource) ScrapeMetrics(start, end time.Time) *DataBatch {
+func (this *summaryMetricsSource) ScrapeMetrics(start, end time.Time) (*DataBatch, error) {
 	result := &DataBatch{
 		Timestamp:  time.Now(),
 		MetricSets: map[string]*MetricSet{},
@@ -94,13 +94,12 @@ func (this *summaryMetricsSource) ScrapeMetrics(start, end time.Time) *DataBatch
 	}()
 
 	if err != nil {
-		glog.Errorf("error while getting metrics summary from Kubelet %s(%s:%d): %v", this.node.NodeName, this.node.IP, this.node.Port, err)
-		return result
+		return nil, err
 	}
 
 	result.MetricSets = this.decodeSummary(summary)
 
-	return result
+	return result, err
 }
 
 const (

--- a/metrics/sources/summary/summary_test.go
+++ b/metrics/sources/summary/summary_test.go
@@ -96,9 +96,9 @@ type fakeSource struct {
 }
 
 func (f *fakeSource) Name() string { return "fake" }
-func (f *fakeSource) ScrapeMetrics(start, end time.Time) *core.DataBatch {
+func (f *fakeSource) ScrapeMetrics(start, end time.Time) (*core.DataBatch, error) {
 	f.scraped = true
-	return nil
+	return nil, nil
 }
 
 func testingSummaryMetricsSource() *summaryMetricsSource {
@@ -422,6 +422,7 @@ func TestScrapeSummaryMetrics(t *testing.T) {
 	ms.node.Port, err = strconv.Atoi(split[1])
 	require.NoError(t, err)
 
-	res := ms.ScrapeMetrics(time.Now(), time.Now())
+	res, err := ms.ScrapeMetrics(time.Now(), time.Now())
+	assert.Nil(t, err, "scrape error")
 	assert.Equal(t, res.MetricSets["node:test"].Labels[core.LabelMetricSetType.Key], core.MetricSetTypeNode)
 }

--- a/metrics/util/dummies.go
+++ b/metrics/util/dummies.go
@@ -78,14 +78,14 @@ func (this *DummyMetricsSource) Name() string {
 	return "dummy"
 }
 
-func (this *DummyMetricsSource) ScrapeMetrics(start, end time.Time) *core.DataBatch {
+func (this *DummyMetricsSource) ScrapeMetrics(start, end time.Time) (*core.DataBatch, error) {
 	time.Sleep(this.latency)
 	return &core.DataBatch{
 		Timestamp: end,
 		MetricSets: map[string]*core.MetricSet{
 			this.metricSet.Labels["name"]: &this.metricSet,
 		},
-	}
+	}, nil
 }
 
 func newDummyMetricSet(name string) core.MetricSet {


### PR DESCRIPTION
When error in scraping a knode metrics, heapster should fail fast after error checking.

Currently, even when scraping error, an successful scrape log will also emitted which is confusing.

/cc @DirectXMan12 @piosz 