### PR TITLE
Allow users to manually configure the Stackdriver sink to restore metric ingestion and stop the crash loop when not running in GCP.

### DIFF
--- a/metrics/sinks/stackdriver/stackdriver.go
+++ b/metrics/sinks/stackdriver/stackdriver.go
@@ -373,17 +373,20 @@ func CreateStackdriverSink(uri *url.URL) (core.DataSink, error) {
 		// Detect zone for old resource model
 		heapsterZone, err = gce.Zone()
 		if err != nil {
-			return nil, err
+			glog.Warningf("Zone could not be discovered using the GCE Metadata Server: %s", err)
+
+			if useOldResourceModel {
+				return nil, err
+			}
 		}
 
 		if useNewResourceModel {
 			if clusterName == "" {
 				glog.Info("An empty cluster name has been provided, checking the GCE Metadata Server to try to auto-detect.")
 
-				clusterName_, err := gce.InstanceAttributeValue("cluster-name")
+				clusterName, err = gce.InstanceAttributeValue("cluster-name")
 				if err == nil {
-					glog.Infof("Discovered '%s' as the cluster name from the GCE Metadata Server.", clusterName_)
-					clusterName = clusterName_
+					glog.Infof("Discovered '%s' as the cluster name from the GCE Metadata Server.", clusterName)
 				} else {
 					glog.Warningf("Cluster name could not be discovered using the GCE Metadata Server: %s", err)
 				}
@@ -392,10 +395,9 @@ func CreateStackdriverSink(uri *url.URL) (core.DataSink, error) {
 			if clusterLocation == "" {
 				glog.Info("An empty cluster location has been provided, checking the GCE Metadata Server to try to auto-detect.")
 
-				clusterLocation_, err := gce.InstanceAttributeValue("cluster-location")
+				clusterLocation, err = gce.InstanceAttributeValue("cluster-location")
 				if err == nil {
-					glog.Infof("Discovered '%s' as the cluster location from the GCE Metadata Server.", clusterLocation_)
-					clusterLocation = clusterLocation_
+					glog.Infof("Discovered '%s' as the cluster location from the GCE Metadata Server.", clusterLocation)
 				} else {
 					glog.Warningf("Cluster location could not be discovered using the GCE Metadata Server: %s", err)
 				}

--- a/metrics/sinks/stackdriver/stackdriver.go
+++ b/metrics/sinks/stackdriver/stackdriver.go
@@ -402,6 +402,7 @@ func CreateStackdriverSink(uri *url.URL) (core.DataSink, error) {
 			}
 		}
 	} else {
+		// Detect project ID from the environment
 		projectId, err = gce_util.GetProjectId()
 		if err != nil {
 			return nil, err

--- a/metrics/sinks/stackdriver/stackdriver.go
+++ b/metrics/sinks/stackdriver/stackdriver.go
@@ -358,20 +358,27 @@ func CreateStackdriverSink(uri *url.URL) (core.DataSink, error) {
 		}
 	}
 
-	if err := gce_util.EnsureOnGCE(); err != nil {
-		return nil, err
-	}
+	var projectId, heapsterZone string
 
-	// Detect project ID
-	projectId, err := gce.ProjectID()
-	if err != nil {
-		return nil, err
-	}
+	if gce.OnGCE() {
+		// Detect project ID
+		projectId, err = gce.ProjectID()
+		if err != nil {
+			return nil, err
+		}
 
-	// Detect zone for old resource model
-	heapsterZone, err := gce.Zone()
-	if err != nil {
-		return nil, err
+		// Detect zone for old resource model
+		heapsterZone, err = gce.Zone()
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		projectId, err = gce_util.GetProjectId()
+		if err != nil {
+			return nil, err
+		}
+
+		heapsterZone = opts["zone"][0]
 	}
 
 	clusterLocation := heapsterZone


### PR DESCRIPTION
**What this PR does**
When Heapster is configured to use Stackdriver as its only sink, and the Kubernetes cluster is not running inside of GCP, Heapster repeatedly crashes, and no metrics are sent to Stackdriver, rendering metrics ingestion useless for Stackdriver monitoring customers with configurations like this. 

This PR allows users to manually configure the Stackdriver sink to restore metric ingestion and stop the crash loop.