### PR TITLE
Adds (fixes) filesystem/available metric

### DIFF
--- a/metrics/core/metrics.go
+++ b/metrics/core/metrics.go
@@ -653,6 +653,26 @@ var MetricFilesystemAvailable = Metric{
 		Units:       UnitsBytes,
 		Labels:      metricLabels,
 	},
+	HasLabeledMetric: func(spec *cadvisor.ContainerSpec) bool {
+		return spec.HasFilesystem
+	},
+	GetLabeledMetric: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) []LabeledMetric {
+		result := make([]LabeledMetric, 0, len(stat.Filesystem))
+		for _, fs := range stat.Filesystem {
+			result = append(result, LabeledMetric{
+				Name: "filesystem/available",
+				Labels: map[string]string{
+					LabelResourceID.Key: fs.Device,
+				},
+				MetricValue: MetricValue{
+					ValueType:  ValueInt64,
+					MetricType: MetricGauge,
+					IntValue:   int64(fs.Available),
+				},
+			})
+		}
+		return result
+	},
 }
 
 var MetricFilesystemInodes = Metric{


### PR DESCRIPTION
**Problem**
metric `filesystem/available` was not showing up on the sink side

**Solution**
Implemented `HasLabeledMetric` and `GetLabeledMetric` by adapting the same methods of the `filesystem/limit` metric

**Testing**
Tested in our monitoring setup and now getting the desired `filesystem/available` metric at our sink