### PR TITLE
reverting influxdb and grafana images to earlier versions in deployment

### DIFF
--- a/deploy/kube-config/influxdb/grafana.yaml
+++ b/deploy/kube-config/influxdb/grafana.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: grafana
-        image: gcr.io/google_containers/heapster-grafana-amd64:v4.4.3
+        image: gcr.io/google_containers/heapster-grafana-amd64:v4.4.1
         ports:
         - containerPort: 3000
           protocol: TCP

--- a/deploy/kube-config/influxdb/influxdb.yaml
+++ b/deploy/kube-config/influxdb/influxdb.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: influxdb
-        image: gcr.io/google_containers/heapster-influxdb-amd64:v1.3.3
+        image: gcr.io/google_containers/heapster-influxdb-amd64:v1.1.1
         volumeMounts:
         - mountPath: /data
           name: influxdb-storage


### PR DESCRIPTION
possible resolution of https://github.com/kubernetes/heapster/issues/1804

Although I don't know if this is the correct or "best" resolution, but the images pushed to the GCR.io at the recent versions have some issues.