### PR TITLE
support multi-OS cluster by adding nodeSelector to yaml files

### DIFF
--- a/deploy/kube-config/google/heapster.yaml
+++ b/deploy/kube-config/google/heapster.yaml
@@ -37,6 +37,8 @@ spec:
       - name: ssl-certs
         hostPath:
           path: /etc/ssl/certs
+      nodeSelector:
+        beta.kubernetes.io/os: linux
 ---
 apiVersion: v1
 kind: Service

--- a/deploy/kube-config/influxdb/grafana.yaml
+++ b/deploy/kube-config/influxdb/grafana.yaml
@@ -48,6 +48,8 @@ spec:
           path: /etc/ssl/certs
       - name: grafana-storage
         emptyDir: {}
+      nodeSelector:
+        beta.kubernetes.io/os: linux
 ---
 apiVersion: v1
 kind: Service

--- a/deploy/kube-config/influxdb/heapster.yaml
+++ b/deploy/kube-config/influxdb/heapster.yaml
@@ -26,6 +26,8 @@ spec:
         - /heapster
         - --source=kubernetes:https://kubernetes.default
         - --sink=influxdb:http://monitoring-influxdb.kube-system.svc:8086
+      nodeSelector:
+        beta.kubernetes.io/os: linux
 ---
 apiVersion: v1
 kind: Service

--- a/deploy/kube-config/influxdb/influxdb.yaml
+++ b/deploy/kube-config/influxdb/influxdb.yaml
@@ -20,6 +20,8 @@ spec:
       volumes:
       - name: influxdb-storage
         emptyDir: {}
+      nodeSelector:
+        beta.kubernetes.io/os: linux
 ---
 apiVersion: v1
 kind: Service

--- a/deploy/kube-config/standalone-test/heapster-controller.yaml
+++ b/deploy/kube-config/standalone-test/heapster-controller.yaml
@@ -27,6 +27,8 @@ spec:
         - name: ssl-certs
           mountPath: /etc/ssl/certs
           readOnly: true
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       volumes:
       - name: ssl-certs
         hostPath:

--- a/deploy/kube-config/standalone-test/heapster-summary-controller.yaml
+++ b/deploy/kube-config/standalone-test/heapster-summary-controller.yaml
@@ -38,6 +38,8 @@ spec:
         - name: ssl-certs
           mountPath: /etc/ssl/certs
           readOnly: true
+      nodeSelector:
+        beta.kubernetes.io/os: linux 
       volumes:
       - name: ssl-certs
         hostPath:

--- a/deploy/kube-config/standalone-with-apiserver/heapster-deployment.yaml
+++ b/deploy/kube-config/standalone-with-apiserver/heapster-deployment.yaml
@@ -47,6 +47,8 @@ spec:
         - name: ssl-certs
           mountPath: /etc/ssl/certs
           readOnly: true
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       volumes:
       - name: heapster-apiserver-secrets
         secret:

--- a/deploy/kube-config/standalone/heapster-controller.yaml
+++ b/deploy/kube-config/standalone/heapster-controller.yaml
@@ -25,6 +25,8 @@ spec:
         command:
         - /heapster
         - --source=kubernetes:https://kubernetes.default
+      nodeSelector:
+        beta.kubernetes.io/os: linux
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
This adds support to the example deployments for multi-OS Kubernetes clusters,
by introducing a `nodeSelector` to the relevant YAML files.