### PR TITLE
Display graphite connection errors

### DIFF
--- a/metrics/sinks/graphite/driver.go
+++ b/metrics/sinks/graphite/driver.go
@@ -191,6 +191,7 @@ func (s *Sink) ExportData(dataBatch *core.DataBatch) {
 	}
 	glog.V(8).Infof("Sending %d events to graphite", len(metrics))
 	if err := s.client.SendMetrics(metrics); err != nil {
+		glog.V(4).Error("Graphite connection error:", err)
 		glog.V(2).Info("There were errors sending events to Graphite, reconecting")
 		s.client.Disconnect()
 		s.client.Connect()

--- a/metrics/sinks/graphite/driver.go
+++ b/metrics/sinks/graphite/driver.go
@@ -191,7 +191,7 @@ func (s *Sink) ExportData(dataBatch *core.DataBatch) {
 	}
 	glog.V(8).Infof("Sending %d events to graphite", len(metrics))
 	if err := s.client.SendMetrics(metrics); err != nil {
-		glog.V(4).Error("Graphite connection error:", err)
+		glog.V(4).Info("Graphite connection error:", err)
 		glog.V(2).Info("There were errors sending events to Graphite, reconecting")
 		s.client.Disconnect()
 		s.client.Connect()


### PR DESCRIPTION
I hit a graphite connection error today, but was unable to see the error in the logs.  This will display graphite sink connection logs.