### PR TITLE
make use of ObjectMeta ListOptions in meta/v1

### DIFF
--- a/metrics/apis/metrics/handlers.go
+++ b/metrics/apis/metrics/handlers.go
@@ -150,7 +150,7 @@ func (a *Api) getNodeMetrics(node string) *v1alpha1.NodeMetrics {
 	}
 
 	return &v1alpha1.NodeMetrics{
-		ObjectMeta: kube_v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:              node,
 			CreationTimestamp: metav1.NewTime(time.Now()),
 		},
@@ -248,7 +248,7 @@ func (a *Api) getPodMetrics(pod *kube_v1.Pod) *v1alpha1.PodMetrics {
 	}
 
 	res := &v1alpha1.PodMetrics{
-		ObjectMeta: kube_v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:              pod.Name,
 			Namespace:         pod.Namespace,
 			CreationTimestamp: metav1.NewTime(time.Now()),

--- a/metrics/apis/metrics/register.go
+++ b/metrics/apis/metrics/register.go
@@ -15,9 +15,9 @@
 package metrics
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/pkg/api"
 )
 
 // GroupName is the group name use in this package
@@ -47,7 +47,7 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&NodeMetricsList{},
 		&PodMetrics{},
 		&PodMetricsList{},
-		&api.ListOptions{},
+		&metav1.ListOptions{},
 	)
 	return nil
 }

--- a/metrics/apis/metrics/types.go
+++ b/metrics/apis/metrics/types.go
@@ -21,8 +21,8 @@ import (
 
 // resource usage metrics of a node.
 type NodeMetrics struct {
-	metav1.TypeMeta `json:",inline"`
-	api.ObjectMeta  `json:"metadata,omitempty"`
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// The following fields define time interval from which metrics were
 	// collected from the interval [Timestamp-Window, Timestamp].
@@ -46,8 +46,8 @@ type NodeMetricsList struct {
 
 // resource usage metrics of a pod.
 type PodMetrics struct {
-	metav1.TypeMeta `json:",inline"`
-	api.ObjectMeta  `json:"metadata,omitempty"`
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// The following fields define time interval from which metrics were
 	// collected from the interval [Timestamp-Window, Timestamp].

--- a/metrics/apis/metrics/v1alpha1/register.go
+++ b/metrics/apis/metrics/v1alpha1/register.go
@@ -18,7 +18,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/pkg/api/v1"
 )
 
 // GroupName is the group name use in this package
@@ -43,7 +42,7 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&NodeMetricsList{},
 		&PodMetrics{},
 		&PodMetricsList{},
-		&v1.ListOptions{},
+		&metav1.ListOptions{},
 	)
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
 	return nil

--- a/metrics/apis/metrics/v1alpha1/types.go
+++ b/metrics/apis/metrics/v1alpha1/types.go
@@ -21,8 +21,8 @@ import (
 
 // resource usage metrics of a node.
 type NodeMetrics struct {
-	metav1.TypeMeta `json:",inline"`
-	v1.ObjectMeta   `json:"metadata,omitempty"`
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// The following fields define time interval from which metrics were
 	// collected from the interval [Timestamp-Window, Timestamp].
@@ -46,8 +46,8 @@ type NodeMetricsList struct {
 
 // resource usage metrics of a pod.
 type PodMetrics struct {
-	metav1.TypeMeta `json:",inline"`
-	v1.ObjectMeta   `json:"metadata,omitempty"`
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// The following fields define time interval from which metrics were
 	// collected from the interval [Timestamp-Window, Timestamp].


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

** please remove empty sections and comments before submitting **
-->

**What this PR does**
As ListOptions and ObjectMeta was moved to meta/v1, and they are deprecated in core api group a year ago, and will be removed in future release. So here change to use `meta/v1.ListOptions ObjectMeta `
