### PR TITLE
Add OWNERS files

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,20 @@
+reviewers:
+- DirectXMan12
+- piosz
+- x13n
+- kawych
+- crassirostris
+- loburm
+- mwieglus
+- huangyuqi
+- andyxning
+approvers:
+- DirectXMan12
+- piosz
+- x13n
+- kawych
+- crassirostris
+- loburm
+- mwieglus
+- huangyuqi
+- andyxning

--- a/events/sinks/elasticsearch/OWNERS
+++ b/events/sinks/elasticsearch/OWNERS
@@ -1,0 +1,9 @@
+reviewers:
+- almogbaku
+- andyxning
+- huangyuqi
+approvers:
+- almogbaku
+- andyxning
+- huangyuqi
+

--- a/events/sinks/gcl/OWNERS
+++ b/events/sinks/gcl/OWNERS
@@ -1,0 +1,15 @@
+reviewers:
+- piosz
+- x13n
+- kawych
+- crassirostris
+- loburm
+- mwieglus
+approvers:
+- piosz
+- x13n
+- kawych
+- crassirostris
+- loburm
+- mwieglus
+

--- a/events/sinks/honeycomb/OWNERS
+++ b/events/sinks/honeycomb/OWNERS
@@ -1,0 +1,5 @@
+reviewers:
+- emfree
+approvers:
+- emfree
+

--- a/events/sinks/influxdb/OWNERS
+++ b/events/sinks/influxdb/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+- andyxning
+- acobaugh
+approvers:
+- andyxning
+- acobaugh

--- a/events/sinks/kafka/OWNERS
+++ b/events/sinks/kafka/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+- miaoyq
+- Kokan
+approvers:
+- miaoyq
+- Kokan

--- a/events/sinks/riemann/OWNERS
+++ b/events/sinks/riemann/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+- jamtur01
+- mcorbin
+approvers:
+- jamtur01
+- mcorbin

--- a/metrics/sinks/elasticsearch/OWNERS
+++ b/metrics/sinks/elasticsearch/OWNERS
@@ -1,0 +1,8 @@
+reviewers:
+- almogbaku
+- andyxning
+- huangyuqi
+approvers:
+- almogbaku
+- andyxning
+- huangyuqi

--- a/metrics/sinks/gcm/OWNERS
+++ b/metrics/sinks/gcm/OWNERS
@@ -1,0 +1,14 @@
+reviewers:
+- piosz
+- x13n
+- kawych
+- crassirostris
+- loburm
+- mwieglus
+approvers:
+- piosz
+- x13n
+- kawych
+- crassirostris
+- loburm
+- mwieglus

--- a/metrics/sinks/graphite/OWNERS
+++ b/metrics/sinks/graphite/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+- jsoriano
+- theairkit
+approvers:
+- jsoriano
+- theairkit

--- a/metrics/sinks/hawkular/OWNERS
+++ b/metrics/sinks/hawkular/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+- burmanm
+- mwringe
+approvers:
+- burmanm
+- mwringe

--- a/metrics/sinks/honeycomb/OWNERS
+++ b/metrics/sinks/honeycomb/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+- emfree
+approvers:
+- emfree

--- a/metrics/sinks/influxdb/OWNERS
+++ b/metrics/sinks/influxdb/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+- andyxning
+- acobaugh
+approvers:
+- andyxning
+- acobaugh

--- a/metrics/sinks/kafka/OWNERS
+++ b/metrics/sinks/kafka/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+- miaoyq
+- Kokan
+approvers:
+- miaoyq
+- Kokan

--- a/metrics/sinks/librato/OWNERS
+++ b/metrics/sinks/librato/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+- johanneswuerbach
+approvers:
+- johanneswuerbach

--- a/metrics/sinks/opentsdb/OWNERS
+++ b/metrics/sinks/opentsdb/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+- bluebreezecf
+approvers:
+- bluebreezecf

--- a/metrics/sinks/riemann/OWNERS
+++ b/metrics/sinks/riemann/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+- jamtur01
+- mcorbin
+approvers:
+- jamtur01
+- mcorbin

--- a/metrics/sinks/stackdriver/OWNERS
+++ b/metrics/sinks/stackdriver/OWNERS
@@ -1,0 +1,14 @@
+reviewers:
+- piosz
+- x13n
+- kawych
+- crassirostris
+- loburm
+- mwieglus
+approvers:
+- piosz
+- x13n
+- kawych
+- crassirostris
+- loburm
+- mwieglus

--- a/metrics/sinks/statsd/OWNERS
+++ b/metrics/sinks/statsd/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+- yogeswaran
+approvers:
+- yogeswaran

--- a/metrics/sinks/wavefront/OWNERS
+++ b/metrics/sinks/wavefront/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+- ezeev
+approvers:
+- ezeev


### PR DESCRIPTION
Each sink has its own OWNERS file, which should make triage and merging
easier once we turn the bot on.