### PR TITLE
Fix nil pointer dereference when a sink return (nil, err)

### DIFF
--- a/events/sinks/factory.go
+++ b/events/sinks/factory.go
@@ -59,7 +59,7 @@ func (this *SinkFactory) BuildAll(uris flags.Uris) []core.EventSink {
 	for _, uri := range uris {
 		sink, err := this.Build(uri)
 		if err != nil {
-			glog.Errorf("Failed to create sink: %v", err)
+			glog.Errorf("Failed to create %s sink: %v", uri, err)
 			continue
 		}
 		result = append(result, sink)

--- a/metrics/sinks/factory.go
+++ b/metrics/sinks/factory.go
@@ -87,7 +87,7 @@ func (this *SinkFactory) BuildAll(uris flags.Uris, historicalUri string, disable
 	for _, uri := range uris {
 		sink, err := this.Build(uri)
 		if err != nil {
-			glog.Errorf("Failed to create %s sink: %v", sink.Name(), err)
+			glog.Errorf("Failed to create %s sink: %v", uri, err)
 			continue
 		}
 		if uri.Key == "metric" {


### PR DESCRIPTION
* Fix nil pointer dereference when a metric sink return an error (use uri to get sink info vs .Name() on a nil pointer)
* Harmonize metrics and events factory code