### PR TITLE
add disable_metric_sink command line argument

### DIFF
--- a/metrics/heapster.go
+++ b/metrics/heapster.go
@@ -86,7 +86,7 @@ func main() {
 		glog.Fatalf("Failed to get kubernetes address: %v", err)
 	}
 	sourceManager := createSourceManagerOrDie(opt.Sources)
-	sinkManager, metricSink, historicalSource := createAndInitSinksOrDie(opt.Sinks, opt.HistoricalSource, opt.SinkExportDataTimeout)
+	sinkManager, metricSink, historicalSource := createAndInitSinksOrDie(opt.Sinks, opt.HistoricalSource, opt.SinkExportDataTimeout, opt.DisableMetricSink)
 
 	podLister, nodeLister := getListersOrDie(kubernetesUrl)
 	dataProcessors := createDataProcessorsOrDie(kubernetesUrl, podLister, labelCopier)
@@ -189,10 +189,10 @@ func createSourceManagerOrDie(src flags.Uris) core.MetricsSource {
 	return sourceManager
 }
 
-func createAndInitSinksOrDie(sinkAddresses flags.Uris, historicalSource string, sinkExportDataTimeout time.Duration) (core.DataSink, *metricsink.MetricSink, core.HistoricalSource) {
+func createAndInitSinksOrDie(sinkAddresses flags.Uris, historicalSource string, sinkExportDataTimeout time.Duration, disableMetricSink bool) (core.DataSink, *metricsink.MetricSink, core.HistoricalSource) {
 	sinksFactory := sinks.NewSinkFactory()
-	metricSink, sinkList, histSource := sinksFactory.BuildAll(sinkAddresses, historicalSource)
-	if metricSink == nil {
+	metricSink, sinkList, histSource := sinksFactory.BuildAll(sinkAddresses, historicalSource, disableMetricSink)
+	if metricSink == nil && !disableMetricSink {
 		glog.Fatal("Failed to create metric sink")
 	}
 	if histSource == nil && len(historicalSource) > 0 {

--- a/metrics/options/options.go
+++ b/metrics/options/options.go
@@ -51,6 +51,7 @@ type HeapsterRunOptions struct {
 	StoredLabels          []string
 	DisableMetricExport   bool
 	SinkExportDataTimeout time.Duration
+	DisableMetricSink     bool
 }
 
 func NewHeapsterRunOptions() *HeapsterRunOptions {
@@ -90,4 +91,5 @@ func (h *HeapsterRunOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringSliceVar(&h.StoredLabels, "store_label", []string{}, "store this label separately from joined labels with the same name (name) or with different name (newName=name)")
 	fs.BoolVar(&h.DisableMetricExport, "disable_export", false, "Disable exporting metrics in api/v1/metric-export")
 	fs.DurationVar(&h.SinkExportDataTimeout, "sink_export_data_timeout", 20*time.Second, "Timeout for exporting data to a sink")
+	fs.BoolVar(&h.DisableMetricSink, "disable_metric_sink", false, "Disable metric sink")
 }

--- a/metrics/sinks/factory.go
+++ b/metrics/sinks/factory.go
@@ -77,7 +77,7 @@ func (this *SinkFactory) Build(uri flags.Uri) (core.DataSink, error) {
 	}
 }
 
-func (this *SinkFactory) BuildAll(uris flags.Uris, historicalUri string) (*metricsink.MetricSink, []core.DataSink, core.HistoricalSource) {
+func (this *SinkFactory) BuildAll(uris flags.Uris, historicalUri string, disableMetricSink bool) (*metricsink.MetricSink, []core.DataSink, core.HistoricalSource) {
 	result := make([]core.DataSink, 0, len(uris))
 	var metric *metricsink.MetricSink
 	var historical core.HistoricalSource
@@ -104,7 +104,7 @@ func (this *SinkFactory) BuildAll(uris flags.Uris, historicalUri string) (*metri
 		glog.Fatal("No available sink to use")
 	}
 
-	if metric == nil {
+	if metric == nil && !disableMetricSink {
 		uri := flags.Uri{}
 		uri.Set("metric")
 		sink, err := this.Build(uri)


### PR DESCRIPTION
This PR will add `disable-metric-sink` command line argument to heapster. 

As for now if we deploy heapster in standalone we do not need the history metrics for HPA. So, i think we should add an command option to disable sink metric which is consuming many memory when the cluster is large.

/cc @DirectXMan12 @piosz @loburm 