### PR TITLE
Use float64 instead of float32 for metrics of Float type

### DIFF
--- a/metrics/core/types.go
+++ b/metrics/core/types.go
@@ -86,7 +86,7 @@ func (self *UnitsType) String() string {
 
 type MetricValue struct {
 	IntValue   int64
-	FloatValue float32
+	FloatValue float64
 	MetricType MetricType
 	ValueType  ValueType
 }

--- a/metrics/processors/node_autoscaling_enricher.go
+++ b/metrics/processors/node_autoscaling_enricher.go
@@ -56,18 +56,18 @@ func (this *NodeAutoscalingEnricher) Process(batch *core.DataBatch) (*core.DataB
 			memUsed := getInt(metricSet, &core.MetricMemoryUsage)
 
 			if allocatableCpu.MilliValue() != 0 {
-				setFloat(metricSet, &core.MetricNodeCpuUtilization, float32(cpuUsed)/float32(allocatableCpu.MilliValue()))
-				setFloat(metricSet, &core.MetricNodeCpuReservation, float32(cpuRequested)/float32(allocatableCpu.MilliValue()))
+				setFloat(metricSet, &core.MetricNodeCpuUtilization, float64(cpuUsed)/float64(allocatableCpu.MilliValue()))
+				setFloat(metricSet, &core.MetricNodeCpuReservation, float64(cpuRequested)/float64(allocatableCpu.MilliValue()))
 			}
-			setFloat(metricSet, &core.MetricNodeCpuCapacity, float32(capacityCpu.MilliValue()))
-			setFloat(metricSet, &core.MetricNodeCpuAllocatable, float32(allocatableCpu.MilliValue()))
+			setFloat(metricSet, &core.MetricNodeCpuCapacity, float64(capacityCpu.MilliValue()))
+			setFloat(metricSet, &core.MetricNodeCpuAllocatable, float64(allocatableCpu.MilliValue()))
 
 			if allocatableMem.Value() != 0 {
-				setFloat(metricSet, &core.MetricNodeMemoryUtilization, float32(memUsed)/float32(allocatableMem.Value()))
-				setFloat(metricSet, &core.MetricNodeMemoryReservation, float32(memRequested)/float32(allocatableMem.Value()))
+				setFloat(metricSet, &core.MetricNodeMemoryUtilization, float64(memUsed)/float64(allocatableMem.Value()))
+				setFloat(metricSet, &core.MetricNodeMemoryReservation, float64(memRequested)/float64(allocatableMem.Value()))
 			}
-			setFloat(metricSet, &core.MetricNodeMemoryCapacity, float32(capacityMem.Value()))
-			setFloat(metricSet, &core.MetricNodeMemoryAllocatable, float32(allocatableMem.Value()))
+			setFloat(metricSet, &core.MetricNodeMemoryCapacity, float64(capacityMem.Value()))
+			setFloat(metricSet, &core.MetricNodeMemoryAllocatable, float64(allocatableMem.Value()))
 		}
 	}
 	return batch, nil
@@ -80,7 +80,7 @@ func getInt(metricSet *core.MetricSet, metric *core.Metric) int64 {
 	return 0
 }
 
-func setFloat(metricSet *core.MetricSet, metric *core.Metric, value float32) {
+func setFloat(metricSet *core.MetricSet, metric *core.Metric, value float64) {
 	metricSet.MetricValues[metric.MetricDescriptor.Name] = core.MetricValue{
 		MetricType: core.MetricGauge,
 		ValueType:  core.ValueFloat,

--- a/metrics/processors/rate_calculator.go
+++ b/metrics/processors/rate_calculator.go
@@ -76,8 +76,8 @@ func (this *RateCalculator) Process(batch *core.DataBatch) (*core.DataBatch, err
 
 					if foundNew && foundOld {
 						if targetMetric.MetricDescriptor.ValueType == core.ValueFloat {
-							newVal := 1e9 * float32(metricValNew.IntValue-metricValOld.IntValue) /
-								float32(newMs.ScrapeTime.UnixNano()-oldMs.ScrapeTime.UnixNano())
+							newVal := 1e9 * float64(metricValNew.IntValue-metricValOld.IntValue) /
+								float64(newMs.ScrapeTime.UnixNano()-oldMs.ScrapeTime.UnixNano())
 
 							newMs.LabeledMetrics = append(newMs.LabeledMetrics, core.LabeledMetric{
 								Name:   targetMetric.MetricDescriptor.Name,
@@ -109,8 +109,8 @@ func (this *RateCalculator) Process(batch *core.DataBatch) (*core.DataBatch, err
 					}
 
 				} else if foundNew && foundOld && targetMetric.MetricDescriptor.ValueType == core.ValueFloat {
-					newVal := 1e9 * float32(metricValNew.IntValue-metricValOld.IntValue) /
-						float32(newMs.ScrapeTime.UnixNano()-oldMs.ScrapeTime.UnixNano())
+					newVal := 1e9 * float64(metricValNew.IntValue-metricValOld.IntValue) /
+						float64(newMs.ScrapeTime.UnixNano()-oldMs.ScrapeTime.UnixNano())
 
 					newMs.MetricValues[targetMetric.MetricDescriptor.Name] = core.MetricValue{
 						ValueType:  core.ValueFloat,

--- a/metrics/sinks/stackdriver/stackdriver_test.go
+++ b/metrics/sinks/stackdriver/stackdriver_test.go
@@ -55,7 +55,7 @@ func generateLabeledIntMetric(value int64, labels map[string]string, name string
 	}
 }
 
-func generateFloatMetric(value float32) core.MetricValue {
+func generateFloatMetric(value float64) core.MetricValue {
 	return core.MetricValue{
 		ValueType:  core.ValueFloat,
 		FloatValue: value,

--- a/metrics/sources/kubelet/kubelet.go
+++ b/metrics/sources/kubelet/kubelet.go
@@ -221,7 +221,7 @@ metricloop:
 			mv.IntValue = newest.IntValue
 		case cadvisor.FloatType:
 			mv.ValueType = ValueFloat
-			mv.FloatValue = float32(newest.FloatValue)
+			mv.FloatValue = newest.FloatValue
 		default:
 			glog.V(4).Infof("Skipping %s: unknown custom metric format", spec.Name, spec.Format)
 			continue metricloop

--- a/metrics/sources/summary/summary.go
+++ b/metrics/sources/summary/summary.go
@@ -335,7 +335,7 @@ func (this *summaryMetricsSource) decodeUserDefinedMetrics(metrics *MetricSet, u
 
 		// TODO: Handle double-precision values.
 		mv.ValueType = ValueFloat
-		mv.FloatValue = float32(metric.Value)
+		mv.FloatValue = metric.Value
 
 		metrics.MetricValues[CustomMetricPrefix+metric.Name] = mv
 	}


### PR DESCRIPTION
This PR fixes a bug where Heapster sometimes exported incorrect metrics (e.g. node allocatable memory < 0) due to float32 overflow.