### PR TITLE
Add concurrency support for metrics influxdb sink

### DIFF
--- a/common/influxdb/dummy_influxdb.go
+++ b/common/influxdb/dummy_influxdb.go
@@ -56,9 +56,10 @@ func (client *FakeInfluxDBClient) Ping() (time.Duration, string, error) {
 var Client = NewFakeInfluxDBClient()
 
 var Config = InfluxdbConfig{
-	User:     "root",
-	Password: "root",
-	Host:     "localhost:8086",
-	DbName:   "k8s",
-	Secure:   false,
+	User:        "root",
+	Password:    "root",
+	Host:        "localhost:8086",
+	DbName:      "k8s",
+	Secure:      false,
+	Concurrency: 1,
 }

--- a/docs/sink-configuration.md
+++ b/docs/sink-configuration.md
@@ -37,6 +37,7 @@ The following options are available:
 * `withfields` - Use [InfluxDB fields](storage-schema.md#using-fields) (default: `false`)
 * `cluster_name` - Cluster name for different Kubernetes clusters. (default: `default`)
 * `disable_counter_metrics` - Disable sink counter metrics to InfluxDB. (default: `false`)
+* `concurrency` - concurrency for sinking to InfluxDB. (default: `1`)
 
 ### Stackdriver
 

--- a/metrics/sinks/influxdb/influxdb.go
+++ b/metrics/sinks/influxdb/influxdb.go
@@ -33,6 +33,10 @@ type influxdbSink struct {
 	sync.RWMutex
 	c        influxdb_common.InfluxdbConfig
 	dbExists bool
+
+	// wg and conChan will work together to limit concurrent influxDB sink goroutines.
+	wg      sync.WaitGroup
+	conChan chan struct{}
 }
 
 var influxdbBlacklistLabels = map[string]struct{}{
@@ -112,7 +116,7 @@ func (sink *influxdbSink) ExportData(dataBatch *core.DataBatch) {
 
 			dataPoints = append(dataPoints, point)
 			if len(dataPoints) >= maxSendBatchSize {
-				sink.sendData(dataPoints)
+				sink.concurrentSendData(dataPoints)
 				dataPoints = make([]influxdb.Point, 0, 0)
 			}
 		}
@@ -172,17 +176,34 @@ func (sink *influxdbSink) ExportData(dataBatch *core.DataBatch) {
 
 			dataPoints = append(dataPoints, point)
 			if len(dataPoints) >= maxSendBatchSize {
-				sink.sendData(dataPoints)
+				sink.concurrentSendData(dataPoints)
 				dataPoints = make([]influxdb.Point, 0, 0)
 			}
 		}
 	}
 	if len(dataPoints) >= 0 {
-		sink.sendData(dataPoints)
+		sink.concurrentSendData(dataPoints)
 	}
+
+	sink.wg.Wait()
+}
+
+func (sink *influxdbSink) concurrentSendData(dataPoints []influxdb.Point) {
+	sink.wg.Add(1)
+	// use the channel to block until there's less than the maximum number of concurrent requests running
+	sink.conChan <- struct{}{}
+	go func(dataPoints []influxdb.Point) {
+		sink.sendData(dataPoints)
+	}(dataPoints)
 }
 
 func (sink *influxdbSink) sendData(dataPoints []influxdb.Point) {
+	defer func() {
+		// empty an item from the channel so the next waiting request can run
+		<-sink.conChan
+		sink.wg.Done()
+	}()
+
 	if err := sink.createDatabase(); err != nil {
 		glog.Errorf("Failed to create influxdb: %v", err)
 		return
@@ -276,8 +297,9 @@ func new(c influxdb_common.InfluxdbConfig) core.DataSink {
 		glog.Errorf("issues while creating an InfluxDB sink: %v, will retry on use", err)
 	}
 	return &influxdbSink{
-		client: client, // can be nil
-		c:      c,
+		client:  client, // can be nil
+		c:       c,
+		conChan: make(chan struct{}, c.Concurrency),
 	}
 }
 

--- a/metrics/sinks/influxdb/influxdb_test.go
+++ b/metrics/sinks/influxdb/influxdb_test.go
@@ -37,8 +37,9 @@ type fakeInfluxDBDataSink struct {
 
 func newRawInfluxSink() *influxdbSink {
 	return &influxdbSink{
-		client: influxdb_common.Client,
-		c:      influxdb_common.Config,
+		client:  influxdb_common.Client,
+		c:       influxdb_common.Config,
+		conChan: make(chan struct{}, influxdb_common.Config.Concurrency),
 	}
 }
 


### PR DESCRIPTION
This PR will add concurrency support for metrics influxdb sink. The main reason for adding this support is when Kubernetes cluster becomes larger, more and more data points needs to be pushed into influxdb in limited `--metric-resolution`. Sequential invoke of `sendData` is not acceptable when data is more and more large.

/cc @DirectXMan12 @loburm @piosz 