### PR TITLE
Update grafana.yaml to mention proxy subresource

### DIFF
--- a/deploy/kube-config/influxdb/grafana.yaml
+++ b/deploy/kube-config/influxdb/grafana.yaml
@@ -40,7 +40,7 @@ spec:
           value: Admin
         - name: GF_SERVER_ROOT_URL
           # If you're only using the API Server proxy, set this value instead:
-          # value: /api/v1/proxy/namespaces/kube-system/services/monitoring-grafana/
+          # value: /api/v1/namespaces/kube-system/services/monitoring-grafana/proxy
           value: /
       volumes:
       - name: ca-certificates


### PR DESCRIPTION
Recent versions of Kubernetes use the proxy subresource (services/proxy), not proxy as a prefix.
This updates the comment on `GF_SERVER_ROOT_URL` to reflect this.