### PR TITLE
Add OWNERS file to common directory

### DIFF
--- a/common/elasticsearch/OWNERS
+++ b/common/elasticsearch/OWNERS
@@ -1,0 +1,8 @@
+reviewers:
+- almogbaku
+- andyxning
+- huangyuqi
+approvers:
+- almogbaku
+- andyxning
+- huangyuqi

--- a/common/honeycomb/OWNERS
+++ b/common/honeycomb/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+- emfree
+approvers:
+- emfree

--- a/common/influxdb/OWNERS
+++ b/common/influxdb/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+- andyxning
+- acobaugh
+approvers:
+- andyxning
+- acobaugh

--- a/common/kafka/OWNERS
+++ b/common/kafka/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+- miaoyq
+- Kokan
+approvers:
+- miaoyq
+- Kokan

--- a/common/librato/OWNERS
+++ b/common/librato/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+- johanneswuerbach
+approvers:
+- johanneswuerbach

--- a/common/riemann/OWNERS
+++ b/common/riemann/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+- jamtur01
+- mcorbin
+approvers:
+- jamtur01
+- mcorbin


### PR DESCRIPTION
The common directory did not have the OWNER files, I copied it from the `metrics/sink`, I hope everything is correct.
@almogbaku @andyxning @huangyuqi @emfree @miaoyq @johanneswuerbach @jamtur01 @mcorbin