### PR TITLE
Fix grafana dashboards. Fixes #1958

### DIFF
--- a/grafana/dashboards/cluster.json
+++ b/grafana/dashboards/cluster.json
@@ -1,4 +1,5 @@
 {
+  "dashboard": {
     "id": null,
     "title": "Cluster",
     "originalTitle": "Cluster",
@@ -2459,4 +2460,6 @@
     "schemaVersion": 8,
     "version": 10,
     "links": []
+  },
+  "overwrite": false
 }

--- a/grafana/dashboards/pods.json
+++ b/grafana/dashboards/pods.json
@@ -1,4 +1,5 @@
 {
+  "dashboard": {
     "id": null,
     "title": "Pods",
     "originalTitle": "Pods",
@@ -1054,4 +1055,6 @@
     "schemaVersion": 8,
     "version": 14,
     "links": []
+  },
+  "overwrite": false
 }


### PR DESCRIPTION
Grafana dashboard JSON needs to be wrapped in "dashboard": {} when
POSTing to /api/dashboards/db [1]. The bare dashboard is usable when
importing via the UI as it handles that wrapping for us. The wrapped
dashboard also imports just fine in the UI.

[1] http://docs.grafana.org/http_api/dashboard/)

This reverts commit e960cd47fb14847f642ef275da01726496e7faff.