### PR TITLE
Add local ephemeral storage metric into heapster

### DIFF
--- a/docs/storage-schema.md
+++ b/docs/storage-schema.md
@@ -13,6 +13,13 @@ Heapster exports the following metrics to its backends.
 | cpu/usage | Cumulative CPU usage on all cores. |
 | cpu/usage_rate | CPU usage on all cores in millicores. |
 | cpu/load | CPU load in milliloads, i.e., runnable threads * 1000 |
+| ephemeral_storage/limit | Local ephemeral storage hard limit in bytes. |
+| ephemeral_storage/request | Local ephemeral storage request (the guaranteed amount of resources) in bytes. |
+| ephemeral_storage/usage | Total local ephemeral storage usage. |
+| ephemeral_storage/node_capacity | Local ephemeral storage capacity of a node. |
+| ephemeral_storage/node_allocatable | Local ephemeral storage allocatable of a node. |
+| ephemeral_storage/node_reservation | Share of local ephemeral storage that is reserved on the node allocatable. |
+| ephemeral_storage/node_utilization | Local ephemeral utilization as a share of ephemeral storage allocatable. |
 | filesystem/usage | Total number of bytes consumed on a filesystem. |
 | filesystem/limit | The total size of filesystem in bytes. |
 | filesystem/available | The number of available bytes remaining in a the filesystem |

--- a/metrics/core/metrics.go
+++ b/metrics/core/metrics.go
@@ -47,7 +47,9 @@ var AdditionalMetrics = []Metric{
 	MetricCpuRequest,
 	MetricCpuLimit,
 	MetricMemoryRequest,
-	MetricMemoryLimit}
+	MetricMemoryLimit,
+	MetricEphemeralStorageRequest,
+	MetricEphemeralStorageLimit}
 
 // Computed based on corresponding StandardMetrics.
 var RateMetrics = []Metric{
@@ -90,12 +92,16 @@ var LabeledMetrics = []Metric{
 var NodeAutoscalingMetrics = []Metric{
 	MetricNodeCpuCapacity,
 	MetricNodeMemoryCapacity,
+	MetricNodeEphemeralStorageCapacity,
 	MetricNodeCpuAllocatable,
 	MetricNodeMemoryAllocatable,
+	MetricNodeEphemeralStorageAllocatable,
 	MetricNodeCpuUtilization,
 	MetricNodeMemoryUtilization,
+	MetricNodeEphemeralStorageUtilization,
 	MetricNodeCpuReservation,
 	MetricNodeMemoryReservation,
+	MetricNodeEphemeralStorageReservation,
 }
 
 var CpuMetrics = []Metric{
@@ -244,7 +250,7 @@ var MetricCpuUsage = Metric{
 
 var MetricEphemeralStorageUsage = Metric{
 	MetricDescriptor: MetricDescriptor{
-		Name:        "ephemeralstorage/usage",
+		Name:        "ephemeral_storage/usage",
 		Description: "Ephemeral storage usage",
 		Type:        MetricGauge,
 		ValueType:   ValueInt64,
@@ -502,6 +508,26 @@ var MetricMemoryLimit = Metric{
 	},
 }
 
+var MetricEphemeralStorageRequest = Metric{
+	MetricDescriptor: MetricDescriptor{
+		Name:        "ephemeral_storage/request",
+		Description: "ephemeral storage request (the guaranteed amount of resources) in bytes. This metric is Kubernetes specific.",
+		Type:        MetricGauge,
+		ValueType:   ValueInt64,
+		Units:       UnitsBytes,
+	},
+}
+
+var MetricEphemeralStorageLimit = Metric{
+	MetricDescriptor: MetricDescriptor{
+		Name:        "ephemeral_storage/limit",
+		Description: "ephemeral storage hard limit in bytes.",
+		Type:        MetricGauge,
+		ValueType:   ValueInt64,
+		Units:       UnitsBytes,
+	},
+}
+
 // Definition of Rate Metrics.
 var MetricCpuUsageRate = Metric{
 	MetricDescriptor: MetricDescriptor{
@@ -593,6 +619,16 @@ var MetricNodeMemoryCapacity = Metric{
 	},
 }
 
+var MetricNodeEphemeralStorageCapacity = Metric{
+	MetricDescriptor: MetricDescriptor{
+		Name:        "ephemeral_storage/node_capacity",
+		Description: "Ephemeral storage capacity of a node",
+		Type:        MetricGauge,
+		ValueType:   ValueFloat,
+		Units:       UnitsCount,
+	},
+}
+
 var MetricNodeCpuAllocatable = Metric{
 	MetricDescriptor: MetricDescriptor{
 		Name:        "cpu/node_allocatable",
@@ -607,6 +643,16 @@ var MetricNodeMemoryAllocatable = Metric{
 	MetricDescriptor: MetricDescriptor{
 		Name:        "memory/node_allocatable",
 		Description: "Memory allocatable of a node",
+		Type:        MetricGauge,
+		ValueType:   ValueFloat,
+		Units:       UnitsCount,
+	},
+}
+
+var MetricNodeEphemeralStorageAllocatable = Metric{
+	MetricDescriptor: MetricDescriptor{
+		Name:        "ephemeral_storage/node_allocatable",
+		Description: "Ephemeral storage allocatable of a node",
 		Type:        MetricGauge,
 		ValueType:   ValueFloat,
 		Units:       UnitsCount,
@@ -633,6 +679,16 @@ var MetricNodeMemoryUtilization = Metric{
 	},
 }
 
+var MetricNodeEphemeralStorageUtilization = Metric{
+	MetricDescriptor: MetricDescriptor{
+		Name:        "ephemeral_storage/node_utilization",
+		Description: "Ephemeral storage utilization as a share of storage capacity",
+		Type:        MetricGauge,
+		ValueType:   ValueFloat,
+		Units:       UnitsCount,
+	},
+}
+
 var MetricNodeCpuReservation = Metric{
 	MetricDescriptor: MetricDescriptor{
 		Name:        "cpu/node_reservation",
@@ -647,6 +703,16 @@ var MetricNodeMemoryReservation = Metric{
 	MetricDescriptor: MetricDescriptor{
 		Name:        "memory/node_reservation",
 		Description: "Share of memory that is reserved on the node",
+		Type:        MetricGauge,
+		ValueType:   ValueFloat,
+		Units:       UnitsCount,
+	},
+}
+
+var MetricNodeEphemeralStorageReservation = Metric{
+	MetricDescriptor: MetricDescriptor{
+		Name:        "ephemeral_storage/node_reservation",
+		Description: "Share of ephemeral storage that is reserved on the node",
 		Type:        MetricGauge,
 		ValueType:   ValueFloat,
 		Units:       UnitsCount,

--- a/metrics/heapster.go
+++ b/metrics/heapster.go
@@ -264,6 +264,8 @@ func createDataProcessorsOrDie(kubernetesUrl *url.URL, podLister v1listers.PodLi
 		core.MetricCpuLimit.Name,
 		core.MetricMemoryRequest.Name,
 		core.MetricMemoryLimit.Name,
+		core.MetricEphemeralStorageRequest.Name,
+		core.MetricEphemeralStorageLimit.Name,
 	}
 
 	dataProcessors = append(dataProcessors,

--- a/metrics/processors/node_autoscaling_enricher.go
+++ b/metrics/processors/node_autoscaling_enricher.go
@@ -47,13 +47,17 @@ func (this *NodeAutoscalingEnricher) Process(batch *core.DataBatch) (*core.DataB
 			this.labelCopier.Copy(node.Labels, metricSet.Labels)
 			capacityCpu, _ := node.Status.Capacity[kube_api.ResourceCPU]
 			capacityMem, _ := node.Status.Capacity[kube_api.ResourceMemory]
+			capacityEphemeralStorage, storageExist := node.Status.Capacity[kube_api.ResourceEphemeralStorage]
 			allocatableCpu, _ := node.Status.Allocatable[kube_api.ResourceCPU]
 			allocatableMem, _ := node.Status.Allocatable[kube_api.ResourceMemory]
+			allocatableEphemeralStorage, allocatableStorageExist := node.Status.Allocatable[kube_api.ResourceEphemeralStorage]
 
 			cpuRequested := getInt(metricSet, &core.MetricCpuRequest)
 			cpuUsed := getInt(metricSet, &core.MetricCpuUsageRate)
 			memRequested := getInt(metricSet, &core.MetricMemoryRequest)
 			memUsed := getInt(metricSet, &core.MetricMemoryUsage)
+			epheRequested := getInt(metricSet, &core.MetricEphemeralStorageRequest)
+			epheUsed := getInt(metricSet, &core.MetricEphemeralStorageUsage)
 
 			if allocatableCpu.MilliValue() != 0 {
 				setFloat(metricSet, &core.MetricNodeCpuUtilization, float64(cpuUsed)/float64(allocatableCpu.MilliValue()))
@@ -68,6 +72,15 @@ func (this *NodeAutoscalingEnricher) Process(batch *core.DataBatch) (*core.DataB
 			}
 			setFloat(metricSet, &core.MetricNodeMemoryCapacity, float64(capacityMem.Value()))
 			setFloat(metricSet, &core.MetricNodeMemoryAllocatable, float64(allocatableMem.Value()))
+
+			if storageExist && allocatableStorageExist {
+				setFloat(metricSet, &core.MetricNodeEphemeralStorageCapacity, float64(capacityEphemeralStorage.Value()))
+				setFloat(metricSet, &core.MetricNodeEphemeralStorageAllocatable, float64(allocatableEphemeralStorage.Value()))
+				if allocatableEphemeralStorage.Value() != 0 {
+					setFloat(metricSet, &core.MetricNodeEphemeralStorageUtilization, float64(epheUsed)/float64(allocatableEphemeralStorage.Value()))
+					setFloat(metricSet, &core.MetricNodeEphemeralStorageReservation, float64(epheRequested)/float64(allocatableEphemeralStorage.Value()))
+				}
+			}
 		}
 	}
 	return batch, nil

--- a/metrics/processors/pod_based_enricher.go
+++ b/metrics/processors/pod_based_enricher.go
@@ -181,6 +181,11 @@ func updateContainerResourcesAndLimits(metricSet *core.MetricSet, container kube
 	} else {
 		metricSet.MetricValues[core.MetricMemoryRequest.Name] = intValue(0)
 	}
+	if val, found := requests[kube_api.ResourceEphemeralStorage]; found {
+		metricSet.MetricValues[core.MetricEphemeralStorageRequest.Name] = intValue(val.Value())
+	} else {
+		metricSet.MetricValues[core.MetricEphemeralStorageRequest.Name] = intValue(0)
+	}
 
 	limits := container.Resources.Limits
 	if val, found := limits[kube_api.ResourceCPU]; found {
@@ -192,6 +197,11 @@ func updateContainerResourcesAndLimits(metricSet *core.MetricSet, container kube
 		metricSet.MetricValues[core.MetricMemoryLimit.Name] = intValue(val.Value())
 	} else {
 		metricSet.MetricValues[core.MetricMemoryLimit.Name] = intValue(0)
+	}
+	if val, found := limits[kube_api.ResourceEphemeralStorage]; found {
+		metricSet.MetricValues[core.MetricEphemeralStorageLimit.Name] = intValue(val.Value())
+	} else {
+		metricSet.MetricValues[core.MetricEphemeralStorageLimit.Name] = intValue(0)
 	}
 }
 

--- a/metrics/sinks/stackdriver/metadata.go
+++ b/metrics/sinks/stackdriver/metadata.go
@@ -63,6 +63,24 @@ var (
 		Name:       "kubernetes.io/container/memory/limit_bytes",
 	}
 
+	ephemeralstorageContainerUsedBytesMD = &metricMetadata{
+		MetricKind: google_api5.MetricDescriptor_GAUGE,
+		ValueType:  google_api5.MetricDescriptor_INT64,
+		Name:       "kubernetes.io/container/ephemeral_storage/used_bytes",
+	}
+
+	ephemeralstorageRequestedBytesMD = &metricMetadata{
+		MetricKind: google_api5.MetricDescriptor_GAUGE,
+		ValueType:  google_api5.MetricDescriptor_INT64,
+		Name:       "kubernetes.io/container/ephemeral_storage/request_bytes",
+	}
+
+	ephemeralstorageLimitBytesMD = &metricMetadata{
+		MetricKind: google_api5.MetricDescriptor_GAUGE,
+		ValueType:  google_api5.MetricDescriptor_INT64,
+		Name:       "kubernetes.io/container/ephemeral_storage/limit_bytes",
+	}
+
 	restartCountMD = &metricMetadata{
 		MetricKind: google_api5.MetricDescriptor_CUMULATIVE,
 		ValueType:  google_api5.MetricDescriptor_INT64,
@@ -131,6 +149,24 @@ var (
 		MetricKind: google_api5.MetricDescriptor_GAUGE,
 		ValueType:  google_api5.MetricDescriptor_INT64,
 		Name:       "kubernetes.io/node/memory/allocatable_bytes",
+	}
+
+	ephemeralstorageNodeUsedBytesMD = &metricMetadata{
+		MetricKind: google_api5.MetricDescriptor_GAUGE,
+		ValueType:  google_api5.MetricDescriptor_INT64,
+		Name:       "kubernetes.io/node/ephemeral_storage/used_bytes",
+	}
+
+	ephemeralstorageTotalBytesMD = &metricMetadata{
+		MetricKind: google_api5.MetricDescriptor_GAUGE,
+		ValueType:  google_api5.MetricDescriptor_INT64,
+		Name:       "kubernetes.io/node/ephemeral_storage/total_bytes",
+	}
+
+	ephemeralstorageAllocatableBytesMD = &metricMetadata{
+		MetricKind: google_api5.MetricDescriptor_GAUGE,
+		ValueType:  google_api5.MetricDescriptor_INT64,
+		Name:       "kubernetes.io/node/ephemeral_storage/allocatable_bytes",
 	}
 
 	networkNodeReceivedBytesMD = &metricMetadata{

--- a/metrics/sinks/stackdriver/stackdriver.go
+++ b/metrics/sinks/stackdriver/stackdriver.go
@@ -623,6 +623,16 @@ func (sink *StackdriverSink) TranslateMetric(timestamp time.Time, labels map[str
 		case core.MetricMemoryRequest.MetricDescriptor.Name:
 			point := sink.intPoint(timestamp, timestamp, value.IntValue)
 			return createTimeSeries("k8s_container", containerLabels, memoryRequestedBytesMD, point)
+		case core.MetricEphemeralStorageLimit.MetricDescriptor.Name:
+			point := sink.intPoint(timestamp, timestamp, value.IntValue)
+			return createTimeSeries("k8s_container", containerLabels, ephemeralstorageLimitBytesMD, point)
+		case core.MetricEphemeralStorageRequest.MetricDescriptor.Name:
+			point := sink.intPoint(timestamp, timestamp, value.IntValue)
+			return createTimeSeries("k8s_container", containerLabels, ephemeralstorageRequestedBytesMD, point)
+		case core.MetricEphemeralStorageUsage.MetricDescriptor.Name:
+			point := sink.intPoint(timestamp, timestamp, value.IntValue)
+			return createTimeSeries("k8s_container", containerLabels, ephemeralstorageContainerUsedBytesMD, point)
+
 		case core.MetricRestartCount.MetricDescriptor.Name:
 			if entityCreateTime.IsZero() {
 				glog.V(2).Infof("Skipping restart_count metric for container %s because entity create time is zero", core.PodContainerKey(containerLabels["namespace_name"], containerLabels["pod_name"], containerLabels["container_name"]))
@@ -679,6 +689,10 @@ func (sink *StackdriverSink) TranslateMetric(timestamp time.Time, labels map[str
 		case core.MetricNetworkTx.MetricDescriptor.Name:
 			point := sink.intPoint(timestamp, collectionStartTime, value.IntValue)
 			return createTimeSeries("k8s_node", nodeLabels, networkNodeSentBytesMD, point)
+		case core.MetricNodeEphemeralStorageCapacity.MetricDescriptor.Name:
+			point := sink.intPoint(timestamp, timestamp, value.IntValue)
+			return createTimeSeries("k8s_node", nodeLabels, ephemeralstorageTotalBytesMD, point)
+
 		}
 	case core.MetricSetTypeSystemContainer:
 		nodeLabels := sink.getNodeResourceLabels(labels)

--- a/metrics/sinks/stackdriver/stackdriver_test.go
+++ b/metrics/sinks/stackdriver/stackdriver_test.go
@@ -332,6 +332,9 @@ func TestTranslateMetricSet(t *testing.T) {
 	containerMemoryUsage := testTranslateMetric(as, generateIntMetric(5), containerLabels, "memory/bytes_used", "kubernetes.io/container/memory/used_bytes")
 	containerMemoryRequest := testTranslateMetric(as, generateIntMetric(6), containerLabels, "memory/request", "kubernetes.io/container/memory/request_bytes")
 	containerMemoryLimit := testTranslateMetric(as, generateIntMetric(7), containerLabels, "memory/limit", "kubernetes.io/container/memory/limit_bytes")
+	containerEphemeralStorageUsage := testTranslateMetric(as, generateIntMetric(5), containerLabels, "ephemeral_storage/usage", "kubernetes.io/container/ephemeral_storage/used_bytes")
+	containerEphemeralStorageRequest := testTranslateMetric(as, generateIntMetric(6), containerLabels, "ephemeral_storage/request", "kubernetes.io/container/ephemeral_storage/request_bytes")
+	containerEphemeralStorageLimit := testTranslateMetric(as, generateIntMetric(7), containerLabels, "ephemeral_storage/limit", "kubernetes.io/container/ephemeral_storage/limit_bytes")
 	containerRestartCount := testTranslateMetric(as, generateIntMetric(8), containerLabels, "restart_count", "kubernetes.io/container/restart_count")
 	podNetworkBytesRx := testTranslateMetric(as, generateIntMetric(9), podLabels, "network/rx", "kubernetes.io/pod/network/received_bytes_count")
 	podNetworkBytesTx := testTranslateMetric(as, generateIntMetric(10), podLabels, "network/tx", "kubernetes.io/pod/network/sent_bytes_count")
@@ -370,4 +373,7 @@ func TestTranslateMetricSet(t *testing.T) {
 	as.Equal(int64(20), nodeNetworkBytesTx.GetInt64Value())
 	as.Equal(float64(21), nodeDaemonCpuUsage.GetDoubleValue())
 	as.Equal(int64(22), nodeDaemonMemoryUsage.GetInt64Value())
+	as.Equal(int64(5), containerEphemeralStorageUsage.GetInt64Value())
+	as.Equal(int64(6), containerEphemeralStorageRequest.GetInt64Value())
+	as.Equal(int64(7), containerEphemeralStorageLimit.GetInt64Value())
 }

--- a/metrics/sources/summary/summary_test.go
+++ b/metrics/sources/summary/summary_test.go
@@ -238,23 +238,25 @@ func TestDecodeSummaryMetrics(t *testing.T) {
 
 	containerFs := []string{"/", "logs"}
 	expectations := []struct {
-		key              string
-		setType          string
-		seed             int64
-		cpu              bool
-		memory           bool
-		network          bool
-		accelerators     bool
-		ephemeralstorage bool
-		fs               []string
+		key                       string
+		setType                   string
+		seed                      int64
+		cpu                       bool
+		memory                    bool
+		network                   bool
+		accelerators              bool
+		ephemeralstorage          bool
+		containerEphemeralstorage bool
+		fs                        []string
 	}{{
-		key:     core.NodeKey(nodeInfo.NodeName),
-		setType: core.MetricSetTypeNode,
-		seed:    seedNode,
-		cpu:     true,
-		memory:  true,
-		network: true,
-		fs:      []string{"/"},
+		key:              core.NodeKey(nodeInfo.NodeName),
+		setType:          core.MetricSetTypeNode,
+		seed:             seedNode,
+		cpu:              true,
+		memory:           true,
+		network:          true,
+		ephemeralstorage: true,
+		fs:               []string{"/"},
 	}, {
 		key:     core.NodeContainerKey(nodeInfo.NodeName, "kubelet"),
 		setType: core.MetricSetTypeSystemContainer,
@@ -308,7 +310,8 @@ func TestDecodeSummaryMetrics(t *testing.T) {
 		seed:    seedPod0Container0,
 		cpu:     true,
 		memory:  true,
-		fs:      containerFs,
+		containerEphemeralstorage: true,
+		fs: containerFs,
 	}, {
 		key:     core.PodContainerKey(namespace0, pName0, cName01),
 		setType: core.MetricSetTypePodContainer,
@@ -391,6 +394,9 @@ func TestDecodeSummaryMetrics(t *testing.T) {
 		}
 		if e.ephemeralstorage {
 			checkIntMetric(t, m, e.key, core.MetricEphemeralStorageUsage, e.seed+offsetFsUsed)
+		}
+		if e.containerEphemeralstorage {
+			checkIntMetric(t, m, e.key, core.MetricEphemeralStorageUsage, 2*(e.seed+offsetFsUsed))
 		}
 		for _, label := range e.fs {
 			checkFsMetric(t, m, e.key, label, core.MetricFilesystemAvailable, e.seed+offsetFsAvailable)


### PR DESCRIPTION
 This commit adds pod-level cpu, memory and ephemeralstorage metrics from
   summary API to heaspter.
    
Before, some pod-level metrics are aggregated from containers. After getting those metrics directly from pod summary API, it no longer needs to aggregate from containers.

