### PR TITLE
add github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,35 @@
+<!--
+Before you report a new issue, make sure that we do not have any duplicates
+already open. You can ensure this by searching the issue list for this
+repository. If there is a duplicate, please close your issue and add a comment
+to the existing issue instead.
+
+** please remove empty sections and comments before submitting **
+-->
+
+**Description**
+
+<!--
+Briefly describe the problem you are having in a few paragraphs.
+-->
+
+**Steps to reproduce:**
+
+
+**Describe the results you received:**
+
+
+**Describe the results you expected:**
+
+
+**Output of `heapster --version`:**
+
+```
+(paste your output here)
+```
+
+**Output of `kubectl version`:**
+
+```
+(paste your output here)
+```

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+<!--
+If this is a bug fix, make sure your description includes "fixes #xxxx", or
+"closes #xxxx"
+
+** please remove empty sections and comments before submitting **
+-->
+
+**What this PR does**
+


### PR DESCRIPTION
This PR adds github issue and PR templates to heapster. This can help us to avoid some comments to inform contributors to add some basic info and description like @DirectXMan12 did in https://github.com/kubernetes/heapster/pull/1923#issuecomment-355121226.



/cc @DirectXMan12 @piosz @loburm 