### PR TITLE
Fix an issue when memory/bytes_used is not reported.

### DIFF
--- a/metrics/sinks/stackdriver/stackdriver.go
+++ b/metrics/sinks/stackdriver/stackdriver.go
@@ -498,7 +498,18 @@ func (sink *StackdriverSink) TranslateMetric(timestamp time.Time, labels map[str
 		return ts
 	case "memory/bytes_used":
 		point := sink.intPoint(timestamp, timestamp, value.IntValue)
-		return createTimeSeries(resourceLabels, memoryBytesUsedMD, point)
+		ts := createTimeSeries(resourceLabels, memoryBytesUsedMD, point)
+		ts.Metric.Labels = map[string]string{
+			"memory_type": "evictable",
+		}
+		return ts
+	case core.MetricMemoryWorkingSet.MetricDescriptor.Name:
+		point := sink.intPoint(timestamp, timestamp, value.IntValue)
+		ts := createTimeSeries(resourceLabels, memoryBytesUsedMD, point)
+		ts.Metric.Labels = map[string]string{
+			"memory_type": "non-evictable",
+		}
+		return ts
 	case "memory/minor_page_faults":
 		point := sink.intPoint(timestamp, createTime, value.IntValue)
 		ts := createTimeSeries(resourceLabels, memoryPageFaultsMD, point)

--- a/metrics/sinks/stackdriver/stackdriver_test.go
+++ b/metrics/sinks/stackdriver/stackdriver_test.go
@@ -130,6 +130,36 @@ func TestTranslateMemoryNodeAllocatable(t *testing.T) {
 	as.Equal(int64(2048), value.Int64Value)
 }
 
+func TestTranslateMemoryUsedEvictable(t *testing.T) {
+	metricValue := generateIntMetric(100)
+	name := "memory/bytes_used"
+	timestamp := time.Now()
+	createTime := timestamp.Add(-time.Second)
+
+	ts := sink.TranslateMetric(timestamp, commonLabels, name, metricValue, createTime)
+
+	as := assert.New(t)
+	as.Equal(ts.Metric.Type, "container.googleapis.com/container/memory/bytes_used")
+	as.Equal(len(ts.Points), 1)
+	as.Equal(ts.Points[0].Value.Int64Value, int64(100))
+	as.Equal(ts.Metric.Labels["memory_type"], "evictable")
+}
+
+func TestTranslateMemoryUsedNonEvictable(t *testing.T) {
+	metricValue := generateIntMetric(200)
+	name := core.MetricMemoryWorkingSet.MetricDescriptor.Name
+	timestamp := time.Now()
+	createTime := timestamp.Add(-time.Second)
+
+	ts := sink.TranslateMetric(timestamp, commonLabels, name, metricValue, createTime)
+
+	as := assert.New(t)
+	as.Equal(ts.Metric.Type, "container.googleapis.com/container/memory/bytes_used")
+	as.Equal(len(ts.Points), 1)
+	as.Equal(ts.Points[0].Value.Int64Value, int64(200))
+	as.Equal(ts.Metric.Labels["memory_type"], "non-evictable")
+}
+
 func TestTranslateMemoryMajorPageFaults(t *testing.T) {
 	metricValue := generateIntMetric(20)
 	name := "memory/major_page_faults"
@@ -158,14 +188,6 @@ func TestTranslateMemoryMinorPageFaults(t *testing.T) {
 	as.Equal(len(ts.Points), 1)
 	as.Equal(ts.Points[0].Value.Int64Value, int64(42))
 	as.Equal(ts.Metric.Labels["fault_type"], "minor")
-}
-
-func TestTranslateMemoryBytesUsed(t *testing.T) {
-	as := assert.New(t)
-	value := testTranslateMetric(as, 987, "memory/bytes_used", commonLabels,
-		"container.googleapis.com/container/memory/bytes_used")
-
-	as.Equal(int64(987), value.Int64Value)
 }
 
 // Test TranslateLabeledMetric


### PR DESCRIPTION
Export both evictable and non-evictable metrics.

Patch of 1.4 release. Base on #1822.