### PR TITLE
Adds scraping iNode metrics in summary api

### DIFF
--- a/metrics/sources/summary/summary.go
+++ b/metrics/sources/summary/summary.go
@@ -298,6 +298,8 @@ func (this *summaryMetricsSource) decodeFsStats(metrics *MetricSet, fsKey string
 	this.addLabeledIntMetric(metrics, &MetricFilesystemUsage, fsLabels, fs.UsedBytes)
 	this.addLabeledIntMetric(metrics, &MetricFilesystemLimit, fsLabels, fs.CapacityBytes)
 	this.addLabeledIntMetric(metrics, &MetricFilesystemAvailable, fsLabels, fs.AvailableBytes)
+	this.addLabeledIntMetric(metrics, &MetricFilesystemInodes, fsLabels, fs.Inodes)
+	this.addLabeledIntMetric(metrics, &MetricFilesystemInodesFree, fsLabels, fs.InodesFree)
 }
 
 func (this *summaryMetricsSource) decodeUserDefinedMetrics(metrics *MetricSet, udm []stats.UserDefinedMetric) {


### PR DESCRIPTION
iNode metrics, specifically `filesystem/inodes` and `filesystem/inodes_free` were not getting scraped in the summary source. Added code to do so. 