### PR TITLE
Split Honeycomb API requests into sub-batches

### DIFF
--- a/common/honeycomb/honeycomb_test.go
+++ b/common/honeycomb/honeycomb_test.go
@@ -47,14 +47,24 @@ func TestHoneycombClientWrite(t *testing.T) {
 
 	client, _ := NewClient(stubURL)
 
-	err = client.SendBatch([]*BatchPoint{
-		{
-			Data:      "test",
-			Timestamp: time.Now(),
-		},
-	})
+	testBatchPoint := &BatchPoint{
+		Data:      "test",
+		Timestamp: time.Now(),
+	}
+
+	err = client.SendBatch([]*BatchPoint{testBatchPoint})
 
 	assert.NoError(t, err)
 
-	handler.ValidateRequestCount(t, 1)
+	batch2 := []*BatchPoint{}
+
+	for i := 0; i < maxBatchSize*2; i++ {
+		batch2 = append(batch2, testBatchPoint)
+	}
+
+	err = client.SendBatch(batch2)
+
+	assert.NoError(t, err)
+
+	handler.ValidateRequestCount(t, 3)
 }


### PR DESCRIPTION
**What this PR does**

Fixes an issue with overly large request bodies in the Honeycomb integration.

The Honeycomb API will reject requests if they are too large, but the
typical batch size will grow linearly with the amount of metrics
gathered from the Kubernetes cluster. Thus, we will split batches up
into sub-batches so that if they exceed the maximum desired batch size,
they will be sent as independent requests.