### PR TITLE
Push accelerator metrics to new Stackdriver sink.

### DIFF
--- a/metrics/sinks/stackdriver/metadata.go
+++ b/metrics/sinks/stackdriver/metadata.go
@@ -81,6 +81,24 @@ var (
 		Name:       "kubernetes.io/container/ephemeral_storage/limit_bytes",
 	}
 
+	acceleratorMemoryTotalMD = &metricMetadata{
+		MetricKind: google_api5.MetricDescriptor_GAUGE,
+		ValueType:  google_api5.MetricDescriptor_INT64,
+		Name:       "kubernetes.io/container/accelerator/memory_total",
+	}
+
+	acceleratorMemoryUsedMD = &metricMetadata{
+		MetricKind: google_api5.MetricDescriptor_GAUGE,
+		ValueType:  google_api5.MetricDescriptor_INT64,
+		Name:       "kubernetes.io/container/accelerator/memory_used",
+	}
+
+	acceleratorDutyCycleMD = &metricMetadata{
+		MetricKind: google_api5.MetricDescriptor_GAUGE,
+		ValueType:  google_api5.MetricDescriptor_INT64,
+		Name:       "kubernetes.io/container/accelerator/duty_cycle",
+	}
+
 	acceleratorRequestedMD = &metricMetadata{
 		MetricKind: google_api5.MetricDescriptor_GAUGE,
 		ValueType:  google_api5.MetricDescriptor_INT64,

--- a/metrics/sinks/stackdriver/stackdriver.go
+++ b/metrics/sinks/stackdriver/stackdriver.go
@@ -584,6 +584,37 @@ func (sink *StackdriverSink) TranslateLabeledMetric(timestamp time.Time, labels 
 			}
 			return ts
 		}
+	case core.MetricSetTypePodContainer:
+		containerLabels := sink.getContainerResourceLabels(labels)
+		switch metric.Name {
+		case core.MetricAcceleratorMemoryTotal.MetricDescriptor.Name:
+			point := sink.intPoint(timestamp, timestamp, metric.IntValue)
+			ts := createTimeSeries("k8s_container", containerLabels, acceleratorMemoryTotalMD, point)
+			ts.Metric.Labels = map[string]string{
+				core.LabelAcceleratorMake.Key:  metric.Labels[core.LabelAcceleratorMake.Key],
+				core.LabelAcceleratorModel.Key: metric.Labels[core.LabelAcceleratorModel.Key],
+				core.LabelAcceleratorID.Key:    metric.Labels[core.LabelAcceleratorID.Key],
+			}
+			return ts
+		case core.MetricAcceleratorMemoryUsed.MetricDescriptor.Name:
+			point := sink.intPoint(timestamp, timestamp, metric.IntValue)
+			ts := createTimeSeries("k8s_container", containerLabels, acceleratorMemoryUsedMD, point)
+			ts.Metric.Labels = map[string]string{
+				core.LabelAcceleratorMake.Key:  metric.Labels[core.LabelAcceleratorMake.Key],
+				core.LabelAcceleratorModel.Key: metric.Labels[core.LabelAcceleratorModel.Key],
+				core.LabelAcceleratorID.Key:    metric.Labels[core.LabelAcceleratorID.Key],
+			}
+			return ts
+		case core.MetricAcceleratorDutyCycle.MetricDescriptor.Name:
+			point := sink.intPoint(timestamp, timestamp, metric.IntValue)
+			ts := createTimeSeries("k8s_container", containerLabels, acceleratorDutyCycleMD, point)
+			ts.Metric.Labels = map[string]string{
+				core.LabelAcceleratorMake.Key:  metric.Labels[core.LabelAcceleratorMake.Key],
+				core.LabelAcceleratorModel.Key: metric.Labels[core.LabelAcceleratorModel.Key],
+				core.LabelAcceleratorID.Key:    metric.Labels[core.LabelAcceleratorID.Key],
+			}
+			return ts
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
https://github.com/kubernetes/heapster/pull/1891 added pushing to old resource model in Stackdriver. This adds pushing to new resource model.

/cc @piosz @kawych @vishh @jiayingz @x13n 