### PR TITLE
Adding Datadog statsd formatter option

### DIFF
--- a/metrics/sinks/statsd/dogstatsd_formatter.go
+++ b/metrics/sinks/statsd/dogstatsd_formatter.go
@@ -16,18 +16,18 @@ package statsd
 
 import (
 	"fmt"
+	"github.com/golang/glog"
 	"k8s.io/heapster/metrics/core"
+	"regexp"
 	"sort"
 	"strings"
-	"github.com/golang/glog"
-	"regexp"
 )
 
 type DogstatsdFormatter struct {
 	delimReplacer *strings.Replacer
 }
 
-var allowedChars ="[a-zA-Z_][a-zA-Z0-9_]*"
+var allowedChars = "[a-zA-Z_][a-zA-Z0-9_]*"
 var replacer *regexp.Regexp
 
 func (formatter *DogstatsdFormatter) Format(prefix string, name string, labels map[string]string, customizeLabel CustomizeLabel, metricValue core.MetricValue) (res string, err error) {
@@ -75,8 +75,8 @@ func (formatter *DogstatsdFormatter) expandUserLabels(labels map[string]string) 
 	return res
 }
 
-func sanitizeLabel(src string) string{
-	return replacer.ReplaceAllString(src,"_")
+func sanitizeLabel(src string) string {
+	return replacer.ReplaceAllString(src, "_")
 }
 
 func NewDogstatsdFormatter() Formatter {

--- a/metrics/sinks/statsd/dogstatsd_formatter.go
+++ b/metrics/sinks/statsd/dogstatsd_formatter.go
@@ -1,0 +1,87 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statsd
+
+import (
+	"fmt"
+	"k8s.io/heapster/metrics/core"
+	"sort"
+	"strings"
+	"github.com/golang/glog"
+	"regexp"
+)
+
+type DogstatsdFormatter struct {
+	delimReplacer *strings.Replacer
+}
+
+var allowedChars ="[a-zA-Z_][a-zA-Z0-9_]*"
+var replacer *regexp.Regexp
+
+func (formatter *DogstatsdFormatter) Format(prefix string, name string, labels map[string]string, customizeLabel CustomizeLabel, metricValue core.MetricValue) (res string, err error) {
+	replacer = regexp.MustCompile(allowedChars)
+	expandedLabels := formatter.expandUserLabels(labels)
+	keys := make([]string, len(expandedLabels))
+	finalizedLabels := make([]string, len(expandedLabels))
+	for k := range expandedLabels {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	idx := 0
+	for _, k := range keys {
+		v := expandedLabels[k]
+		if v != "" {
+			finalizedLabels[idx] = fmt.Sprintf("%s:%s", customizeLabel(sanitizeLabel(k)), formatter.delimReplacer.Replace(v))
+			idx++
+		}
+	}
+
+	res = fmt.Sprintf("%s:%v|g|#%s",
+		fmt.Sprintf("%s%s", sanitizeLabel(prefix), sanitizeLabel(name)), metricValue.GetValue(),
+		strings.Join(finalizedLabels, ","))
+
+	return res, nil
+}
+
+func (formatter *DogstatsdFormatter) expandUserLabels(labels map[string]string) map[string]string {
+	res := make(map[string]string)
+	var userLabelStr string
+	for k, v := range labels {
+		if k == core.LabelLabels.Key {
+			userLabelStr = v
+		} else {
+			res[k] = v
+		}
+	}
+	kvPairs := strings.Split(userLabelStr, ",")
+	for _, kvPair := range kvPairs {
+		kv := strings.Split(kvPair, ":")
+		if len(kv) >= 2 {
+			res[kv[0]] = kv[1]
+		}
+	}
+	return res
+}
+
+func sanitizeLabel(src string) string{
+	return replacer.ReplaceAllString(src,"_")
+}
+
+func NewDogstatsdFormatter() Formatter {
+	glog.V(2).Info("Dogstatsd formatter is created")
+	return &DogstatsdFormatter{
+		delimReplacer: strings.NewReplacer(",", "_", ":", "_", "=", "_", "|", "_"),
+	}
+}

--- a/metrics/sinks/statsd/dogstatsd_formatter_test.go
+++ b/metrics/sinks/statsd/dogstatsd_formatter_test.go
@@ -1,0 +1,72 @@
+// Copyright 2015 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statsd
+
+import (
+	"github.com/stretchr/testify/assert"
+	"k8s.io/heapster/metrics/core"
+	"testing"
+)
+
+var (
+	dogstatsPrefix       = "testprefix."
+	dogstatsMetricName   = "testmetric"
+	dogstatsResourceName = "testresource"
+)
+
+var dogstatsLabels = map[string]string{
+	"test_tag_1": "value1",
+	"test_tag_2": "value2",
+	"test_tag_3": "value3",
+}
+
+var dogstatsMetricValue = core.MetricValue{
+	MetricType: core.MetricGauge,
+	ValueType:  core.ValueInt64,
+	IntValue:   1000,
+}
+
+func TestDogStatsFormatWithoutLabels(t *testing.T) {
+	expectedMsg := "testprefix.testmetric:1000|g"
+
+	formatter := NewInfluxstatsdFormatter()
+	assert.NotNil(t, formatter)
+
+	msg, err := formatter.Format(dogstatsPrefix, dogstatsMetricName, nil, SnakeToLowerCamel, dogstatsMetricValue)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedMsg, msg)
+}
+
+func TestDogStatsFormatWithLabels(t *testing.T) {
+	expectedMsg := "testprefix.testmetric:1000|g|#testTag1=value1,testTag2=value2,testTag3=value3"
+
+	formatter := NewInfluxstatsdFormatter()
+	assert.NotNil(t, formatter)
+
+	msg, err := formatter.Format(dogstatsPrefix, dogstatsMetricName, dogstatsLabels, SnakeToLowerCamel, dogstatsMetricValue)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedMsg, msg)
+}
+
+func TestDogStatsFormatWithoutPrefix(t *testing.T) {
+	expectedMsg := "testmetric:1000|g|#TestTag1=value1,TestTag2=value2,TestTag3=value3"
+
+	formatter := NewInfluxstatsdFormatter()
+	assert.NotNil(t, formatter)
+
+	msg, err := formatter.Format("", dogstatsMetricName, dogstatsLabels, SnakeToUpperCamel, dogstatsMetricValue)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedMsg, msg)
+}

--- a/metrics/sinks/statsd/dogstatsd_formatter_test.go
+++ b/metrics/sinks/statsd/dogstatsd_formatter_test.go
@@ -39,9 +39,9 @@ var dogstatsMetricValue = core.MetricValue{
 }
 
 func TestDogStatsFormatWithoutLabels(t *testing.T) {
-	expectedMsg := "testprefix.testmetric:1000|g"
+	expectedMsg := "testprefix.testmetric:1000|g|#"
 
-	formatter := NewInfluxstatsdFormatter()
+	formatter := NewDogstatsdFormatter()
 	assert.NotNil(t, formatter)
 
 	msg, err := formatter.Format(dogstatsPrefix, dogstatsMetricName, nil, SnakeToLowerCamel, dogstatsMetricValue)
@@ -50,9 +50,9 @@ func TestDogStatsFormatWithoutLabels(t *testing.T) {
 }
 
 func TestDogStatsFormatWithLabels(t *testing.T) {
-	expectedMsg := "testprefix.testmetric:1000|g|#testTag1=value1,testTag2=value2,testTag3=value3"
+	expectedMsg := "testprefix.testmetric:1000|g|#testTag1:value1,testTag2:value2,testTag3:value3"
 
-	formatter := NewInfluxstatsdFormatter()
+	formatter := NewDogstatsdFormatter()
 	assert.NotNil(t, formatter)
 
 	msg, err := formatter.Format(dogstatsPrefix, dogstatsMetricName, dogstatsLabels, SnakeToLowerCamel, dogstatsMetricValue)
@@ -61,9 +61,9 @@ func TestDogStatsFormatWithLabels(t *testing.T) {
 }
 
 func TestDogStatsFormatWithoutPrefix(t *testing.T) {
-	expectedMsg := "testmetric:1000|g|#TestTag1=value1,TestTag2=value2,TestTag3=value3"
+	expectedMsg := "testmetric:1000|g|#TestTag1:value1,TestTag2:value2,TestTag3:value3"
 
-	formatter := NewInfluxstatsdFormatter()
+	formatter := NewDogstatsdFormatter()
 	assert.NotNil(t, formatter)
 
 	msg, err := formatter.Format("", dogstatsMetricName, dogstatsLabels, SnakeToUpperCamel, dogstatsMetricValue)

--- a/metrics/sinks/statsd/formatter.go
+++ b/metrics/sinks/statsd/formatter.go
@@ -46,6 +46,8 @@ func NewFormatter(protocolType string) (formatter Formatter, err error) {
 		return NewEtsystatsdFormatter(), nil
 	case "influxstatsd":
 		return NewInfluxstatsdFormatter(), nil
+	case "dogstatsd":
+		return NewDogstatsdFormatter(), nil
 	default:
 		return nil, fmt.Errorf("Unknown statd formatter %s", protocolType)
 	}


### PR DESCRIPTION
Datadog's extended statsd format (dogstatsd) is a tag supporting format similar to the Influx statsd format, except the tags are a suffix on the end of the payload. This addition of the dogstatsd format will be handy for anyone using Datadog's metric service.  