### PR TITLE
Update influxdb and grafana dependencies

### DIFF
--- a/deploy/kube-config/influxdb/grafana.yaml
+++ b/deploy/kube-config/influxdb/grafana.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: grafana
-        image: k8s.gcr.io/heapster-grafana-amd64:v4.6.3
+        image: k8s.gcr.io/heapster-grafana-amd64:v5.0.4
         ports:
         - containerPort: 3000
           protocol: TCP

--- a/deploy/kube-config/influxdb/grafana.yaml
+++ b/deploy/kube-config/influxdb/grafana.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: grafana
-        image: k8s.gcr.io/heapster-grafana-amd64:v4.4.3
+        image: k8s.gcr.io/heapster-grafana-amd64:v4.6.3
         ports:
         - containerPort: 3000
           protocol: TCP

--- a/deploy/kube-config/influxdb/influxdb.yaml
+++ b/deploy/kube-config/influxdb/influxdb.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: influxdb
-        image: k8s.gcr.io/heapster-influxdb-amd64:v1.3.3
+        image: k8s.gcr.io/heapster-influxdb-amd64:v1.5.1
         volumeMounts:
         - mountPath: /data
           name: influxdb-storage

--- a/deploy/kube-config/influxdb/influxdb.yaml
+++ b/deploy/kube-config/influxdb/influxdb.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: influxdb
-        image: k8s.gcr.io/heapster-influxdb-amd64:v1.5.1
+        image: k8s.gcr.io/heapster-influxdb-amd64:v1.5.2
         volumeMounts:
         - mountPath: /data
           name: influxdb-storage

--- a/grafana/Makefile
+++ b/grafana/Makefile
@@ -19,8 +19,8 @@
 
 all: build
 
-VERSION?=v4.6.3
-DEB_VERSION?=4.6.3
+VERSION?=v5.0.4
+DEB_VERSION?=5.0.4
 
 PREFIX?=staging-k8s.gcr.io
 ARCH?=amd64
@@ -33,23 +33,23 @@ ML_PLATFORMS=linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/s390x
 
 # Set default base image dynamically for each arch
 ifeq ($(ARCH),amd64)
-	BASEIMAGE?=busybox
+	BASEIMAGE?=busybox:glibc
 	CC=gcc
 endif
 ifeq ($(ARCH),arm)
-	BASEIMAGE?=armhf/busybox
+	BASEIMAGE?=armhf/busybox:glibc
 	CC=arm-linux-gnueabihf-gcc
 endif
 ifeq ($(ARCH),arm64)
-	BASEIMAGE?=aarch64/busybox
+	BASEIMAGE?=aarch64/busybox:glibc
 	CC=aarch64-linux-gnu-gcc
 endif
 ifeq ($(ARCH),ppc64le)
-	BASEIMAGE?=ppc64le/busybox
+	BASEIMAGE?=ppc64le/busybox:glibc
 	CC=powerpc64le-linux-gnu-gcc
 endif
 ifeq ($(ARCH),s390x)
-	BASEIMAGE?=s390x/busybox
+	BASEIMAGE?=s390x/busybox:glibc
 	CC=s390x-linux-gnu-gcc
 endif
 

--- a/grafana/Makefile
+++ b/grafana/Makefile
@@ -19,14 +19,14 @@
 
 all: build
 
-VERSION?=v4.4.3
-DEB_VERSION?=4.4.3
+VERSION?=v4.6.3
+DEB_VERSION?=4.6.3
 
 PREFIX?=staging-k8s.gcr.io
 ARCH?=amd64
 TEMP_DIR:=$(shell mktemp -d)
 LDFLAGS=-w -X main.version=$(VERSION) -X main.commit=unknown-dev -X main.timestamp=0 -extldflags '-static'
-KUBE_CROSS_IMAGE=k8s.gcr.io/kube-cross:v1.8.3-2
+KUBE_CROSS_IMAGE=k8s.gcr.io/kube-cross:v1.9.3-2
 
 ALL_ARCHITECTURES=amd64 arm arm64 ppc64le s390x
 ML_PLATFORMS=linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/s390x

--- a/grafana/README.md
+++ b/grafana/README.md
@@ -1,7 +1,7 @@
 # Grafana Image For Heapster/InfluxDB
 
 ## What's in it:
- - Grafana 4
+ - Grafana 5
  - A Go binary that:
    - creates a datasource for InfluxDB
    - creates a couple of dashboards during startup.

--- a/grafana/RELEASES.md
+++ b/grafana/RELEASES.md
@@ -1,7 +1,7 @@
 # Release Notes for Grafana container.
 
-## 5.0.3 (27-03-2018)
-- Support Grafana 5.0.3.
+## 5.0.4 (18-04-2018)
+- Support Grafana 5.0.4.
 
 ## 4.4.1 (18-07-2017)
 - Image includes grafana.ini configuration file.

--- a/grafana/RELEASES.md
+++ b/grafana/RELEASES.md
@@ -1,5 +1,8 @@
 # Release Notes for Grafana container.
 
+## 5.0.3 (27-03-2018)
+- Support Grafana 5.0.3.
+
 ## 4.4.1 (18-07-2017)
 - Image includes grafana.ini configuration file.
 - Support Grafana 4.4.1.

--- a/influxdb/Makefile
+++ b/influxdb/Makefile
@@ -19,7 +19,7 @@
 
 all: build
 
-VERSION?=v1.5.1
+VERSION?=v1.5.2
 PREFIX?=staging-k8s.gcr.io
 ARCH?=amd64
 GOLANG_VERSION=1.10

--- a/influxdb/Makefile
+++ b/influxdb/Makefile
@@ -19,10 +19,10 @@
 
 all: build
 
-VERSION?=v1.3.3
+VERSION?=v1.5.1
 PREFIX?=staging-k8s.gcr.io
 ARCH?=amd64
-GOLANG_VERSION=1.8
+GOLANG_VERSION=1.10
 TEMP_DIR:=$(shell mktemp -d)
 
 ALL_ARCHITECTURES=amd64 arm arm64 ppc64le s390x

--- a/influxdb/RELEASES.md
+++ b/influxdb/RELEASES.md
@@ -1,5 +1,8 @@
 # Release Notes for the Heapster InfluxDB container.
 
+## v1.5.1 (03-27-2018)
+- Updated to version 1.5.1; bumped Go build container to 1.10
+
 ## v1.1.1 (11.1.2016)
 - Updated to version v1.1.1; bumped Godeps and modified some code in heapster to use the latest schema
 

--- a/influxdb/RELEASES.md
+++ b/influxdb/RELEASES.md
@@ -1,7 +1,7 @@
 # Release Notes for the Heapster InfluxDB container.
 
-## v1.5.1 (03-27-2018)
-- Updated to version 1.5.1; bumped Go build container to 1.10
+## v1.5.2 (04-18-2018)
+- Updated to version 1.5.2; bumped Go build container to 1.10
 
 ## v1.1.1 (11.1.2016)
 - Updated to version v1.1.1; bumped Godeps and modified some code in heapster to use the latest schema


### PR DESCRIPTION
Update the builds for `influxdb` and `grafana` to use recent versions.

Can't get `grafana` to cross-compile properly with 5.x because of warnings like this against `go-sqlite3` even when compiling statically:
```
/tmp.k8s/go-link-464062632/000002.o: In function `unixDlOpen':
/go/src/github.com/grafana/grafana/vendor/github.com/mattn/go-sqlite3/sqlite3-binding.c:36542: warning: Using 'dlopen' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking
```

I don't have a good way to test, but if that's not a showstopper (as suggested [elsewhere](https://software.intel.com/en-us/comment/1892902#comment-1892902)) then It would be nice to get `grafana` bumped to 5.0.3 as well. It might be as easy as changing `FROM busybox` to `FROM busybox:glibc`.