### PR TITLE
bump cadvisor dep to support disk io device name

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -201,8 +201,8 @@
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/info/v1",
-			"Comment": "v0.25.0-182-gc99f241",
-			"Rev": "c99f2418fa7bbc6fc54159fa50f0043f882e9e7c"
+			"Comment": "v0.28.0-14-g5231853",
+			"Rev": "5231853e7124d03b32678c7d2b0f4651dfa6110c"
 		},
 		{
 			"ImportPath": "github.com/google/gofuzz",

--- a/vendor/github.com/google/cadvisor/info/v1/container.go
+++ b/vendor/github.com/google/cadvisor/info/v1/container.go
@@ -307,7 +307,7 @@ type CpuStats struct {
 }
 
 type PerDiskStats struct {
-	Device string            `json:"-"`
+	Device string            `json:"device"`
 	Major  uint64            `json:"major"`
 	Minor  uint64            `json:"minor"`
 	Stats  map[string]uint64 `json:"stats"`


### PR DESCRIPTION
This PR will update cAdvisor dep to support device name for disk io metrics. This is related to #1450.

/cc @DirectXMan12 @piosz @loburm @dashpole