### PR TITLE
deploy: version bump of heapster container to v.1.5.2

### DIFF
--- a/deploy/kube-config/influxdb/heapster.yaml
+++ b/deploy/kube-config/influxdb/heapster.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: heapster
       containers:
       - name: heapster
-        image: k8s.gcr.io/heapster-amd64:v1.4.2
+        image: k8s.gcr.io/heapster-amd64:v1.5.2
         imagePullPolicy: IfNotPresent
         command:
         - /heapster


### PR DESCRIPTION
This PR updates the version of the heapster container that is pulled during the deploy to `v1.5.2`
