### PR TITLE
Fix negative value on "disk/io_{read,write}_bytes_rate"

### DIFF
--- a/metrics/processors/rate_calculator.go
+++ b/metrics/processors/rate_calculator.go
@@ -67,7 +67,8 @@ func (this *RateCalculator) Process(batch *core.DataBatch) (*core.DataBatch, err
 					if itemNew.Name == metricName {
 						metricValNew, foundNew = itemNew.MetricValue, true
 						for _, itemOld := range oldMs.LabeledMetrics {
-							if itemOld.Name == metricName {
+							// Fix negative value on "disk/io_read_bytes_rate" and "disk/io_write_bytes_rate" when multiple disk devices are available
+							if itemOld.Name == metricName && itemOld.Labels[core.LabelResourceID.Key] == itemNew.Labels[core.LabelResourceID.Key] {
 								metricValOld, foundOld = itemOld.MetricValue, true
 								break
 							}


### PR DESCRIPTION
closes #2002

**What this PR does**
Makes rate calculator honor resource ids for disk io metrics. This is basically a copy of #2002.
