### PR TITLE
Avoid passing token when using http

### DIFF
--- a/metrics/sources/kubelet/util/kubelet_client.go
+++ b/metrics/sources/kubelet/util/kubelet_client.go
@@ -73,7 +73,9 @@ func (c *KubeletClientConfig) transportConfig() *transport.Config {
 			KeyFile:  c.KeyFile,
 			KeyData:  c.KeyData,
 		},
-		BearerToken: c.BearerToken,
+	}
+	if c.EnableHttps {
+		cfg.BearerToken = c.BearerToken
 	}
 	if c.EnableHttps && !cfg.HasCA() {
 		cfg.TLS.Insecure = true


### PR DESCRIPTION
Bearer token is required on kubelet secure port that uses HTTPS. Sending
token to insecure port can pose security risk.

/cc @kawych