### PR TITLE
fix remove blacklist labels for influxdb

### DIFF
--- a/metrics/sinks/influxdb/influxdb.go
+++ b/metrics/sinks/influxdb/influxdb.go
@@ -145,8 +145,10 @@ func (sink *influxdbSink) ExportData(dataBatch *core.DataBatch) {
 			}
 
 			for key, value := range metricSet.Labels {
-				if value != "" {
-					point.Tags[key] = value
+				if _, exists := influxdbBlacklistLabels[key]; !exists {
+					if value != "" {
+						point.Tags[key] = value
+					}
 				}
 			}
 			for key, value := range labeledMetric.Labels {


### PR DESCRIPTION
This PR will fix removing of blacklist labels for labeled metrics for InfluxDB. Currently, we do not remove blacklist labels for all labels of a labeled metric.

/cc @DirectXMan12 @piosz @loburm 