### PR TITLE
Hawkular, reduce the sink's memory usage in definition caching

### DIFF
--- a/metrics/sinks/hawkular/driver.go
+++ b/metrics/sinks/hawkular/driver.go
@@ -198,7 +198,7 @@ func NewHawkularSink(u *url.URL) (core.DataSink, error) {
 }
 
 func (h *hawkularSink) init() error {
-	h.reg = make(map[string]*metrics.MetricDefinition)
+	h.reg = make(map[string]uint64)
 	h.models = make(map[string]*metrics.MetricDefinition)
 	h.modifiers = make([]metrics.Modifier, 0)
 	h.filters = make([]Filter, 0)

--- a/metrics/sinks/hawkular/driver_test.go
+++ b/metrics/sinks/hawkular/driver_test.go
@@ -34,7 +34,7 @@ import (
 
 func dummySink() *hawkularSink {
 	return &hawkularSink{
-		reg:    make(map[string]*metrics.MetricDefinition),
+		reg:    make(map[string]uint64),
 		models: make(map[string]*metrics.MetricDefinition),
 	}
 }
@@ -303,7 +303,7 @@ func TestRegister(t *testing.T) {
 		defer m.Unlock()
 		w.Header().Set("Content-Type", "application/json")
 
-		if strings.Contains(r.RequestURI, "metrics?type=") {
+		if strings.Contains(r.RequestURI, "metrics?tags=descriptor_name%3A%2A&type=") {
 			typ := r.RequestURI[strings.Index(r.RequestURI, "type=")+5:]
 			definitionsCalled[typ] = true
 			if typ == "gauge" {
@@ -545,19 +545,7 @@ func TestTags(t *testing.T) {
 
 	assert.Equal(t, 1, tagsUpdated)
 
-	tags := hSink.reg["test-container/test-podid/test/metric/A/XYZ"].Tags
-	assert.Equal(t, 10, len(tags))
-	assert.Equal(t, "test-label", tags["projectId"])
-	assert.Equal(t, "test-container", tags[core.LabelContainerName.Key])
-	assert.Equal(t, "test-podid", tags[core.LabelPodId.Key])
-	assert.Equal(t, "test-container/test/metric/A", tags["group_id"])
-	assert.Equal(t, "test/metric/A", tags["descriptor_name"])
-	assert.Equal(t, "XYZ", tags[core.LabelResourceID.Key])
-	assert.Equal(t, "bytes", tags["units"])
-
-	assert.Equal(t, "testLabelA:testValueA,testLabelB:testValueB", tags[core.LabelLabels.Key])
-	assert.Equal(t, "testValueA", tags["labels.testLabelA"])
-	assert.Equal(t, "testValueB", tags["labels.testLabelB"])
+	assert.True(t, hSink.reg["test-container/test-podid/test/metric/A/XYZ"] > 0)
 
 	assert.Equal(t, 10, len(serverTags))
 	assert.Equal(t, "test-label", serverTags["projectId"])

--- a/metrics/sinks/hawkular/types.go
+++ b/metrics/sinks/hawkular/types.go
@@ -49,7 +49,7 @@ type hawkularSink struct {
 	client  *metrics.Client
 	models  map[string]*metrics.MetricDefinition // Model definitions
 	regLock sync.RWMutex
-	reg     map[string]*metrics.MetricDefinition // Real definitions
+	reg     map[string]uint64 // Hash of real definition
 
 	uri *url.URL
 


### PR DESCRIPTION
Instead of storing the struct of the metric definition in memory, store only a hash of it. In cases with large amount of metrics, this should reduce the memory usage (and GC load). This also removes a need for reflect.DeepEqual, which should speed up as a side-effect the recent check.

Also, pushes the descriptorTag filtering to the HWKMETRICS side, instead of filtering at the client side.

@mwringe 