### PR TITLE
Added Statsd metrics sink for Heapster

### DIFF
--- a/docs/sink-configuration.md
+++ b/docs/sink-configuration.md
@@ -75,6 +75,51 @@ To use the GCL sink add the following flag:
     * Where `project_ID` is the project ID of the Google Cloud Platform project.
     * Select `kubernetes.io/events` from the `All logs` drop down menu.
 
+### StatsD
+This sink supports monitoring metrics only.
+To use the StatsD sink add the following flag:
+```
+  --sink="statsd:udp://<HOST>:<PORT>[?<OPTIONS>]"
+```
+
+The following options are available:
+
+* `prefix`           - Adds specified prefix to all metrics, default is empty
+* `protocolType`     - Protocol type specifies the message format, it can be either etsystatsd or influxstatsd, default is etsystatsd
+* `numMetricsPerMsg` - number of metrics to be packed in an UDP message, default is 5
+* `renameLabels`     - renames labels, old and new label separated by ':' and pairs of old and new labels separated by ','
+* `allowedLabels`    - comma-separated labels that are allowed, default is empty ie all labels are allowed
+* `labelStyle`       - convert labels from default snake case to other styles, default is no convertion. Styles supported are `lowerCamelCase` and `upperCamelCase`
+
+For example.
+```
+  --sink="statsd:udp://127.0.0.1:4125?prefix=kubernetes.example.&protocolType=influxstatsd&numMetricsPerMsg=10&renameLabels=type:k8s_type,host_name:k8s_host_name&allowedLabels=container_name,namespace_name,type,host_name&labelStyle=lowerCamelCase"
+```
+
+#### etsystatsd metrics format
+
+| Metric Set Type |  Metrics Format                                                                       |
+|:----------------|:--------------------------------------------------------------------------------------|
+| Cluster         | `<PREFIX>.<SUFFIX>`                                                                   |
+| Node            | `<PREFIX>.node.<NODE>.<SUFFIX>`                                                       |
+| Namespace       | `<PREFIX>.namespace.<NAMESPACE>.<SUFFIX>`                                             |
+| Pod             | `<PREFIX>.node.<NODE>.namespace.<NAMESPACE>.pod.<POD>.<SUFFIX>`                       |
+| PodContainer    | `<PREFIX>.node.<NODE>.namespace.<NAMESPACE>.pod.<POD>.container.<CONTAINER>.<SUFFIX>` |
+| SystemContainer | `<PREFIX>.node.<NODE>.sys-container.<SYS-CONTAINER>.<SUFFIX>`                         |
+
+* `PREFIX`      - configured prefix
+* `SUFFIX`      - `[.<USER_LABELS>].<METRIC>[.<RESOURCE_ID>]`
+* `USER_LABELS` - user provided labels `[.<KEY1>.<VAL1>][.<KEY2>.<VAL2>] ...`
+* `METRIC`      - metric name, eg: filesystem/usage
+* `RESOURCE_ID` - An unique identifier used to differentiate multiple metrics of the same type. eg: FS partitions under filesystem/usage
+
+#### influxstatsd metrics format
+Influx StatsD is very similar to Etsy StatsD. Tags are supported by adding a comma-separated list of tags in key=value format.
+
+```
+<METRIC>[,<KEY1=VAL1>,<KEY2=VAL2>...]:<METRIC_VALUE>|<METRIC_TYPE>
+```
+
 ### Hawkular-Metrics
 This sink supports monitoring metrics only.
 To use the Hawkular-Metrics sink add the following flag:

--- a/docs/sink-owners.md
+++ b/docs/sink-owners.md
@@ -38,3 +38,4 @@ List of Owners
 | Wavefront       | :heavy_check_mark: | :x:                | @ezeev                                        | :ok:           |
 | Librato         | :heavy_check_mark: | :x:                | @johanneswuerbach                             | :ok:           |
 | Honeycomb       | :heavy_check_mark: | :heavy_check_mark: | @emfree                                       | :new: #1762    |
+| StatsD          | :heavy_check_mark: | :x:                | @yogeswaran                                   | :ok:           |

--- a/metrics/sinks/factory.go
+++ b/metrics/sinks/factory.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/heapster/metrics/sinks/opentsdb"
 	"k8s.io/heapster/metrics/sinks/riemann"
 	"k8s.io/heapster/metrics/sinks/stackdriver"
+	"k8s.io/heapster/metrics/sinks/statsd"
 	"k8s.io/heapster/metrics/sinks/wavefront"
 )
 
@@ -48,6 +49,8 @@ func (this *SinkFactory) Build(uri flags.Uri) (core.DataSink, error) {
 		return gcm.CreateGCMSink(&uri.Val)
 	case "stackdriver":
 		return stackdriver.CreateStackdriverSink(&uri.Val)
+	case "statsd":
+		return statsd.NewStatsdSink(&uri.Val)
 	case "graphite":
 		return graphite.NewGraphiteSink(&uri.Val)
 	case "hawkular":

--- a/metrics/sinks/statsd/driver.go
+++ b/metrics/sinks/statsd/driver.go
@@ -1,0 +1,199 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statsd
+
+import (
+	"fmt"
+	"github.com/golang/glog"
+	"k8s.io/heapster/metrics/core"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+const (
+	defaultHost             = "localhost:8125"
+	defaultNumMetricsPerMsg = 5
+	defaultProtocolType     = "etsystatsd"
+)
+
+type statsdSink struct {
+	config    statsdConfig
+	formatter Formatter
+	client    statsdClient
+	sync.RWMutex
+}
+
+type statsdConfig struct {
+	host             string
+	prefix           string
+	numMetricsPerMsg int
+	protocolType     string
+	renameLabels     map[string]string
+	allowedLabels    map[string]string
+	customizeLabel   CustomizeLabel
+}
+
+func getConfig(uri *url.URL) (cfg statsdConfig, err error) {
+	config := statsdConfig{
+		host:             defaultHost,
+		prefix:           "",
+		numMetricsPerMsg: defaultNumMetricsPerMsg,
+		protocolType:     defaultProtocolType,
+		renameLabels:     make(map[string]string),
+		allowedLabels:    make(map[string]string),
+		customizeLabel:   nil,
+	}
+
+	if len(uri.Host) > 0 {
+		config.host = uri.Host
+	}
+	opts := uri.Query()
+	if len(opts["numMetricsPerMsg"]) >= 1 {
+		val, err := strconv.Atoi(opts["numMetricsPerMsg"][0])
+		if err != nil {
+			return config, fmt.Errorf("failed to parse `numMetricsPerMsg` field - %v", err)
+		}
+		config.numMetricsPerMsg = val
+	}
+	if len(opts["protocolType"]) >= 1 {
+		config.protocolType = strings.ToLower(opts["protocolType"][0])
+	}
+	if len(opts["prefix"]) >= 1 {
+		config.prefix = opts["prefix"][0]
+	}
+	if len(opts["renameLabels"]) >= 1 {
+		renameLabels := strings.Split(opts["renameLabels"][0], ",")
+		for _, renameLabel := range renameLabels {
+			kv := strings.SplitN(renameLabel, ":", 2)
+			config.renameLabels[kv[0]] = kv[1]
+		}
+	}
+	if len(opts["allowedLabels"]) >= 1 {
+		allowedLabels := strings.Split(opts["allowedLabels"][0], ",")
+		for _, allowedLabel := range allowedLabels {
+			config.allowedLabels[allowedLabel] = allowedLabel
+		}
+	}
+	labelStyle := DefaultLabelStyle
+	if len(opts["labelStyle"]) >= 1 {
+		switch opts["labelStyle"][0] {
+		case "lowerCamelCase":
+			labelStyle = SnakeToLowerCamel
+		case "upperCamelCase":
+			labelStyle = SnakeToUpperCamel
+		default:
+			glog.Errorf("invalid labelStyle - %s", opts["labelStyle"][0])
+		}
+	}
+	labelCustomizer := LabelCustomizer{config.renameLabels, labelStyle}
+	config.customizeLabel = labelCustomizer.Customize
+	glog.Infof("statsd metrics sink using configuration : %+v", config)
+	return config, nil
+}
+
+func (sink *statsdSink) ExportData(dataBatch *core.DataBatch) {
+	sink.Lock()
+	defer sink.Unlock()
+
+	var metrics []string
+	var tmpstr string
+	var err error
+	allowAllLabels := len(sink.config.allowedLabels) == 0
+	for _, metricSet := range dataBatch.MetricSets {
+		var metricSetLabels map[string]string
+		if allowAllLabels {
+			metricSetLabels = metricSet.Labels
+		} else {
+			metricSetLabels = make(map[string]string)
+			for k, v := range metricSet.Labels {
+				_, allowed := sink.config.allowedLabels[k]
+				if allowed {
+					metricSetLabels[k] = v
+				}
+			}
+		}
+		for metricName, metricValue := range metricSet.MetricValues {
+			tmpstr, err = sink.formatter.Format(sink.config.prefix, metricName, metricSetLabels, sink.config.customizeLabel, metricValue)
+			if err != nil {
+				glog.Errorf("statsd metrics sink - failed to format metrics : %s", err.Error())
+				continue
+			}
+			metrics = append(metrics, tmpstr)
+		}
+		for _, metric := range metricSet.LabeledMetrics {
+			labels := make(map[string]string)
+			for k, v := range metricSetLabels {
+				labels[k] = v
+			}
+			for k, v := range metric.Labels {
+				_, allowed := sink.config.allowedLabels[k]
+				if allowed || allowAllLabels {
+					labels[k] = v
+				}
+			}
+			tmpstr, err = sink.formatter.Format(sink.config.prefix, metric.Name, labels, sink.config.customizeLabel, metric.MetricValue)
+			if err != nil {
+				glog.Errorf("statsd metrics sink - failed to format labeled metrics : %v", err)
+				continue
+			}
+			metrics = append(metrics, tmpstr)
+		}
+	}
+	glog.V(5).Infof("Sending metrics --- %s", metrics)
+	err = sink.client.send(metrics)
+	if err != nil {
+		glog.Errorf("statsd metrics sink - failed to send some metrics : %v", err)
+	}
+}
+
+func (sink *statsdSink) Name() string {
+	return "StatsD Sink"
+}
+
+func (sink *statsdSink) Stop() {
+	glog.V(2).Info("statsd metrics sink is stopping")
+	sink.client.close()
+}
+
+func NewStatsdSinkWithClient(uri *url.URL, client statsdClient) (sink core.DataSink, err error) {
+	config, err := getConfig(uri)
+	if err != nil {
+		return nil, err
+	}
+	formatter, err := NewFormatter(config.protocolType)
+	if err != nil {
+		return nil, err
+	}
+	glog.V(2).Info("statsd metrics sink is created")
+	return &statsdSink{
+		config:    config,
+		formatter: formatter,
+		client:    client,
+	}, nil
+}
+
+func NewStatsdSink(uri *url.URL) (sink core.DataSink, err error) {
+	config, err := getConfig(uri)
+	if err != nil {
+		return nil, err
+	}
+	client, err := NewStatsdClient(config.host, config.numMetricsPerMsg)
+	if err != nil {
+		return nil, err
+	}
+	return NewStatsdSinkWithClient(uri, client)
+}

--- a/metrics/sinks/statsd/driver_test.go
+++ b/metrics/sinks/statsd/driver_test.go
@@ -1,0 +1,118 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statsd
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/heapster/metrics/core"
+)
+
+const (
+	driverUrl = "udp://127.0.0.1:4125?protocolType=influxstatsd&allowedLabels=tag1,tag3"
+)
+
+func TestDriverName(t *testing.T) {
+	url, err := url.Parse(driverUrl)
+	assert.NoError(t, err)
+
+	sink, err := NewStatsdSink(url)
+	assert.NoError(t, err)
+	assert.NotNil(t, sink)
+
+	assert.Equal(t, "StatsD Sink", sink.Name())
+}
+
+func TestDriverExportData(t *testing.T) {
+	url, err := url.Parse(driverUrl)
+	assert.NoError(t, err)
+
+	client := &dummyStatsdClientImpl{messages: nil}
+	sink, err := NewStatsdSinkWithClient(url, client)
+	assert.NoError(t, err)
+	assert.NotNil(t, sink)
+
+	timestamp := time.Now()
+
+	m1 := "test.metric.1"
+	m2 := "test.metric.2"
+	m3 := "test.metric.3"
+	m4 := "test.metric.4"
+
+	var labels = map[string]string{
+		"tag1": "value1",
+		"tag2": "value2",
+		"tag3": "value3",
+	}
+
+	labelStr := "tag1=value1,tag3=value3"
+	expectedMsgs := [...]string{
+		fmt.Sprintf("%s,%s:1|g\n", m1, labelStr),
+		fmt.Sprintf("%s,%s:2|g\n", m2, labelStr),
+		fmt.Sprintf("%s,%s:3|g\n", m3, labelStr),
+		fmt.Sprintf("%s,%s:4|g\n", m4, labelStr),
+	}
+	metricSet1 := core.MetricSet{
+		Labels: labels,
+		MetricValues: map[string]core.MetricValue{
+			m1: {
+				ValueType:  core.ValueInt64,
+				MetricType: core.MetricGauge,
+				IntValue:   1,
+			},
+			m2: {
+				ValueType:  core.ValueInt64,
+				MetricType: core.MetricGauge,
+				IntValue:   2,
+			},
+		},
+	}
+
+	metricSet2 := core.MetricSet{
+		Labels: labels,
+		MetricValues: map[string]core.MetricValue{
+			m3: {
+				ValueType:  core.ValueInt64,
+				MetricType: core.MetricGauge,
+				IntValue:   3,
+			},
+			m4: {
+				ValueType:  core.ValueInt64,
+				MetricType: core.MetricGauge,
+				IntValue:   4,
+			},
+		},
+	}
+
+	dataBatch := &core.DataBatch{
+		Timestamp: timestamp,
+		MetricSets: map[string]*core.MetricSet{
+			"pod1": &metricSet1,
+			"pod2": &metricSet2,
+		},
+	}
+
+	sink.ExportData(dataBatch)
+
+	res := strings.Join(client.messages, "\n") + "\n"
+	for _, expectedMsg := range expectedMsgs[:] {
+		assert.Contains(t, res, expectedMsg)
+	}
+}

--- a/metrics/sinks/statsd/dummy_statsd_client.go
+++ b/metrics/sinks/statsd/dummy_statsd_client.go
@@ -1,0 +1,38 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statsd
+
+import (
+	"github.com/golang/glog"
+)
+
+type dummyStatsdClientImpl struct {
+	messages []string
+}
+
+func (client *dummyStatsdClientImpl) open() error {
+	glog.V(2).Infof("dummy statsd client open() called, doing nothing")
+	return nil
+}
+
+func (client *dummyStatsdClientImpl) close() error {
+	glog.V(2).Infof("dummy statsd client close() called, doing nothing")
+	return nil
+}
+
+func (client *dummyStatsdClientImpl) send(messages []string) error {
+	client.messages = messages
+	return nil
+}

--- a/metrics/sinks/statsd/etsystatsd_formatter.go
+++ b/metrics/sinks/statsd/etsystatsd_formatter.go
@@ -1,0 +1,139 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statsd
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/golang/glog"
+	"k8s.io/heapster/metrics/core"
+	"sort"
+	"strings"
+)
+
+type EtsystatsdFormatter struct {
+	delimReplacer *strings.Replacer
+}
+
+func (formatter *EtsystatsdFormatter) Format(prefix string, name string, labels map[string]string, customizeLabel CustomizeLabel, metricValue core.MetricValue) (res string, err error) {
+	var metricName string
+	var suffix string
+	if resourceId, ok := labels[core.LabelResourceID.Key]; ok {
+		metricName = fmt.Sprintf("%s.%s",
+			formatter.delimReplacer.Replace(name),
+			formatter.delimReplacer.Replace(resourceId))
+	} else {
+		metricName = formatter.delimReplacer.Replace(name)
+	}
+	if prefix != "" {
+		prefix = formatter.delimReplacer.Replace(prefix) + "."
+	}
+	userLabelStr := labels[core.LabelLabels.Key]
+	if len(userLabelStr) > 0 {
+		suffix = fmt.Sprintf("%s.%s:%v|g",
+			formatter.formatUserLabels(userLabelStr, customizeLabel),
+			metricName,
+			metricValue.GetValue(),
+		)
+	} else {
+		suffix = fmt.Sprintf("%s:%v|g",
+			metricName,
+			metricValue.GetValue(),
+		)
+	}
+	metricType, hasMetricType := labels[core.LabelMetricSetType.Key]
+	if !hasMetricType {
+		return "", fmt.Errorf("Missing LabelMetricSetType in labels, failed to format metrics")
+	}
+	switch metricType {
+	case core.MetricSetTypePodContainer:
+		return fmt.Sprintf("%snode.%s.namespace.%s.pod.%s.container.%s.%s",
+			prefix,
+			formatter.delimReplacer.Replace(labels[core.LabelHostname.Key]),
+			formatter.delimReplacer.Replace(labels[core.LabelNamespaceName.Key]),
+			formatter.delimReplacer.Replace(labels[core.LabelPodName.Key]),
+			formatter.delimReplacer.Replace(labels[core.LabelContainerName.Key]),
+			suffix,
+		), nil
+	case core.MetricSetTypeSystemContainer:
+		return fmt.Sprintf("%snode.%s.sys-container.%s.%s",
+			prefix,
+			formatter.delimReplacer.Replace(labels[core.LabelHostname.Key]),
+			formatter.delimReplacer.Replace(labels[core.LabelContainerName.Key]),
+			suffix,
+		), nil
+	case core.MetricSetTypePod:
+		return fmt.Sprintf("%snode.%s.namespace.%s.pod.%s.%s",
+			prefix,
+			formatter.delimReplacer.Replace(labels[core.LabelHostname.Key]),
+			formatter.delimReplacer.Replace(labels[core.LabelNamespaceName.Key]),
+			formatter.delimReplacer.Replace(labels[core.LabelPodName.Key]),
+			suffix,
+		), nil
+	case core.MetricSetTypeNamespace:
+		return fmt.Sprintf("%snamespace.%s.%s",
+			prefix,
+			formatter.delimReplacer.Replace(labels[core.LabelNamespaceName.Key]),
+			suffix,
+		), nil
+	case core.MetricSetTypeNode:
+		return fmt.Sprintf("%snode.%s.%s",
+			prefix,
+			formatter.delimReplacer.Replace(labels[core.LabelHostname.Key]),
+			suffix,
+		), nil
+	case core.MetricSetTypeCluster:
+		return fmt.Sprintf("%scluster.%s",
+			prefix,
+			suffix,
+		), nil
+	default:
+		err = fmt.Errorf("Unknown metric set type %s", metricType)
+	}
+	return "", err
+}
+
+func (formatter *EtsystatsdFormatter) formatUserLabels(appLabel string, customizeLabel CustomizeLabel) string {
+	labelMap := make(map[string]string)
+	kvPairs := strings.Split(appLabel, ",")
+	for _, kvPair := range kvPairs {
+		kv := strings.Split(kvPair, ":")
+		if len(kv) >= 2 {
+			labelMap[kv[0]] = kv[1]
+		}
+	}
+	keys := make([]string, len(labelMap))
+	for k := range labelMap {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var buffer bytes.Buffer
+	for _, k := range keys {
+		v := labelMap[k]
+		if v != "" && buffer.Len() > 0 {
+			buffer.WriteString(fmt.Sprintf(".%s.%s", customizeLabel(formatter.delimReplacer.Replace(k)), formatter.delimReplacer.Replace(v)))
+		} else if v != "" {
+			buffer.WriteString(fmt.Sprintf("%s.%s", customizeLabel(formatter.delimReplacer.Replace(k)), formatter.delimReplacer.Replace(v)))
+		}
+	}
+	return buffer.String()
+}
+
+func NewEtsystatsdFormatter() Formatter {
+	glog.V(2).Info("etsystatsd formatter is created")
+	return &EtsystatsdFormatter{
+		delimReplacer: strings.NewReplacer(".", "_", "=", "_", "|", "_"),
+	}
+}

--- a/metrics/sinks/statsd/etsystatsd_formatter_test.go
+++ b/metrics/sinks/statsd/etsystatsd_formatter_test.go
@@ -1,0 +1,175 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statsd
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/heapster/metrics/core"
+	"testing"
+)
+
+var (
+	etsyPrefix               = "testprefix"
+	etsyMetricName           = "testmetric"
+	etsyHostName             = "testhost"
+	etsyNamespace            = "testnamespace"
+	etsyPodName              = "testpodname"
+	etsyContainerName        = "testcontainername"
+	etsyResourceName         = "testresource"
+	etsyUserLabels           = "test_tag_1:val1,test_tag_2:val2,test_tag_3:val3"
+	expectedLowerCamelLabels = "testTag1.val1.testTag2.val2.testTag3.val3"
+	expectedUpperCamelLabels = "TestTag1.val1.TestTag2.val2.TestTag3.val3"
+)
+
+var etsyLabels = map[string]string{
+	core.LabelHostname.Key:      etsyHostName,
+	core.LabelNamespaceName.Key: etsyNamespace,
+	core.LabelPodName.Key:       etsyPodName,
+	core.LabelContainerName.Key: etsyContainerName,
+	core.LabelLabels.Key:        etsyUserLabels,
+}
+
+var etsyMetricValue = core.MetricValue{
+	MetricType: core.MetricGauge,
+	ValueType:  core.ValueInt64,
+	IntValue:   1000,
+}
+
+var renameLabels = map[string]string{"old1": "new1", "old2": "new_label_2", "old3": "new_label_3"}
+var defaultCustomizer = LabelCustomizer{renameLabels, DefaultLabelStyle}
+var lowerCamelCustomizer = LabelCustomizer{renameLabels, SnakeToLowerCamel}
+var upperCamelCustomizer = LabelCustomizer{renameLabels, SnakeToUpperCamel}
+
+var defaultCustomize = defaultCustomizer.Customize
+var lowerCamelCustomize = lowerCamelCustomizer.Customize
+var upperCamelCustomize = upperCamelCustomizer.Customize
+
+func TestEtsyFormatUnknownType(t *testing.T) {
+	etsyLabels[core.LabelMetricSetType.Key] = "UnknownMetricSetType"
+	expectedMsg := ""
+
+	formatter := NewEtsystatsdFormatter()
+	assert.NotNil(t, formatter)
+
+	msg, err := formatter.Format(etsyPrefix, etsyMetricName, etsyLabels, defaultCustomize, etsyMetricValue)
+	assert.Error(t, err)
+	assert.Equal(t, expectedMsg, msg)
+}
+
+func TestEtsyFormatPodContainerType(t *testing.T) {
+	etsyLabels[core.LabelMetricSetType.Key] = core.MetricSetTypePodContainer
+	expectedMsg := fmt.Sprintf("%s.node.%s.namespace.%s.pod.%s.container.%s.%s.%s:%v|g",
+		etsyPrefix, etsyHostName, etsyNamespace, etsyPodName, etsyContainerName, expectedLowerCamelLabels, etsyMetricName, etsyMetricValue.IntValue)
+
+	formatter := NewEtsystatsdFormatter()
+	assert.NotNil(t, formatter)
+
+	msg, err := formatter.Format(etsyPrefix, etsyMetricName, etsyLabels, lowerCamelCustomize, etsyMetricValue)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedMsg, msg)
+}
+
+func TestEtsyFormatSystemContainerType(t *testing.T) {
+	etsyLabels[core.LabelMetricSetType.Key] = core.MetricSetTypeSystemContainer
+	expectedMsg := fmt.Sprintf("%s.node.%s.sys-container.%s.%s.%s:%v|g",
+		etsyPrefix, etsyHostName, etsyContainerName, expectedUpperCamelLabels, etsyMetricName, etsyMetricValue.IntValue)
+
+	formatter := NewEtsystatsdFormatter()
+	assert.NotNil(t, formatter)
+
+	msg, err := formatter.Format(etsyPrefix, etsyMetricName, etsyLabels, upperCamelCustomize, etsyMetricValue)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedMsg, msg)
+}
+
+func TestEtsyFormatPodType(t *testing.T) {
+	etsyLabels[core.LabelMetricSetType.Key] = core.MetricSetTypePod
+	expectedMsg := fmt.Sprintf("%s.node.%s.namespace.%s.pod.%s.%s.%s:%v|g",
+		etsyPrefix, etsyHostName, etsyNamespace, etsyPodName, expectedLowerCamelLabels, etsyMetricName, etsyMetricValue.IntValue)
+
+	formatter := NewEtsystatsdFormatter()
+	assert.NotNil(t, formatter)
+
+	msg, err := formatter.Format(etsyPrefix, etsyMetricName, etsyLabels, lowerCamelCustomize, etsyMetricValue)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedMsg, msg)
+}
+
+func TestEtsyFormatNamespaceType(t *testing.T) {
+	etsyLabels[core.LabelMetricSetType.Key] = core.MetricSetTypeNamespace
+	expectedMsg := fmt.Sprintf("%s.namespace.%s.%s.%s:%v|g",
+		etsyPrefix, etsyNamespace, expectedUpperCamelLabels, etsyMetricName, etsyMetricValue.IntValue)
+
+	formatter := NewEtsystatsdFormatter()
+	assert.NotNil(t, formatter)
+
+	msg, err := formatter.Format(etsyPrefix, etsyMetricName, etsyLabels, upperCamelCustomize, etsyMetricValue)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedMsg, msg)
+}
+
+func TestEtsyFormatNodeType(t *testing.T) {
+	etsyLabels[core.LabelMetricSetType.Key] = core.MetricSetTypeNode
+	expectedMsg := fmt.Sprintf("%s.node.%s.%s.%s:%v|g",
+		etsyPrefix, etsyHostName, expectedLowerCamelLabels, etsyMetricName, etsyMetricValue.IntValue)
+
+	formatter := NewEtsystatsdFormatter()
+	assert.NotNil(t, formatter)
+
+	msg, err := formatter.Format(etsyPrefix, etsyMetricName, etsyLabels, lowerCamelCustomize, etsyMetricValue)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedMsg, msg)
+}
+
+func TestEtsyFormatClusterType(t *testing.T) {
+	etsyLabels[core.LabelMetricSetType.Key] = core.MetricSetTypeCluster
+	expectedMsg := fmt.Sprintf("%s.cluster.%s.%s:%v|g",
+		etsyPrefix, expectedUpperCamelLabels, etsyMetricName, etsyMetricValue.IntValue)
+
+	formatter := NewEtsystatsdFormatter()
+	assert.NotNil(t, formatter)
+
+	msg, err := formatter.Format(etsyPrefix, etsyMetricName, etsyLabels, upperCamelCustomize, etsyMetricValue)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedMsg, msg)
+}
+
+func TestEtsyFormatWithoutPrefix(t *testing.T) {
+	etsyLabels[core.LabelMetricSetType.Key] = core.MetricSetTypeCluster
+	expectedMsg := fmt.Sprintf("cluster.%s.%s:%v|g",
+		expectedLowerCamelLabels, etsyMetricName, etsyMetricValue.IntValue)
+
+	formatter := NewEtsystatsdFormatter()
+	assert.NotNil(t, formatter)
+
+	msg, err := formatter.Format("", etsyMetricName, etsyLabels, lowerCamelCustomize, etsyMetricValue)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedMsg, msg)
+}
+
+func TestEtsyFormatWithResource(t *testing.T) {
+	etsyLabels[core.LabelMetricSetType.Key] = core.MetricSetTypeCluster
+	etsyLabels[core.LabelResourceID.Key] = etsyResourceName
+	expectedMsg := fmt.Sprintf("%s.cluster.%s.%s.%s:%v|g",
+		etsyPrefix, expectedUpperCamelLabels, etsyMetricName, etsyResourceName, etsyMetricValue.IntValue)
+
+	formatter := NewEtsystatsdFormatter()
+	assert.NotNil(t, formatter)
+
+	msg, err := formatter.Format(etsyPrefix, etsyMetricName, etsyLabels, upperCamelCustomize, etsyMetricValue)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedMsg, msg)
+}

--- a/metrics/sinks/statsd/formatter.go
+++ b/metrics/sinks/statsd/formatter.go
@@ -1,0 +1,75 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statsd
+
+import (
+	"fmt"
+	"k8s.io/heapster/metrics/core"
+	"strings"
+	"unicode"
+)
+
+type Formatter interface {
+	Format(prefix string, name string, labels map[string]string, customizeLabel CustomizeLabel, metricValue core.MetricValue) (res string, err error)
+}
+
+type LabelStyle func(string) string
+type CustomizeLabel func(string) string
+
+type LabelCustomizer struct {
+	renameLabels map[string]string
+	labelStyle   LabelStyle
+}
+
+func (customizer LabelCustomizer) Customize(label string) string {
+	if val, ok := customizer.renameLabels[label]; ok {
+		label = val
+	}
+	return (customizer.labelStyle(label))
+}
+
+func NewFormatter(protocolType string) (formatter Formatter, err error) {
+	switch protocolType {
+	case "etsystatsd":
+		return NewEtsystatsdFormatter(), nil
+	case "influxstatsd":
+		return NewInfluxstatsdFormatter(), nil
+	default:
+		return nil, fmt.Errorf("Unknown statd formatter %s", protocolType)
+	}
+}
+
+func DefaultLabelStyle(str string) string {
+	return str
+}
+
+func SnakeToLowerCamel(str string) string {
+	res := SnakeToUpperCamel(str)
+
+	ustr := []rune(res)
+	ustr[0] = unicode.ToLower(ustr[0])
+	res = string(ustr)
+
+	return res
+}
+
+func SnakeToUpperCamel(str string) string {
+	res := ""
+	words := strings.Split(str, "_")
+	for _, word := range words {
+		res += strings.Title(word)
+	}
+	return res
+}

--- a/metrics/sinks/statsd/influxstatsd_formatter.go
+++ b/metrics/sinks/statsd/influxstatsd_formatter.go
@@ -1,0 +1,75 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statsd
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/golang/glog"
+	"k8s.io/heapster/metrics/core"
+	"sort"
+	"strings"
+)
+
+type InfluxstatsdFormatter struct {
+	delimReplacer *strings.Replacer
+}
+
+func (formatter *InfluxstatsdFormatter) Format(prefix string, name string, labels map[string]string, customizeLabel CustomizeLabel, metricValue core.MetricValue) (res string, err error) {
+	var buffer bytes.Buffer
+	buffer.WriteString(fmt.Sprintf("%s%s", formatter.delimReplacer.Replace(prefix), formatter.delimReplacer.Replace(name)))
+	expandedLabels := formatter.expandUserLabels(labels)
+	keys := make([]string, len(expandedLabels))
+	for k := range expandedLabels {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		v := expandedLabels[k]
+		if v != "" {
+			buffer.WriteString(fmt.Sprintf(",%s=%s", customizeLabel(formatter.delimReplacer.Replace(k)), formatter.delimReplacer.Replace(v)))
+		}
+	}
+	buffer.WriteString(fmt.Sprintf(":%v|g", metricValue.GetValue()))
+
+	return buffer.String(), nil
+}
+
+func (formatter *InfluxstatsdFormatter) expandUserLabels(labels map[string]string) map[string]string {
+	res := make(map[string]string)
+	var userLabelStr string
+	for k, v := range labels {
+		if k == core.LabelLabels.Key {
+			userLabelStr = v
+		} else {
+			res[k] = v
+		}
+	}
+	kvPairs := strings.Split(userLabelStr, ",")
+	for _, kvPair := range kvPairs {
+		kv := strings.Split(kvPair, ":")
+		if len(kv) >= 2 {
+			res[kv[0]] = kv[1]
+		}
+	}
+	return res
+}
+
+func NewInfluxstatsdFormatter() Formatter {
+	glog.V(2).Info("influxstatsd formatter is created")
+	return &InfluxstatsdFormatter{
+		delimReplacer: strings.NewReplacer(",", "_", ":", "_", "=", "_", "|", "_"),
+	}
+}

--- a/metrics/sinks/statsd/influxstatsd_formatter_test.go
+++ b/metrics/sinks/statsd/influxstatsd_formatter_test.go
@@ -1,0 +1,72 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statsd
+
+import (
+	"github.com/stretchr/testify/assert"
+	"k8s.io/heapster/metrics/core"
+	"testing"
+)
+
+var (
+	influxPrefix       = "testprefix."
+	influxMetricName   = "testmetric"
+	influxResourceName = "testresource"
+)
+
+var influxLabels = map[string]string{
+	"test_tag_1": "value1",
+	"test_tag_2": "value2",
+	"test_tag_3": "value3",
+}
+
+var influxMetricValue = core.MetricValue{
+	MetricType: core.MetricGauge,
+	ValueType:  core.ValueInt64,
+	IntValue:   1000,
+}
+
+func TestInfluxFormatWithoutLabels(t *testing.T) {
+	expectedMsg := "testprefix.testmetric:1000|g"
+
+	formatter := NewInfluxstatsdFormatter()
+	assert.NotNil(t, formatter)
+
+	msg, err := formatter.Format(influxPrefix, influxMetricName, nil, SnakeToLowerCamel, influxMetricValue)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedMsg, msg)
+}
+
+func TestInfluxFormatWithLabels(t *testing.T) {
+	expectedMsg := "testprefix.testmetric,testTag1=value1,testTag2=value2,testTag3=value3:1000|g"
+
+	formatter := NewInfluxstatsdFormatter()
+	assert.NotNil(t, formatter)
+
+	msg, err := formatter.Format(influxPrefix, influxMetricName, influxLabels, SnakeToLowerCamel, influxMetricValue)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedMsg, msg)
+}
+
+func TestInfluxFormatWithoutPrefix(t *testing.T) {
+	expectedMsg := "testmetric,TestTag1=value1,TestTag2=value2,TestTag3=value3:1000|g"
+
+	formatter := NewInfluxstatsdFormatter()
+	assert.NotNil(t, formatter)
+
+	msg, err := formatter.Format("", influxMetricName, influxLabels, SnakeToUpperCamel, influxMetricValue)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedMsg, msg)
+}

--- a/metrics/sinks/statsd/statsd_client.go
+++ b/metrics/sinks/statsd/statsd_client.go
@@ -1,0 +1,95 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statsd
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/golang/glog"
+	"net"
+)
+
+type statsdClient interface {
+	open() error
+	close() error
+	send(messages []string) error
+}
+
+type statsdClientImpl struct {
+	host             string
+	numMetricsPerMsg int
+	conn             net.Conn
+}
+
+func (client *statsdClientImpl) open() error {
+	var err error
+	client.conn, err = net.Dial("udp", client.host)
+	if err != nil {
+		glog.Errorf("Failed to open statsd client connection : %v", err)
+	} else {
+		glog.V(2).Infof("statsd client connection opened : %+v", client.conn)
+	}
+	return err
+}
+
+func (client *statsdClientImpl) close() error {
+	if client.conn == nil {
+		glog.Info("statsd client connection already closed")
+		return nil
+	}
+	err := client.conn.Close()
+	client.conn = nil
+	glog.V(2).Infof("statsd client connection closed")
+	return err
+}
+
+func (client *statsdClientImpl) send(messages []string) error {
+	if client.conn == nil {
+		err := client.open()
+		if err != nil {
+			return fmt.Errorf("send() failed - %v", err)
+		}
+	}
+	var numMetrics = 0
+	var err, tmpErr error
+	buf := bytes.NewBufferString("")
+	for _, msg := range messages {
+		buf.WriteString(fmt.Sprintf("%s\n", msg))
+		numMetrics++
+		if numMetrics >= client.numMetricsPerMsg {
+			_, tmpErr = client.conn.Write(buf.Bytes())
+			if tmpErr != nil {
+				err = tmpErr
+			}
+			buf.Reset()
+			numMetrics = 0
+		}
+	}
+	if buf.Len() > 0 {
+		_, tmpErr = client.conn.Write(buf.Bytes())
+		if tmpErr != nil {
+			err = tmpErr
+		}
+	}
+	return err
+}
+
+func NewStatsdClient(host string, numMetricsPerMsg int) (client statsdClient, err error) {
+	if numMetricsPerMsg <= 0 {
+		return nil, fmt.Errorf("numMetricsPerMsg should be a positive integer : %d", numMetricsPerMsg)
+	}
+	glog.V(2).Infof("statsd client created")
+	return &statsdClientImpl{host: host, numMetricsPerMsg: numMetricsPerMsg}, nil
+}

--- a/metrics/sinks/statsd/statsd_client_test.go
+++ b/metrics/sinks/statsd/statsd_client_test.go
@@ -1,0 +1,180 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statsd
+
+import (
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	validHost             = "127.0.0.1:48125"
+	validNumMetricsPerMsg = 3
+	bufferSize            = 1024
+)
+
+var msgs = [...]string{
+	"test message 0",
+	"test message 1",
+	"test message 2",
+	"test message 3",
+	"test message 4",
+	"test message 5",
+	"test message 6",
+	"test message 7",
+}
+
+func TestInvalidHostname(t *testing.T) {
+	client, err := NewStatsdClient("badhostname:8125", validNumMetricsPerMsg)
+	assert.NoError(t, err)
+	assert.NotNil(t, client)
+	err = client.open()
+	assert.Error(t, err, "An error to lookup an invalid host was expected")
+}
+
+func TestInvalidPortNumber(t *testing.T) {
+	client, err := NewStatsdClient("localhost", validNumMetricsPerMsg)
+	assert.NoError(t, err)
+	assert.NotNil(t, client)
+	err = client.open()
+	assert.Error(t, err, "Error expected - missing port number")
+
+	client, err = NewStatsdClient("localhost:-8125", validNumMetricsPerMsg)
+	assert.NoError(t, err)
+	assert.NotNil(t, client)
+	err = client.open()
+	assert.Error(t, err, "Error expected - port number cannot be negative")
+}
+
+func TestInvalidNumMetricsPerMsg(t *testing.T) {
+	_, err := NewStatsdClient(validHost, 0)
+	assert.Error(t, err, "Error expected - number of metrics per message cannot be 0")
+
+	_, err = NewStatsdClient(validHost, -1)
+	assert.Error(t, err, "Error expected - number of metrics per message cannot be negative")
+}
+
+func TestClose(t *testing.T) {
+	client, err := NewStatsdClient(validHost, validNumMetricsPerMsg)
+	assert.NoError(t, err)
+	assert.NotNil(t, client)
+	err = client.close()
+	assert.NoError(t, err, "Unexpected error - close() should be a NOOP if it is called before open()")
+
+	err = client.open()
+	assert.NoError(t, err)
+	err = client.close()
+	assert.NoError(t, err)
+	err = client.close()
+	assert.NoError(t, err, "Unexpected error - close() should be a NOOP if it is called after another close()")
+}
+
+func initClientServer(t *testing.T, messages []string, numMetricsPerMsg int) (client statsdClient, serverConn *net.UDPConn) {
+	client, err := NewStatsdClient(validHost, numMetricsPerMsg)
+	assert.NoError(t, err)
+	assert.NotNil(t, client)
+
+	err = client.open()
+	assert.NoError(t, err)
+
+	addr, err := net.ResolveUDPAddr("udp", validHost)
+	assert.NoError(t, err)
+	assert.NotNil(t, addr)
+
+	conn, err := net.ListenUDP("udp", addr)
+	assert.NoError(t, err)
+	assert.NotNil(t, conn)
+
+	conn.SetReadDeadline(time.Now().Add(10 * time.Second))
+
+	err = client.send(messages)
+	assert.NoError(t, err)
+
+	return client, conn
+}
+
+func TestSendOneMsg(t *testing.T) {
+
+	numMetricsPerMsg := 10
+	start := 0
+	end := 5
+	client, conn := initClientServer(t, msgs[start:end], numMetricsPerMsg)
+
+	expectedMsg := strings.Join(msgs[start:end], "\n") + "\n"
+
+	buf := make([]byte, 1024)
+	n, _, err := conn.ReadFromUDP(buf)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedMsg, string(buf[0:n]))
+
+	err = client.close()
+	assert.NoError(t, err)
+	conn.Close()
+}
+
+func TestSendMultipleMsgsEqualBatches(t *testing.T) {
+
+	buf := make([]byte, bufferSize)
+	numMetricsPerMsg := 4
+	start := 0
+	end := 8
+	client, conn := initClientServer(t, msgs[start:end], numMetricsPerMsg)
+
+	expectedMsg := strings.Join(msgs[0:4], "\n") + "\n"
+	n, _, err := conn.ReadFromUDP(buf)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedMsg, string(buf[0:n]))
+
+	expectedMsg = strings.Join(msgs[4:8], "\n") + "\n"
+	n, _, err = conn.ReadFromUDP(buf)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedMsg, string(buf[0:n]))
+
+	err = client.close()
+	assert.NoError(t, err)
+	conn.Close()
+}
+
+func TestSendMultipleMsgsUnequalBatches(t *testing.T) {
+
+	buf := make([]byte, bufferSize)
+	numMetricsPerMsg := 3
+	start := 0
+	end := 8
+	client, conn := initClientServer(t, msgs[start:end], numMetricsPerMsg)
+
+	expectedMsg := strings.Join(msgs[0:3], "\n") + "\n"
+	n, _, err := conn.ReadFromUDP(buf)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedMsg, string(buf[0:n]))
+
+	expectedMsg = strings.Join(msgs[3:6], "\n") + "\n"
+	n, _, err = conn.ReadFromUDP(buf)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedMsg, string(buf[0:n]))
+
+	expectedMsg = strings.Join(msgs[6:8], "\n") + "\n"
+	n, _, err = conn.ReadFromUDP(buf)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedMsg, string(buf[0:n]))
+
+	err = client.close()
+	assert.NoError(t, err)
+	conn.Close()
+}


### PR DESCRIPTION
This PR introduces a new heapster metrics sink for statsd. StatsD is a metric collection protocol, there are few variations of StatsD, this PR supports following two types of StatsD

- [etsyStatsD](https://github.com/etsy/statsd/wiki)
- [Influx StatsD](https://www.influxdata.com/blog/getting-started-with-sending-statsd-metrics-to-telegraf-influxdb/) 