### PR TITLE
Handle IPs as net.IP objects in the way to support IPv6

### DIFF
--- a/metrics/heapster.go
+++ b/metrics/heapster.go
@@ -20,10 +20,12 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -106,7 +108,7 @@ func main() {
 	handler := setupHandlers(metricSink, podLister, nodeLister, historicalSource, opt.DisableMetricExport)
 	healthz.InstallHandler(mux, healthzChecker(metricSink))
 
-	addr := fmt.Sprintf("%s:%d", opt.Ip, opt.Port)
+	addr := net.JoinHostPort(opt.Ip, strconv.Itoa(opt.Port))
 	glog.Infof("Starting heapster on port %d", opt.Port)
 
 	if len(opt.TLSCertFile) > 0 && len(opt.TLSKeyFile) > 0 {

--- a/metrics/sources/kubelet/kubelet_test.go
+++ b/metrics/sources/kubelet/kubelet_test.go
@@ -15,6 +15,7 @@ package kubelet
 
 import (
 	"encoding/json"
+	"net"
 	"net/http/httptest"
 	"strconv"
 	"strings"
@@ -402,10 +403,10 @@ var nodes = []kube_api.Node{
 
 func TestGetNodeHostnameAndIP(t *testing.T) {
 	for _, node := range nodes {
-		hostname, ip, err := getNodeHostnameAndIP(&node)
+		hostname, ip, err := GetNodeHostnameAndIP(&node)
 		assert.NoError(t, err)
 		assert.Equal(t, hostname, "testNode")
-		assert.Equal(t, ip, "127.0.0.1")
+		assert.True(t, ip.Equal(net.ParseIP("127.0.0.1")))
 	}
 }
 
@@ -479,7 +480,7 @@ func TestScrapeMetrics(t *testing.T) {
 	}
 
 	split := strings.SplitN(strings.Replace(server.URL, "http://", "", 1), ":", 2)
-	mtrcSrc.host.IP = split[0]
+	mtrcSrc.host.IP = net.ParseIP(split[0])
 	mtrcSrc.host.Port, err = strconv.Atoi(split[1])
 
 	start := time.Now()

--- a/metrics/sources/summary/summary_test.go
+++ b/metrics/sources/summary/summary_test.go
@@ -16,6 +16,7 @@ package summary
 
 import (
 	"encoding/json"
+	"net"
 	"net/http/httptest"
 	"strconv"
 	"strings"
@@ -527,7 +528,7 @@ func TestScrapeSummaryMetrics(t *testing.T) {
 
 	ms := testingSummaryMetricsSource()
 	split := strings.SplitN(strings.Replace(server.URL, "http://", "", 1), ":", 2)
-	ms.node.IP = split[0]
+	ms.node.IP = net.ParseIP(split[0])
 	ms.node.Port, err = strconv.Atoi(split[1])
 	require.NoError(t, err)
 


### PR DESCRIPTION
This PR tries to solve problems seen in #1852, handling addresses indiferently if the are IPv4 or IPv6. For that it uses `net.IP` type and `net.JoinHostPort` function.
It also makes public the function `kubelet.GetHostnameAndIP` used to obtain hostname and ip of a node so this code can be reused.