### PR TITLE
Avoid nil pointer dereference on error

### DIFF
--- a/metrics/sinks/factory.go
+++ b/metrics/sinks/factory.go
@@ -87,7 +87,7 @@ func (this *SinkFactory) BuildAll(uris flags.Uris, historicalUri string, disable
 	for _, uri := range uris {
 		sink, err := this.Build(uri)
 		if err != nil {
-			glog.Errorf("Failed to create %s sink: %v", sink.Name(), err)
+			glog.Errorf("Failed to create %s sink: %v", uri.Key, err)
 			continue
 		}
 		if uri.Key == "metric" {


### PR DESCRIPTION
In this line of code, `sink` is generally nil since `err` is non-nil.