### PR TITLE
[infra] Add Influx owners to the Grafana directory

### DIFF
--- a/grafana/OWNERS
+++ b/grafana/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+- andyxning
+- acobaugh
+approvers:
+- andyxning
+- acobaugh


### PR DESCRIPTION
This adds the Influx owners to the Grafana directory, so that people
knowlegable about Influx can also approve the Influx Grafana templates.