### PR TITLE
fix unkeyed fields error

### DIFF
--- a/metrics/sinks/riemann/driver_test.go
+++ b/metrics/sinks/riemann/driver_test.go
@@ -198,11 +198,11 @@ func TestStoreMultipleDataInput(t *testing.T) {
 		},
 		LabeledMetrics: []core.LabeledMetric{
 			{
-				"labeledmetric",
-				map[string]string{
+				Name: "labeledmetric",
+				Labels: map[string]string{
 					"foo": "bar",
 				},
-				metricValue,
+				MetricValue: metricValue,
 			},
 		},
 	}


### PR DESCRIPTION
**What this PR does**
This PR fix ci error: `metrics/sinks/riemann/driver_test.go:200: k8s.io/heapster/metrics/core.LabeledMetric composite literal uses unkeyed fields` for #2002, #2007, #2008 



