### PR TITLE
Add an option to read Host ID from node annotation if ExternalID is not available

### DIFF
--- a/events/sinks/factory.go
+++ b/events/sinks/factory.go
@@ -59,7 +59,7 @@ func (this *SinkFactory) BuildAll(uris flags.Uris) []core.EventSink {
 	for _, uri := range uris {
 		sink, err := this.Build(uri)
 		if err != nil {
-			glog.Errorf("Failed to create %s sink: %v", uri, err)
+			glog.Errorf("Failed to create %v sink: %v", uri, err)
 			continue
 		}
 		result = append(result, sink)

--- a/metrics/sinks/factory.go
+++ b/metrics/sinks/factory.go
@@ -87,7 +87,7 @@ func (this *SinkFactory) BuildAll(uris flags.Uris, historicalUri string, disable
 	for _, uri := range uris {
 		sink, err := this.Build(uri)
 		if err != nil {
-			glog.Errorf("Failed to create %s sink: %v", uri, err)
+			glog.Errorf("Failed to create %v sink: %v", uri, err)
 			continue
 		}
 		if uri.Key == "metric" {


### PR DESCRIPTION
**What this PR does**

Fixes a bug where HostID is not populated starting with Kubernetes 1.11. ExternalID which was originally a source of HostID label was deprecated and is no longer set in Kubernetes 1.11. Starting with this version, host ID can be provided via node annotation.