### PR TITLE
Exports metrics to track non primary container resource requests

### DIFF
--- a/docs/storage-schema.md
+++ b/docs/storage-schema.md
@@ -46,6 +46,7 @@ Heapster exports the following metrics to its backends.
 | accelerator/memory_total | Memory capacity of an accelerator. |
 | accelerator/memory_used | Memory used of an accelerator. |
 | accelerator/duty_cycle | Duty cycle of an accelerator. |
+| accelerator/request | Number of accelerator devices requested by container. |
 | network/rx | Cumulative number of bytes received over the network. |
 | network/rx_errors | Cumulative number of errors while receiving over the network. |
 | network/rx_errors_rate | Number of errors while receiving over the network per second. |

--- a/metrics/core/metrics.go
+++ b/metrics/core/metrics.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	cadvisor "github.com/google/cadvisor/info/v1"
+	kube_api "k8s.io/api/core/v1"
 )
 
 const (
@@ -147,6 +148,15 @@ var NetworkMetrics = []Metric{
 	MetricNetworkTxErrors,
 	MetricNetworkTxErrorsRate,
 	MetricNetworkTxRate,
+}
+
+// Maps from resource name to the metric that tracks container resource request
+// on that resource. The name of the metric is ResourceName/request where ResourceName
+// is the name of the resource requested in container resource requests.
+var ResourceRequestMetrics = map[kube_api.ResourceName]Metric{
+	kube_api.ResourceCPU:              MetricCpuRequest,
+	kube_api.ResourceMemory:           MetricMemoryRequest,
+	kube_api.ResourceEphemeralStorage: MetricEphemeralStorageRequest,
 }
 
 type MetricFamily string

--- a/metrics/sinks/stackdriver/metadata.go
+++ b/metrics/sinks/stackdriver/metadata.go
@@ -81,6 +81,12 @@ var (
 		Name:       "kubernetes.io/container/ephemeral_storage/limit_bytes",
 	}
 
+	acceleratorRequestedMD = &metricMetadata{
+		MetricKind: google_api5.MetricDescriptor_GAUGE,
+		ValueType:  google_api5.MetricDescriptor_INT64,
+		Name:       "kubernetes.io/container/accelerator/request",
+	}
+
 	restartCountMD = &metricMetadata{
 		MetricKind: google_api5.MetricDescriptor_CUMULATIVE,
 		ValueType:  google_api5.MetricDescriptor_INT64,
@@ -271,5 +277,11 @@ var (
 		MetricKind: google_api5.MetricDescriptor_GAUGE,
 		ValueType:  google_api5.MetricDescriptor_INT64,
 		Name:       "container.googleapis.com/container/accelerator/duty_cycle",
+	}
+
+	legacyAcceleratorRequestMD = &metricMetadata{
+		MetricKind: google_api5.MetricDescriptor_GAUGE,
+		ValueType:  google_api5.MetricDescriptor_INT64,
+		Name:       "container.googleapis.com/container/accelerator/request",
 	}
 )

--- a/metrics/sinks/stackdriver/stackdriver.go
+++ b/metrics/sinks/stackdriver/stackdriver.go
@@ -539,6 +539,13 @@ func (sink *StackdriverSink) LegacyTranslateMetric(timestamp time.Time, labels m
 			"memory_type": "evictable",
 		}
 		return ts
+	case "nvidia.com/gpu/request":
+		point := sink.intPoint(timestamp, timestamp, value.IntValue)
+		ts := legacyCreateTimeSeries(resourceLabels, legacyAcceleratorRequestMD, point)
+		ts.Metric.Labels = map[string]string{
+			"resource_name": "nvidia.com/gpu",
+		}
+		return ts
 	case core.MetricMemoryWorkingSet.MetricDescriptor.Name:
 		point := sink.intPoint(timestamp, timestamp, value.IntValue)
 		ts := legacyCreateTimeSeries(resourceLabels, legacyMemoryBytesUsedMD, point)
@@ -611,6 +618,13 @@ func (sink *StackdriverSink) TranslateMetric(timestamp time.Time, labels map[str
 			ts := createTimeSeries("k8s_container", containerLabels, memoryContainerUsedBytesMD, point)
 			ts.Metric.Labels = map[string]string{
 				"memory_type": "evictable",
+			}
+			return ts
+		case "nvidia.com/gpu/request":
+			point := sink.intPoint(timestamp, timestamp, value.IntValue)
+			ts := createTimeSeries("k8s_container", containerLabels, acceleratorRequestedMD, point)
+			ts.Metric.Labels = map[string]string{
+				"resource_name": "nvidia.com/gpu",
 			}
 			return ts
 		case core.MetricMemoryWorkingSet.MetricDescriptor.Name:


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

** please remove empty sections and comments before submitting **
-->

**What this PR does**
- Exports metrics on container non-primary resource requests.
- Adds "kubernetes.io/container/nvidia_gpu/request" metric generated from such metrics to stackdriver sink.
