### PR TITLE
deploy: update all references to container images to v1.5.3

### DIFF
--- a/deploy/kube-config/google/heapster.yaml
+++ b/deploy/kube-config/google/heapster.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: heapster
       containers:
       - name: heapster
-        image: k8s.gcr.io/heapster-amd64:v1.4.2
+        image: k8s.gcr.io/heapster-amd64:v1.5.3
         imagePullPolicy: IfNotPresent
         command:
         - /heapster

--- a/deploy/kube-config/influxdb/heapster.yaml
+++ b/deploy/kube-config/influxdb/heapster.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: heapster
       containers:
       - name: heapster
-        image: k8s.gcr.io/heapster-amd64:v1.4.2
+        image: k8s.gcr.io/heapster-amd64:v1.5.3
         imagePullPolicy: IfNotPresent
         command:
         - /heapster

--- a/deploy/kube-config/standalone-test/heapster-controller.yaml
+++ b/deploy/kube-config/standalone-test/heapster-controller.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: heapster
       containers:
       - name: heapster-test
-        image: k8s.gcr.io/heapster-amd64:v1.5.1
+        image: k8s.gcr.io/heapster-amd64:v1.5.3
         imagePullPolicy: Always
         command:
         - /heapster

--- a/deploy/kube-config/standalone-test/heapster-summary-controller.yaml
+++ b/deploy/kube-config/standalone-test/heapster-summary-controller.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: heapster-test
-        image: k8s.gcr.io/heapster-amd64:v1.4.2
+        image: k8s.gcr.io/heapster-amd64:v1.5.3
         imagePullPolicy: Always
         command:
         - /heapster
@@ -28,7 +28,7 @@ spec:
           mountPath: /etc/ssl/certs
           readOnly: true
       - name: eventer-test
-        image: k8s.gcr.io/heapster-amd64:v1.4.2
+        image: k8s.gcr.io/heapster-amd64:v1.5.3
         imagePullPolicy: Always
         command:
         - /eventer

--- a/deploy/kube-config/standalone-with-apiserver/heapster-deployment.yaml
+++ b/deploy/kube-config/standalone-with-apiserver/heapster-deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: heapster
-        image: k8s.gcr.io/heapster-amd64:v1.4.2
+        image: k8s.gcr.io/heapster-amd64:v1.5.3
         command:
         - /heapster
         - --source=kubernetes.summary_api:''

--- a/deploy/kube-config/standalone/heapster-controller.yaml
+++ b/deploy/kube-config/standalone/heapster-controller.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: heapster
       containers:
       - name: heapster
-        image: k8s.gcr.io/heapster-amd64:v1.4.2
+        image: k8s.gcr.io/heapster-amd64:v1.5.3
         imagePullPolicy: IfNotPresent
         command:
         - /heapster


### PR DESCRIPTION
This PR updates all the templates in the `deploy` folder to pull the latest container image version `v1.5.3`.

I checked also all the other containers referenced in the `deploy` folder, but those images don't need any refresh because they already pull the latest available version.
