### PR TITLE
make influxdb bind-address using ip

### DIFF
--- a/influxdb/config.toml
+++ b/influxdb/config.toml
@@ -1,5 +1,5 @@
 reporting-disabled = true
-bind-address = "localhost:8088"
+bind-address = "127.0.0.1:8088"
 
 [meta]
   dir = "/data/meta"


### PR DESCRIPTION
This PR move Influxdb `bind-address` from `localhost:8088` to `127.0.0.1:8088`. This can help us avoid setting up heapster in a Kubernetes cluster when some dns settings is not correct, like something happened in the [#1804](https://github.com/kubernetes/heapster/issues/1804).


/cc @DirectXMan12 