### PR TITLE
Add pod-level metrics into heapster

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -195,12 +195,12 @@
 		},
 		{
 			"ImportPath": "github.com/gogo/protobuf/proto",
-			"Comment": "v0.2-33-ge18d7aa",
+			"Comment": "v0.2-33-ge18d7aa8",
 			"Rev": "e18d7aa8f8c624c915db340349aad4c49b10d173"
 		},
 		{
 			"ImportPath": "github.com/gogo/protobuf/sortkeys",
-			"Comment": "v0.2-33-ge18d7aa",
+			"Comment": "v0.2-33-ge18d7aa8",
 			"Rev": "e18d7aa8f8c624c915db340349aad4c49b10d173"
 		},
 		{
@@ -249,7 +249,7 @@
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/info/v1",
-			"Comment": "v0.28.0-14-g5231853",
+			"Comment": "v0.28.0-14-g5231853e",
 			"Rev": "5231853e7124d03b32678c7d2b0f4651dfa6110c"
 		},
 		{
@@ -1196,387 +1196,387 @@
 		},
 		{
 			"ImportPath": "k8s.io/client-go/discovery",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/apps/v1beta1",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/authentication/v1",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/authentication/v1beta1",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/authorization/v1",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/authorization/v1beta1",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/autoscaling/v1",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/autoscaling/v2alpha1",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/batch/v1",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/batch/v2alpha1",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/certificates/v1beta1",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/core/v1",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/extensions/v1beta1",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/policy/v1beta1",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/rbac/v1alpha1",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/rbac/v1beta1",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/storage/v1beta1",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/listers/core/v1",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/api",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/api/install",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/api/v1",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/apps",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/apps/install",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/apps/v1beta1",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/authentication",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/authentication/install",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/authentication/v1",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/authentication/v1beta1",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/authorization",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/authorization/install",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/authorization/v1",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/authorization/v1beta1",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/autoscaling",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/autoscaling/install",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/autoscaling/v1",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/autoscaling/v2alpha1",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/batch",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/batch/install",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/batch/v1",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/batch/v2alpha1",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/certificates",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/certificates/install",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/certificates/v1beta1",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/extensions",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/extensions/install",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/extensions/v1beta1",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/policy",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/policy/install",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/policy/v1beta1",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/rbac",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/rbac/install",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/rbac/v1alpha1",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/rbac/v1beta1",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/storage",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/storage/install",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/storage/v1beta1",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/util",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/util/labels",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/util/parsers",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/version",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/rest",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/rest/watch",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/auth",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/cache",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/clientcmd",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/clientcmd/api",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/clientcmd/api/latest",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/clientcmd/api/v1",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/metrics",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/transport",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/cert",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/clock",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/flowcontrol",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/homedir",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/integer",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/testing",
-			"Comment": "v2.0.0-alpha.0-75-g6500775",
+			"Comment": "v2.0.0-alpha.0-75-g6500775c",
 			"Rev": "6500775c58c43486978291879ac9e1b0e9fc953f"
 		},
 		{

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,7 +1,7 @@
 {
 	"ImportPath": "k8s.io/heapster",
 	"GoVersion": "go1.8",
-	"GodepVersion": "v79",
+	"GodepVersion": "v80",
 	"Packages": [
 		"./..."
 	],

--- a/metrics/core/metrics.go
+++ b/metrics/core/metrics.go
@@ -29,6 +29,7 @@ const (
 var StandardMetrics = []Metric{
 	MetricUptime,
 	MetricCpuUsage,
+	MetricEphemeralStorageUsage,
 	MetricMemoryUsage,
 	MetricMemoryRSS,
 	MetricMemoryCache,
@@ -220,6 +221,15 @@ var MetricCpuUsage = Metric{
 	},
 }
 
+var MetricEphemeralStorageUsage = Metric{
+	MetricDescriptor: MetricDescriptor{
+		Name:        "ephemeralstorage/usage",
+		Description: "Ephemeral storage usage",
+		Type:        MetricGauge,
+		ValueType:   ValueInt64,
+		Units:       UnitsBytes,
+	},
+}
 var MetricMemoryUsage = Metric{
 	MetricDescriptor: MetricDescriptor{
 		Name:        "memory/usage",

--- a/metrics/processors/pod_aggregator_test.go
+++ b/metrics/processors/pod_aggregator_test.go
@@ -66,6 +66,41 @@ func TestPodAggregator(t *testing.T) {
 					},
 				},
 			},
+
+			core.PodKey("ns1", "pod2"): {
+				Labels: map[string]string{
+					core.LabelMetricSetType.Key: core.MetricSetTypePod,
+					core.LabelPodName.Key:       "pod2",
+					core.LabelNamespaceName.Key: "ns1",
+				},
+				MetricValues: map[string]core.MetricValue{
+					"m1": {
+						ValueType:  core.ValueInt64,
+						MetricType: core.MetricGauge,
+						IntValue:   100,
+					},
+				},
+			},
+
+			core.PodContainerKey("ns1", "pod2", "c1"): {
+				Labels: map[string]string{
+					core.LabelMetricSetType.Key: core.MetricSetTypePodContainer,
+					core.LabelPodName.Key:       "pod2",
+					core.LabelNamespaceName.Key: "ns1",
+				},
+				MetricValues: map[string]core.MetricValue{
+					"m1": {
+						ValueType:  core.ValueInt64,
+						MetricType: core.MetricGauge,
+						IntValue:   10,
+					},
+					"m2": {
+						ValueType:  core.ValueInt64,
+						MetricType: core.MetricGauge,
+						IntValue:   20,
+					},
+				},
+			},
 		},
 	}
 	processor := PodAggregator{}
@@ -93,4 +128,16 @@ func TestPodAggregator(t *testing.T) {
 	labelNsName, found := pod.Labels[core.LabelNamespaceName.Key]
 	assert.True(t, found)
 	assert.Equal(t, "ns1", labelNsName)
+
+	pod, found = result.MetricSets[core.PodKey("ns1", "pod2")]
+	assert.True(t, found)
+
+	m1, found = pod.MetricValues["m1"]
+	assert.True(t, found)
+	assert.Equal(t, int64(100), m1.IntValue)
+
+	m2, found = pod.MetricValues["m2"]
+	assert.True(t, found)
+	assert.Equal(t, int64(20), m2.IntValue)
+
 }

--- a/metrics/sources/summary/summary.go
+++ b/metrics/sources/summary/summary.go
@@ -188,6 +188,9 @@ func (this *summaryMetricsSource) decodePodStats(metrics map[string]*MetricSet, 
 
 	this.decodeUptime(podMetrics, pod.StartTime.Time)
 	this.decodeNetworkStats(podMetrics, pod.Network)
+	this.decodeCPUStats(podMetrics, pod.CPU)
+	this.decodeMemoryStats(podMetrics, pod.Memory)
+	this.decodeEphemeralStorageStats(podMetrics, pod.EphemeralStorage)
 	for _, vol := range pod.VolumeStats {
 		this.decodeFsStats(podMetrics, VolumeResourcePrefix+vol.Name, &vol.FsStats)
 	}
@@ -253,6 +256,14 @@ func (this *summaryMetricsSource) decodeCPUStats(metrics *MetricSet, cpu *stats.
 	}
 
 	this.addIntMetric(metrics, &MetricCpuUsage, cpu.UsageCoreNanoSeconds)
+}
+
+func (this *summaryMetricsSource) decodeEphemeralStorageStats(metrics *MetricSet, storage *stats.FsStats) {
+	if storage == nil {
+		glog.V(9).Infof("missing storage usage metric!")
+		return
+	}
+	this.addIntMetric(metrics, &MetricEphemeralStorageUsage, storage.UsedBytes)
 }
 
 func (this *summaryMetricsSource) decodeMemoryStats(metrics *MetricSet, memory *stats.MemoryStats) {

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/apis/stats/v1alpha1/types.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/apis/stats/v1alpha1/types.go
@@ -86,6 +86,12 @@ type PodStats struct {
 	// +patchMergeKey=name
 	// +patchStrategy=merge
 	Containers []ContainerStats `json:"containers" patchStrategy:"merge" patchMergeKey:"name"`
+	// Stats pertaining to CPU resources consumed by pod cgroup (which includes all containers' resource usage and pod overhead).
+	// +optional
+	CPU *CPUStats `json:"cpu,omitempty"`
+	// Stats pertaining to memory (RAM) resources consumed by pod cgroup (which includes all containers' resource usage and pod overhead).
+	// +optional
+	Memory *MemoryStats `json:"memory,omitempty"`
 	// Stats pertaining to network resources.
 	// +optional
 	Network *NetworkStats `json:"network,omitempty"`
@@ -95,6 +101,9 @@ type PodStats struct {
 	// +patchMergeKey=name
 	// +patchStrategy=merge
 	VolumeStats []VolumeStats `json:"volume,omitempty" patchStrategy:"merge" patchMergeKey:"name"`
+	// EphemeralStorage reports the total filesystem usage for the containers and emptyDir-backed volumes in the measured Pod.
+	// +optional
+	EphemeralStorage *FsStats `json:"ephemeral-storage,omitempty"`
 }
 
 // ContainerStats holds container-level unprocessed sample stats.


### PR DESCRIPTION
This PR adds pod-level metrics (cpu, memory and ephemeral storage usage) from summary api to heapster