### PR TITLE
Fixed cat syntax.

### DIFF
--- a/docs/source-configuration.md
+++ b/docs/source-configuration.md
@@ -32,7 +32,7 @@ This requires the apiserver to be setup completely without auth, which can be do
 Alternatively, you can use a heapster-only serviceaccount like this:
 
 ```shell
-cat <EOF | kubectl create -f -
+cat <<EOF | kubectl create -f -
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
Cat with single less-than character does not work.