### PR TITLE
add gpu metrics

### DIFF
--- a/docs/storage-schema.md
+++ b/docs/storage-schema.md
@@ -31,6 +31,9 @@ Heapster exports the following metrics to its backends.
 | memory/cache | Cache memory usage. |
 | memory/rss | RSS memory usage. |
 | memory/working_set | Total working set usage. Working set is the memory being used and not easily dropped by the kernel. |
+| accelerator/memory_total | Memory capacity of an accelerator. |
+| accelerator/memory_used | Memory used of an accelerator. |
+| accelerator/duty_cycle | Duty cycle of an accelerator. |
 | network/rx | Cumulative number of bytes received over the network. |
 | network/rx_errors | Cumulative number of errors while receiving over the network. |
 | network/rx_errors_rate | Number of errors while receiving over the network per second. |
@@ -60,6 +63,9 @@ Heapster tags each metric with the following labels.
 | namespace_id   | UID of the namespace of a Pod                                                 |
 | namespace_name | User-provided name of a Namespace                                             |
 | resource_id    | A unique identifier used to differentiate multiple metrics of the same type. e.x. Fs partitions under filesystem/usage |
+| make  | Make of the accelerator (nvidia, amd, google etc.) |
+| model | Model of the accelerator (tesla-p100, tesla-k80 etc.) |
+| accelerator_id    | ID of the accelerator |
 
 **Note**
   * Label separator can be configured with Heapster `--label-separator`. Comma-seperated label pairs is fine until we use [Bosun](http://bosun.org) as alert system and use `group by labels` to search for labels.

--- a/integration/heapster_api_test.go
+++ b/integration/heapster_api_test.go
@@ -356,7 +356,10 @@ func runMetricExportTest(fm kubeFramework, svc *kube_v1.Service) error {
 			core.MetricFilesystemLimit.MetricDescriptor.Name: {core.LabelResourceID.Key},
 			core.MetricFilesystemAvailable.Name:              {core.LabelResourceID.Key},
 			core.MetricFilesystemInodes.Name:                 {core.LabelResourceID.Key},
-			core.MetricFilesystemInodesFree.Name:             {core.LabelResourceID.Key}}
+			core.MetricFilesystemInodesFree.Name:             {core.LabelResourceID.Key},
+			core.MetricAcceleratorMemoryTotal.Name:           {core.LabelAcceleratorMake.Key, core.LabelAcceleratorModel.Key, core.LabelAcceleratorID.Key},
+			core.MetricAcceleratorMemoryUsed.Name:            {core.LabelAcceleratorMake.Key, core.LabelAcceleratorModel.Key, core.LabelAcceleratorID.Key},
+			core.MetricAcceleratorDutyCycle.Name:             {core.LabelAcceleratorMake.Key, core.LabelAcceleratorModel.Key, core.LabelAcceleratorID.Key}}
 
 		for metricName, points := range ts.Metrics {
 			md, exists := mdMap[metricName]

--- a/metrics/core/metrics.go
+++ b/metrics/core/metrics.go
@@ -71,6 +71,9 @@ var LabeledMetrics = []Metric{
 	MetricFilesystemAvailable,
 	MetricFilesystemInodes,
 	MetricFilesystemInodesFree,
+	MetricAcceleratorMemoryTotal,
+	MetricAcceleratorMemoryUsed,
+	MetricAcceleratorDutyCycle,
 }
 
 var NodeAutoscalingMetrics = []Metric{
@@ -601,7 +604,7 @@ var MetricFilesystemUsage = Metric{
 		Units:       UnitsBytes,
 		Labels:      metricLabels,
 	},
-	HasLabeledMetric: func(spec *cadvisor.ContainerSpec) bool {
+	HasLabeledMetric: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) bool {
 		return spec.HasFilesystem
 	},
 	GetLabeledMetric: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) []LabeledMetric {
@@ -632,7 +635,7 @@ var MetricFilesystemLimit = Metric{
 		Units:       UnitsBytes,
 		Labels:      metricLabels,
 	},
-	HasLabeledMetric: func(spec *cadvisor.ContainerSpec) bool {
+	HasLabeledMetric: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) bool {
 		return spec.HasFilesystem
 	},
 	GetLabeledMetric: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) []LabeledMetric {
@@ -663,7 +666,7 @@ var MetricFilesystemAvailable = Metric{
 		Units:       UnitsBytes,
 		Labels:      metricLabels,
 	},
-	HasLabeledMetric: func(spec *cadvisor.ContainerSpec) bool {
+	HasLabeledMetric: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) bool {
 		return spec.HasFilesystem
 	},
 	GetLabeledMetric: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) []LabeledMetric {
@@ -694,7 +697,7 @@ var MetricFilesystemInodes = Metric{
 		Units:       UnitsBytes,
 		Labels:      metricLabels,
 	},
-	HasLabeledMetric: func(spec *cadvisor.ContainerSpec) bool {
+	HasLabeledMetric: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) bool {
 		return spec.HasFilesystem
 	},
 	GetLabeledMetric: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) []LabeledMetric {
@@ -727,7 +730,7 @@ var MetricFilesystemInodesFree = Metric{
 		Units:       UnitsBytes,
 		Labels:      metricLabels,
 	},
-	HasLabeledMetric: func(spec *cadvisor.ContainerSpec) bool {
+	HasLabeledMetric: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) bool {
 		return spec.HasFilesystem
 	},
 	GetLabeledMetric: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) []LabeledMetric {
@@ -760,6 +763,32 @@ var MetricAcceleratorMemoryTotal = Metric{
 		ValueType:   ValueInt64,
 		Units:       UnitsBytes,
 	},
+	HasLabeledMetric: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) bool {
+		if len(stat.Accelerators) == 0 {
+			return false
+		}
+
+		return true
+	},
+	GetLabeledMetric: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) []LabeledMetric {
+		result := make([]LabeledMetric, 0, len(stat.Accelerators))
+		for _, ac := range stat.Accelerators {
+			result = append(result, LabeledMetric{
+				Name: "accelerator/memory_total",
+				Labels: map[string]string{
+					LabelAcceleratorMake.Key:  ac.Make,
+					LabelAcceleratorModel.Key: ac.Model,
+					LabelAcceleratorID.Key:    ac.ID,
+				},
+				MetricValue: MetricValue{
+					ValueType:  ValueInt64,
+					MetricType: MetricGauge,
+					IntValue:   int64(ac.MemoryTotal),
+				},
+			})
+		}
+		return result
+	},
 }
 
 var MetricAcceleratorMemoryUsed = Metric{
@@ -771,6 +800,32 @@ var MetricAcceleratorMemoryUsed = Metric{
 		ValueType:   ValueInt64,
 		Units:       UnitsBytes,
 	},
+	HasLabeledMetric: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) bool {
+		if len(stat.Accelerators) == 0 {
+			return false
+		}
+
+		return true
+	},
+	GetLabeledMetric: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) []LabeledMetric {
+		result := make([]LabeledMetric, 0, len(stat.Accelerators))
+		for _, ac := range stat.Accelerators {
+			result = append(result, LabeledMetric{
+				Name: "accelerator/memory_used",
+				Labels: map[string]string{
+					LabelAcceleratorMake.Key:  ac.Make,
+					LabelAcceleratorModel.Key: ac.Model,
+					LabelAcceleratorID.Key:    ac.ID,
+				},
+				MetricValue: MetricValue{
+					ValueType:  ValueInt64,
+					MetricType: MetricGauge,
+					IntValue:   int64(ac.MemoryUsed),
+				},
+			})
+		}
+		return result
+	},
 }
 
 var MetricAcceleratorDutyCycle = Metric{
@@ -781,6 +836,32 @@ var MetricAcceleratorDutyCycle = Metric{
 		Type:        MetricGauge,
 		ValueType:   ValueInt64,
 		Units:       UnitsCount,
+	},
+	HasLabeledMetric: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) bool {
+		if len(stat.Accelerators) == 0 {
+			return false
+		}
+
+		return true
+	},
+	GetLabeledMetric: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) []LabeledMetric {
+		result := make([]LabeledMetric, 0, len(stat.Accelerators))
+		for _, ac := range stat.Accelerators {
+			result = append(result, LabeledMetric{
+				Name: "accelerator/duty_cycle",
+				Labels: map[string]string{
+					LabelAcceleratorMake.Key:  ac.Make,
+					LabelAcceleratorModel.Key: ac.Model,
+					LabelAcceleratorID.Key:    ac.ID,
+				},
+				MetricValue: MetricValue{
+					ValueType:  ValueInt64,
+					MetricType: MetricGauge,
+					IntValue:   int64(ac.DutyCycle),
+				},
+			})
+		}
+		return result
 	},
 }
 
@@ -820,7 +901,7 @@ type Metric struct {
 	GetValue func(*cadvisor.ContainerSpec, *cadvisor.ContainerStats) MetricValue
 
 	// Returns whether this metric is present.
-	HasLabeledMetric func(*cadvisor.ContainerSpec) bool
+	HasLabeledMetric func(*cadvisor.ContainerSpec, *cadvisor.ContainerStats) bool
 
 	// Returns a slice of internal point objects that contain metric values and associated labels.
 	GetLabeledMetric func(*cadvisor.ContainerSpec, *cadvisor.ContainerStats) []LabeledMetric

--- a/metrics/sources/kubelet/kubelet.go
+++ b/metrics/sources/kubelet/kubelet.go
@@ -181,7 +181,7 @@ func (this *kubeletMetricsSource) decodeMetrics(c *cadvisor.ContainerInfo) (stri
 	}
 
 	for _, metric := range LabeledMetrics {
-		if metric.HasLabeledMetric != nil && metric.HasLabeledMetric(&c.Spec) {
+		if metric.HasLabeledMetric != nil && metric.HasLabeledMetric(&c.Spec, c.Stats[0]) {
 			labeledMetrics := metric.GetLabeledMetric(&c.Spec, c.Stats[0])
 			cMetrics.LabeledMetrics = append(cMetrics.LabeledMetrics, labeledMetrics...)
 		}


### PR DESCRIPTION
This PR partially fix PR #1872  .

This PR adds support for scrape GPU related metrics when using normal cAdvisor endpoint instead of kubelet summary api. 

* `accelerator/memory_total`
* `accelerator/memory_used`
* `accelerator/duty_cycle`

are added as new accelerator metrics.

/cc @DirectXMan12 @loburm @piosz @mindprince #