### PR TITLE
sinks/influxdb: allow retention policy name to be set

### DIFF
--- a/common/influxdb/influxdb.go
+++ b/common/influxdb/influxdb.go
@@ -41,6 +41,7 @@ type InfluxdbConfig struct {
 	WithFields            bool
 	InsecureSsl           bool
 	RetentionPolicy       string
+	RetentionPolicyName   string
 	ClusterName           string
 	DisableCounterMetrics bool
 	Concurrency           int
@@ -83,6 +84,7 @@ func BuildConfig(uri *url.URL) (*InfluxdbConfig, error) {
 		WithFields:            false,
 		InsecureSsl:           false,
 		RetentionPolicy:       "0",
+		RetentionPolicyName:   "default",
 		ClusterName:           "default",
 		DisableCounterMetrics: false,
 		Concurrency:           1,
@@ -104,6 +106,9 @@ func BuildConfig(uri *url.URL) (*InfluxdbConfig, error) {
 	}
 	if len(opts["retention"]) >= 1 {
 		config.RetentionPolicy = opts["retention"][0]
+	}
+	if len(opts["rpname"]) >= 1 {
+		config.RetentionPolicyName = opts["rpname"][0]
 	}
 	if len(opts["withfields"]) >= 1 {
 		val, err := strconv.ParseBool(opts["withfields"][0])

--- a/docs/sink-configuration.md
+++ b/docs/sink-configuration.md
@@ -32,6 +32,7 @@ The following options are available:
 * `pw` - InfluxDB password (default: `root`)
 * `db` - InfluxDB Database name (default: `k8s`)
 * `retention` - Duration of the default InfluxDB retention policy, e.g. `4h` or `7d` (default: `0` meaning infinite)
+* `rpname` - Retention policy name to use when creating one, and when writing to the database (default: `default`)
 * `secure` - Connect securely to InfluxDB (default: `false`)
 * `insecuressl` - Ignore SSL certificate validity (default: `false`)
 * `withfields` - Use [InfluxDB fields](storage-schema.md#using-fields) (default: `false`)

--- a/events/sinks/influxdb/influxdb.go
+++ b/events/sinks/influxdb/influxdb.go
@@ -153,7 +153,7 @@ func (sink *influxdbSink) sendData(dataPoints []influxdb.Point) {
 	bp := influxdb.BatchPoints{
 		Points:          dataPoints,
 		Database:        sink.c.DbName,
-		RetentionPolicy: "default",
+		RetentionPolicy: sink.c.RetentionPolicyName,
 	}
 
 	start := time.Now()
@@ -212,7 +212,7 @@ func (sink *influxdbSink) createDatabase() error {
 
 func (sink *influxdbSink) createRetentionPolicy() error {
 	q := influxdb.Query{
-		Command: fmt.Sprintf(`CREATE RETENTION POLICY "default" ON %s DURATION 0d REPLICATION 1 DEFAULT`, sink.c.DbName),
+		Command: fmt.Sprintf(`CREATE RETENTION POLICY "%s" ON %s DURATION 0d REPLICATION 1 DEFAULT`, sink.c.RetentionPolicyName, sink.c.DbName),
 	}
 
 	if resp, err := sink.client.Query(q); err != nil {

--- a/metrics/sinks/influxdb/influxdb.go
+++ b/metrics/sinks/influxdb/influxdb.go
@@ -211,7 +211,7 @@ func (sink *influxdbSink) sendData(dataPoints []influxdb.Point) {
 	bp := influxdb.BatchPoints{
 		Points:          dataPoints,
 		Database:        sink.c.DbName,
-		RetentionPolicy: "default",
+		RetentionPolicy: sink.c.RetentionPolicyName,
 	}
 
 	start := time.Now()
@@ -277,7 +277,7 @@ func (sink *influxdbSink) createDatabase() error {
 
 func (sink *influxdbSink) createRetentionPolicy() error {
 	q := influxdb.Query{
-		Command: fmt.Sprintf(`CREATE RETENTION POLICY "default" ON %s DURATION %s REPLICATION 1 DEFAULT`, sink.c.DbName, sink.c.RetentionPolicy),
+		Command: fmt.Sprintf(`CREATE RETENTION POLICY "%s" ON %s DURATION %s REPLICATION 1 DEFAULT`, sink.c.RetentionPolicyName, sink.c.DbName, sink.c.RetentionPolicy),
 	}
 
 	if resp, err := sink.client.Query(q); err != nil {
@@ -286,7 +286,7 @@ func (sink *influxdbSink) createRetentionPolicy() error {
 		}
 	}
 
-	glog.Infof("Created retention policy 'default' in database %q on influxDB server at %q", sink.c.DbName, sink.c.Host)
+	glog.Infof("Created retention policy '%s' in database %q on influxDB server at %q", sink.c.RetentionPolicyName, sink.c.DbName, sink.c.Host)
 	return nil
 }
 


### PR DESCRIPTION
Allow influxdb retention policy name to be configured with a new `rpname` URL option. This has the added benefit of allowing events and metrics to live in the same database but with different retention periods if desired.