### PR TITLE
Hawkular, reduce the sink's memory usage in definition caching

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -264,8 +264,7 @@
 		},
 		{
 			"ImportPath": "github.com/hawkular/hawkular-client-go/metrics",
-			"Comment": "v0.6.0-22-g4863013",
-			"Rev": "4863013673fcb807cda3b5103964b084566a4665"
+			"Rev": "3ec6f27f0d339f9aee02ee4ad545581e52b40e19"
 		},
 		{
 			"ImportPath": "github.com/howeyc/gopass",

--- a/metrics/sinks/hawkular/types.go
+++ b/metrics/sinks/hawkular/types.go
@@ -45,11 +45,19 @@ func (f FilterType) From(s string) FilterType {
 	}
 }
 
+type expiringItem struct {
+	hash uint64
+	ttl  uint64
+}
+
 type hawkularSink struct {
 	client  *metrics.Client
 	models  map[string]*metrics.MetricDefinition // Model definitions
 	regLock sync.RWMutex
-	reg     map[string]*metrics.MetricDefinition // Real definitions
+	// reg      map[string]uint64 // Hash of real definition
+	expReg   map[string]*expiringItem
+	runId    uint64
+	cacheAge uint64
 
 	uri *url.URL
 


### PR DESCRIPTION
* Don't store structs in the memory, instead calculate a hash value which is used for compare
* Always compare the current cached value to the one Heapster provides to see instant change in labels
* Reduce the amount of goroutines for most cache lookups
* Expire the cache items if the Heapster has not seen the metric in two scrapes
* Improve startup time by loading definitions from a new endpoint designed for Openshift (disable with disablePreCaching setup)

With large amount of metrics, this should reduce the amount of memory used by the sink (with 20000 pods, Heapster memory usage was reduced from 5.7GB to 3.9GB)

@DirectXMan12 This replaces the previous PR. These changes have been tested against Heapster 1.3.0, so this is a rebase for newer Heapster.