### PR TITLE
Deploy with the source kubernetes.summary_api

### DIFF
--- a/deploy/kube-config/influxdb/heapster.yaml
+++ b/deploy/kube-config/influxdb/heapster.yaml
@@ -24,7 +24,7 @@ spec:
         imagePullPolicy: IfNotPresent
         command:
         - /heapster
-        - --source=kubernetes:https://kubernetes.default
+        - --source=kubernetes.summary_api:https://kubernetes.default
         - --sink=influxdb:http://monitoring-influxdb.kube-system.svc:8086
 ---
 apiVersion: v1


### PR DESCRIPTION
In Issue #1648 multiple people are reporting the Kubernetes source to fail with
the error message

    Failed to load nodes: Get https://kubernetes.default:443/api/v1/nodes: dial tcp: i/o timeout

The newer kubernetes.summary_api seems to work

This PR uses by default in the deployment the newer source kubernetes.summary_api  

closes #1648 

