### PR TITLE
Make the sink export data timeout configurable

### DIFF
--- a/metrics/heapster.go
+++ b/metrics/heapster.go
@@ -84,7 +84,7 @@ func main() {
 		glog.Fatalf("Failed to get kubernetes address: %v", err)
 	}
 	sourceManager := createSourceManagerOrDie(opt.Sources)
-	sinkManager, metricSink, historicalSource := createAndInitSinksOrDie(opt.Sinks, opt.HistoricalSource)
+	sinkManager, metricSink, historicalSource := createAndInitSinksOrDie(opt.Sinks, opt.HistoricalSource, opt.SinkExportDataTimeout)
 
 	podLister, nodeLister := getListersOrDie(kubernetesUrl)
 	dataProcessors := createDataProcessorsOrDie(kubernetesUrl, podLister, labelCopier)
@@ -187,7 +187,7 @@ func createSourceManagerOrDie(src flags.Uris) core.MetricsSource {
 	return sourceManager
 }
 
-func createAndInitSinksOrDie(sinkAddresses flags.Uris, historicalSource string) (core.DataSink, *metricsink.MetricSink, core.HistoricalSource) {
+func createAndInitSinksOrDie(sinkAddresses flags.Uris, historicalSource string, sinkExportDataTimeout time.Duration) (core.DataSink, *metricsink.MetricSink, core.HistoricalSource) {
 	sinksFactory := sinks.NewSinkFactory()
 	metricSink, sinkList, histSource := sinksFactory.BuildAll(sinkAddresses, historicalSource)
 	if metricSink == nil {
@@ -199,7 +199,7 @@ func createAndInitSinksOrDie(sinkAddresses flags.Uris, historicalSource string) 
 	for _, sink := range sinkList {
 		glog.Infof("Starting with %s", sink.Name())
 	}
-	sinkManager, err := sinks.NewDataSinkManager(sinkList, sinks.DefaultSinkExportDataTimeout, sinks.DefaultSinkStopTimeout)
+	sinkManager, err := sinks.NewDataSinkManager(sinkList, sinkExportDataTimeout, sinks.DefaultSinkStopTimeout)
 	if err != nil {
 		glog.Fatalf("Failed to create sink manager: %v", err)
 	}

--- a/metrics/options/options.go
+++ b/metrics/options/options.go
@@ -33,23 +33,24 @@ type HeapsterRunOptions struct {
 	// Only to be used to for testing
 	DisableAuthForTesting bool
 
-	MetricResolution    time.Duration
-	EnableAPIServer     bool
-	Port                int
-	Ip                  string
-	MaxProcs            int
-	TLSCertFile         string
-	TLSKeyFile          string
-	TLSClientCAFile     string
-	AllowedUsers        string
-	Sources             flags.Uris
-	Sinks               flags.Uris
-	HistoricalSource    string
-	Version             bool
-	LabelSeparator      string
-	IgnoredLabels       []string
-	StoredLabels        []string
-	DisableMetricExport bool
+	MetricResolution      time.Duration
+	EnableAPIServer       bool
+	Port                  int
+	Ip                    string
+	MaxProcs              int
+	TLSCertFile           string
+	TLSKeyFile            string
+	TLSClientCAFile       string
+	AllowedUsers          string
+	Sources               flags.Uris
+	Sinks                 flags.Uris
+	HistoricalSource      string
+	Version               bool
+	LabelSeparator        string
+	IgnoredLabels         []string
+	StoredLabels          []string
+	DisableMetricExport   bool
+	SinkExportDataTimeout time.Duration
 }
 
 func NewHeapsterRunOptions() *HeapsterRunOptions {
@@ -88,4 +89,5 @@ func (h *HeapsterRunOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringSliceVar(&h.IgnoredLabels, "ignore_label", []string{}, "ignore this label when joining labels")
 	fs.StringSliceVar(&h.StoredLabels, "store_label", []string{}, "store this label separately from joined labels with the same name (name) or with different name (newName=name)")
 	fs.BoolVar(&h.DisableMetricExport, "disable_export", false, "Disable exporting metrics in api/v1/metric-export")
+	fs.DurationVar(&h.SinkExportDataTimeout, "sink_export_data_timeout", 20*time.Second, "Timeout for exporting data to a sink")
 }

--- a/metrics/sinks/manager.go
+++ b/metrics/sinks/manager.go
@@ -24,8 +24,7 @@ import (
 )
 
 const (
-	DefaultSinkExportDataTimeout = 20 * time.Second
-	DefaultSinkStopTimeout       = 60 * time.Second
+	DefaultSinkStopTimeout = 60 * time.Second
 )
 
 var (


### PR DESCRIPTION
The sink export data timeout was set to 20 seconds with no way to
configure it.

Add a flag which lets users specify the value for the sink export data
timeout.