### PR TITLE
enlarge default batch points for influxdb to 20k

### DIFF
--- a/metrics/sinks/influxdb/influxdb.go
+++ b/metrics/sinks/influxdb/influxdb.go
@@ -49,7 +49,7 @@ const (
 	dbNotFoundError = "database not found"
 
 	// Maximum number of influxdb Points to be sent in one batch.
-	maxSendBatchSize = 10000
+	maxSendBatchSize = 20000
 )
 
 func (sink *influxdbSink) resetConnection() {


### PR DESCRIPTION
This PR will enlarge default batch points for influxdb from `10000` to `20000`. As for our usage, for 10000 data points, the post body size is almost 1.5MB. When the Kubernetes cluster is large enough, sequential `sendData` invoke will take more roundtrip to send all data points to InfluxDB.

It should be fine to enlarge default batch points for influxdb from `10000` to `20000`, the post body data size will be almost about 3MB which should be ok for InfluxDB to handle this.

/cc @DirectXMan12 @loburm @piosz 