### PR TITLE
Fix few bugs in Heapster exporting metrics for new Stackdriver resource model

### DIFF
--- a/metrics/core/labels.go
+++ b/metrics/core/labels.go
@@ -89,6 +89,10 @@ var (
 		Key:         "schedulable",
 		Description: "Node schedulable status.",
 	}
+	LabelVolumeName = LabelDescriptor{
+		Key:         "volume_name",
+		Description: "The name of the volume.",
+	}
 )
 
 type LabelDescriptor struct {

--- a/metrics/core/metrics.go
+++ b/metrics/core/metrics.go
@@ -685,28 +685,6 @@ var MetricFilesystemAvailable = Metric{
 	},
 }
 
-var MetricVolumeTotal = Metric{
-	MetricDescriptor: MetricDescriptor{
-		Name:        "volume/total_bytes",
-		Description: "Total bytes reserved for a volume",
-		Type:        MetricGauge,
-		ValueType:   ValueInt64,
-		Units:       UnitsBytes,
-		Labels:      metricLabels,
-	},
-}
-
-var MetricVolumeUsage = Metric{
-	MetricDescriptor: MetricDescriptor{
-		Name:        "volume/used_bytes",
-		Description: "Usage bytes reserved for a volume",
-		Type:        MetricGauge,
-		ValueType:   ValueInt64,
-		Units:       UnitsBytes,
-		Labels:      metricLabels,
-	},
-}
-
 var MetricFilesystemInodes = Metric{
 	MetricDescriptor: MetricDescriptor{
 		Name:        "filesystem/inodes",

--- a/metrics/sinks/stackdriver/metadata.go
+++ b/metrics/sinks/stackdriver/metadata.go
@@ -34,7 +34,7 @@ var (
 	cpuRequestedCoresMD = &metricMetadata{
 		MetricKind: "GAUGE",
 		ValueType:  "DOUBLE",
-		Name:       "kubernetes.io/container/cpu/requested_cores",
+		Name:       "kubernetes.io/container/cpu/request_cores",
 	}
 
 	cpuLimitCoresMD = &metricMetadata{
@@ -52,7 +52,7 @@ var (
 	memoryRequestedBytesMD = &metricMetadata{
 		MetricKind: "GAUGE",
 		ValueType:  "INT64",
-		Name:       "kubernetes.io/container/memory/requested_bytes",
+		Name:       "kubernetes.io/container/memory/request_bytes",
 	}
 
 	memoryLimitBytesMD = &metricMetadata{
@@ -75,22 +75,22 @@ var (
 		Name:       "kubernetes.io/pod/volume/used_bytes",
 	}
 
-	volumeRequestedBytesMD = &metricMetadata{
+	volumeTotalBytesMD = &metricMetadata{
 		MetricKind: "GAUGE",
 		ValueType:  "INT64",
-		Name:       "kubernetes.io/pod/volume/requested_bytes",
+		Name:       "kubernetes.io/pod/volume/total_bytes",
 	}
 
-	networkPodRxMD = &metricMetadata{
+	networkPodReceivedBytesMD = &metricMetadata{
 		MetricKind: "CUMULATIVE",
 		ValueType:  "INT64",
-		Name:       "kubernetes.io/pod/network/bytes_rx",
+		Name:       "kubernetes.io/pod/network/received_bytes_count",
 	}
 
-	networkPodTxMD = &metricMetadata{
+	networkPodSentBytesMD = &metricMetadata{
 		MetricKind: "CUMULATIVE",
 		ValueType:  "INT64",
-		Name:       "kubernetes.io/pod/network/bytes_tx",
+		Name:       "kubernetes.io/pod/network/sent_bytes_count",
 	}
 
 	// Node metrics
@@ -131,16 +131,16 @@ var (
 		Name:       "kubernetes.io/node/memory/allocatable_bytes",
 	}
 
-	networkNodeRxMD = &metricMetadata{
+	networkNodeReceivedBytesMD = &metricMetadata{
 		MetricKind: "CUMULATIVE",
 		ValueType:  "INT64",
-		Name:       "kubernetes.io/node/network/bytes_rx",
+		Name:       "kubernetes.io/node/network/received_bytes_count",
 	}
 
-	networkNodeTxMD = &metricMetadata{
+	networkNodeSentBytesMD = &metricMetadata{
 		MetricKind: "CUMULATIVE",
 		ValueType:  "INT64",
-		Name:       "kubernetes.io/node/network/bytes_tx",
+		Name:       "kubernetes.io/node/network/sent_bytes_count",
 	}
 
 	cpuNodeDaemonCoreUsageTimeMD = &metricMetadata{

--- a/metrics/sinks/stackdriver/stackdriver_test.go
+++ b/metrics/sinks/stackdriver/stackdriver_test.go
@@ -37,7 +37,7 @@ var (
 	containerLabels  = map[string]string{"type": "pod_container"}
 	podLabels        = map[string]string{"type": "pod"}
 	nodeLabels       = map[string]string{"type": "node"}
-	nodeDaemonLabels = map[string]string{"type": "sys_container"}
+	nodeDaemonLabels = map[string]string{"type": "sys_container", "container_name": "kubelet"}
 )
 
 func generateIntMetric(value int64) core.MetricValue {
@@ -291,24 +291,24 @@ func TestTranslateMetricSet(t *testing.T) {
 
 	containerUptime := testTranslateMetric(as, generateIntMetric(1000), containerLabels, "uptime", "kubernetes.io/container/uptime")
 	containerCpuUsage := testTranslateMetric(as, generateIntMetric(2000000000), containerLabels, "cpu/usage", "kubernetes.io/container/cpu/core_usage_time")
-	containerCpuRequest := testTranslateMetric(as, generateIntMetric(3000), containerLabels, "cpu/request", "kubernetes.io/container/cpu/requested_cores")
+	containerCpuRequest := testTranslateMetric(as, generateIntMetric(3000), containerLabels, "cpu/request", "kubernetes.io/container/cpu/request_cores")
 	containerCpuLimit := testTranslateMetric(as, generateIntMetric(4000), containerLabels, "cpu/limit", "kubernetes.io/container/cpu/limit_cores")
 	containerMemoryUsage := testTranslateMetric(as, generateIntMetric(5), containerLabels, "memory/bytes_used", "kubernetes.io/container/memory/used_bytes")
-	containerMemoryRequest := testTranslateMetric(as, generateIntMetric(6), containerLabels, "memory/request", "kubernetes.io/container/memory/requested_bytes")
+	containerMemoryRequest := testTranslateMetric(as, generateIntMetric(6), containerLabels, "memory/request", "kubernetes.io/container/memory/request_bytes")
 	containerMemoryLimit := testTranslateMetric(as, generateIntMetric(7), containerLabels, "memory/limit", "kubernetes.io/container/memory/limit_bytes")
 	containerRestartCount := testTranslateMetric(as, generateIntMetric(8), containerLabels, "restart_count", "kubernetes.io/container/restart_count")
-	podNetworkBytesRx := testTranslateMetric(as, generateIntMetric(9), podLabels, "network/rx", "kubernetes.io/pod/network/bytes_rx")
-	podNetworkBytesTx := testTranslateMetric(as, generateIntMetric(10), podLabels, "network/tx", "kubernetes.io/pod/network/bytes_tx")
-	podVolumeTotal := testTranslateLabeledMetric(as, podLabels, generateLabeledIntMetric(11, map[string]string{}, "volume/total_bytes"), "kubernetes.io/pod/volume/requested_bytes")
-	podVolumeUsed := testTranslateLabeledMetric(as, podLabels, generateLabeledIntMetric(12, map[string]string{}, "volume/used_bytes"), "kubernetes.io/pod/volume/used_bytes")
+	podNetworkBytesRx := testTranslateMetric(as, generateIntMetric(9), podLabels, "network/rx", "kubernetes.io/pod/network/received_bytes_count")
+	podNetworkBytesTx := testTranslateMetric(as, generateIntMetric(10), podLabels, "network/tx", "kubernetes.io/pod/network/sent_bytes_count")
+	podVolumeTotal := testTranslateLabeledMetric(as, podLabels, generateLabeledIntMetric(11, map[string]string{}, "filesystem/limit"), "kubernetes.io/pod/volume/total_bytes")
+	podVolumeUsed := testTranslateLabeledMetric(as, podLabels, generateLabeledIntMetric(12, map[string]string{}, "filesystem/usage"), "kubernetes.io/pod/volume/used_bytes")
 	nodeCpuUsage := testTranslateMetric(as, generateIntMetric(13000000000), nodeLabels, "cpu/usage", "kubernetes.io/node/cpu/core_usage_time")
 	nodeCpuTotal := testTranslateMetric(as, generateFloatMetric(14), nodeLabels, "cpu/node_capacity", "kubernetes.io/node/cpu/total_cores")
 	nodeCpuAllocatable := testTranslateMetric(as, generateFloatMetric(15), nodeLabels, "cpu/node_allocatable", "kubernetes.io/node/cpu/allocatable_cores")
 	nodeMemoryUsage := testTranslateMetric(as, generateIntMetric(16), nodeLabels, "memory/bytes_used", "kubernetes.io/node/memory/used_bytes")
 	nodeMemoryTotal := testTranslateMetric(as, generateIntMetric(17), nodeLabels, "memory/node_capacity", "kubernetes.io/node/memory/total_bytes")
 	nodeMemoryAllocatable := testTranslateMetric(as, generateIntMetric(18), nodeLabels, "memory/node_allocatable", "kubernetes.io/node/memory/allocatable_bytes")
-	nodeNetworkBytesRx := testTranslateMetric(as, generateIntMetric(19), nodeLabels, "network/rx", "kubernetes.io/node/network/bytes_rx")
-	nodeNetworkBytesTx := testTranslateMetric(as, generateIntMetric(20), nodeLabels, "network/tx", "kubernetes.io/node/network/bytes_tx")
+	nodeNetworkBytesRx := testTranslateMetric(as, generateIntMetric(19), nodeLabels, "network/rx", "kubernetes.io/node/network/received_bytes_count")
+	nodeNetworkBytesTx := testTranslateMetric(as, generateIntMetric(20), nodeLabels, "network/tx", "kubernetes.io/node/network/sent_bytes_count")
 	nodeDaemonCpuUsage := testTranslateMetric(as, generateIntMetric(21000000000), nodeDaemonLabels, "cpu/usage", "kubernetes.io/node_daemon/cpu/core_usage_time")
 	nodeDaemonMemoryUsage := testTranslateMetric(as, generateIntMetric(22), nodeDaemonLabels, "memory/bytes_used", "kubernetes.io/node_daemon/memory/used_bytes")
 


### PR DESCRIPTION
Changes in this PR:
- Corrected names for several metrics
- Corrected label set for volume and node daemon metrics
- Metrics for volume computed from existing filesystem metrics retrieved by summary API