### PR TITLE
Bump Kubernetes version to 1.9.1 in integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ ifeq ($(INTERACTIVE), 1)
 	TTY=-t
 endif
 
-SUPPORTED_KUBE_VERSIONS=1.7.0-beta.2
+SUPPORTED_KUBE_VERSIONS=1.9.1
 TEST_NAMESPACE=heapster-e2e-tests
 
 HEAPSTER_LDFLAGS=-w -X k8s.io/heapster/version.HeapsterVersion=$(VERSION) -X k8s.io/heapster/version.GitCommit=$(GIT_COMMIT)

--- a/integration/.jenkins.sh
+++ b/integration/.jenkins.sh
@@ -7,7 +7,7 @@ export GOBIN="$GOPATH/bin"
 export PATH="$GOBIN:$PATH"
 
 # Kubernetes version(s) to run the integration tests against.
-kube_version="1.7.0-beta.2"
+kube_version="1.9.1"
 
 if ! git diff --name-only origin/master | grep -c -E "*.go|*.sh|.*yaml|Makefile" &> /dev/null; then
   echo "This PR does not touch files that require integration testing. Skipping integration tests!"


### PR DESCRIPTION
Previous version was no longer working with gcloud past version 1.6.7. Also, it doesn't make sense to test against old version of Kubernetes.