### PR TITLE
add cpu load metrics

### DIFF
--- a/docs/storage-schema.md
+++ b/docs/storage-schema.md
@@ -12,6 +12,7 @@ Heapster exports the following metrics to its backends.
 | cpu/request | CPU request (the guaranteed amount of resources) in millicores. |
 | cpu/usage | Cumulative CPU usage on all cores. |
 | cpu/usage_rate | CPU usage on all cores in millicores. |
+| cpu/load | CPU load in milliloads, i.e., runnable threads * 1000 |
 | filesystem/usage | Total number of bytes consumed on a filesystem. |
 | filesystem/limit | The total size of filesystem in bytes. |
 | filesystem/available | The number of available bytes remaining in a the filesystem |

--- a/metrics/core/metrics.go
+++ b/metrics/core/metrics.go
@@ -29,6 +29,7 @@ const (
 var StandardMetrics = []Metric{
 	MetricUptime,
 	MetricCpuUsage,
+	MetricCpuLoad,
 	MetricEphemeralStorageUsage,
 	MetricMemoryUsage,
 	MetricMemoryRSS,
@@ -101,6 +102,7 @@ var CpuMetrics = []Metric{
 	MetricCpuLimit,
 	MetricCpuRequest,
 	MetricCpuUsage,
+	MetricCpuLoad,
 	MetricCpuUsageRate,
 	MetricNodeCpuAllocatable,
 	MetricNodeCpuCapacity,
@@ -199,6 +201,25 @@ var MetricRestartCount = Metric{
 		Type:        MetricCumulative,
 		ValueType:   ValueInt64,
 		Units:       UnitsCount,
+	},
+}
+
+var MetricCpuLoad = Metric{
+	MetricDescriptor: MetricDescriptor{
+		Name:        "cpu/load",
+		Description: "CPU load",
+		Type:        MetricGauge,
+		ValueType:   ValueInt64,
+		Units:       UnitsCount,
+	},
+	HasValue: func(spec *cadvisor.ContainerSpec) bool {
+		return spec.HasCpu
+	},
+	GetValue: func(spec *cadvisor.ContainerSpec, stat *cadvisor.ContainerStats) MetricValue {
+		return MetricValue{
+			ValueType:  ValueInt64,
+			MetricType: MetricGauge,
+			IntValue:   int64(stat.Cpu.LoadAverage)}
 	},
 }
 


### PR DESCRIPTION
**What this PR does**
This PR adds `cpu/load` metrics to heapster.
