### PR TITLE
remove original counter metrics for influxdb

### DIFF
--- a/common/influxdb/influxdb.go
+++ b/common/influxdb/influxdb.go
@@ -32,15 +32,16 @@ type InfluxdbClient interface {
 }
 
 type InfluxdbConfig struct {
-	User            string
-	Password        string
-	Secure          bool
-	Host            string
-	DbName          string
-	WithFields      bool
-	InsecureSsl     bool
-	RetentionPolicy string
-	ClusterName     string
+	User                  string
+	Password              string
+	Secure                bool
+	Host                  string
+	DbName                string
+	WithFields            bool
+	InsecureSsl           bool
+	RetentionPolicy       string
+	ClusterName           string
+	DisableCounterMetrics bool
 }
 
 func NewClient(c InfluxdbConfig) (InfluxdbClient, error) {
@@ -72,15 +73,16 @@ func NewClient(c InfluxdbConfig) (InfluxdbClient, error) {
 
 func BuildConfig(uri *url.URL) (*InfluxdbConfig, error) {
 	config := InfluxdbConfig{
-		User:            "root",
-		Password:        "root",
-		Host:            "localhost:8086",
-		DbName:          "k8s",
-		Secure:          false,
-		WithFields:      false,
-		InsecureSsl:     false,
-		RetentionPolicy: "0",
-		ClusterName:     "default",
+		User:                  "root",
+		Password:              "root",
+		Host:                  "localhost:8086",
+		DbName:                "k8s",
+		Secure:                false,
+		WithFields:            false,
+		InsecureSsl:           false,
+		RetentionPolicy:       "0",
+		ClusterName:           "default",
+		DisableCounterMetrics: false,
 	}
 
 	if len(uri.Host) > 0 {
@@ -125,6 +127,14 @@ func BuildConfig(uri *url.URL) (*InfluxdbConfig, error) {
 
 	if len(opts["cluster_name"]) >= 1 {
 		config.ClusterName = opts["cluster_name"][0]
+	}
+
+	if len(opts["disable_counter_metrics"]) >= 1 {
+		val, err := strconv.ParseBool(opts["disable_counter_metrics"][0])
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse `disable_counter_metrics` flag - %v", err)
+		}
+		config.DisableCounterMetrics = val
 	}
 
 	return &config, nil

--- a/docs/sink-configuration.md
+++ b/docs/sink-configuration.md
@@ -35,7 +35,8 @@ The following options are available:
 * `secure` - Connect securely to InfluxDB (default: `false`)
 * `insecuressl` - Ignore SSL certificate validity (default: `false`)
 * `withfields` - Use [InfluxDB fields](storage-schema.md#using-fields) (default: `false`)
-* `cluster_name` - cluster name for different Kubernetes clusters. (default: `default`)
+* `cluster_name` - Cluster name for different Kubernetes clusters. (default: `default`)
+* `disable_counter_metrics` - Disable sink counter metrics to InfluxDB. (default: `false`)
 
 ### Stackdriver
 

--- a/metrics/sinks/influxdb/influxdb.go
+++ b/metrics/sinks/influxdb/influxdb.go
@@ -65,6 +65,11 @@ func (sink *influxdbSink) ExportData(dataBatch *core.DataBatch) {
 	dataPoints := make([]influxdb.Point, 0, 0)
 	for _, metricSet := range dataBatch.MetricSets {
 		for metricName, metricValue := range metricSet.MetricValues {
+			if sink.c.DisableCounterMetrics {
+				if _, exists := core.RateMetricsMapping[metricName]; exists {
+					continue
+				}
+			}
 
 			var value interface{}
 			if core.ValueInt64 == metricValue.ValueType {
@@ -113,6 +118,11 @@ func (sink *influxdbSink) ExportData(dataBatch *core.DataBatch) {
 		}
 
 		for _, labeledMetric := range metricSet.LabeledMetrics {
+			if sink.c.DisableCounterMetrics {
+				if _, exists := core.RateMetricsMapping[labeledMetric.Name]; exists {
+					continue
+				}
+			}
 
 			var value interface{}
 			if core.ValueInt64 == labeledMetric.ValueType {


### PR DESCRIPTION
Fix #1880 .

This PR addresses #1880 by adding a new influxdb uri param `disable_counter_metrics` to control whether removing original counter metrics or not described in #1880 for influxdb. This is quite useful when cluster becomes larger. Less stress will be pushed to InfluxDB.

/cc @DirectXMan12 @loburm @piosz 