### PR TITLE
Release Heapster 1.6-beta.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ ifndef TEMP_DIR
 TEMP_DIR:=$(shell mktemp -d /tmp/heapster.XXXXXX)
 endif
 
-VERSION?=v1.5.0-beta.3
+VERSION?=v1.6.0-beta.1
 GIT_COMMIT:=$(shell git rev-parse --short HEAD)
 
 TESTUSER=

--- a/deploy/kube-config/google/heapster.yaml
+++ b/deploy/kube-config/google/heapster.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: heapster
       containers:
       - name: heapster
-        image: k8s.gcr.io/heapster-amd64:v1.5.3
+        image: k8s.gcr.io/heapster-amd64:v1.6.0-beta.1
         imagePullPolicy: IfNotPresent
         command:
         - /heapster

--- a/deploy/kube-config/influxdb/heapster.yaml
+++ b/deploy/kube-config/influxdb/heapster.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: heapster
       containers:
       - name: heapster
-        image: k8s.gcr.io/heapster-amd64:v1.5.3
+        image: k8s.gcr.io/heapster-amd64:v1.6.0-beta.1
         imagePullPolicy: IfNotPresent
         command:
         - /heapster

--- a/deploy/kube-config/standalone-test/heapster-controller.yaml
+++ b/deploy/kube-config/standalone-test/heapster-controller.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: heapster
       containers:
       - name: heapster-test
-        image: k8s.gcr.io/heapster-amd64:v1.5.3
+        image: k8s.gcr.io/heapster-amd64:v1.6.0-beta.1
         imagePullPolicy: Always
         command:
         - /heapster

--- a/deploy/kube-config/standalone-test/heapster-summary-controller.yaml
+++ b/deploy/kube-config/standalone-test/heapster-summary-controller.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: heapster-test
-        image: k8s.gcr.io/heapster-amd64:v1.5.3
+        image: k8s.gcr.io/heapster-amd64:v1.6.0-beta.1
         imagePullPolicy: Always
         command:
         - /heapster
@@ -28,7 +28,7 @@ spec:
           mountPath: /etc/ssl/certs
           readOnly: true
       - name: eventer-test
-        image: k8s.gcr.io/heapster-amd64:v1.5.3
+        image: k8s.gcr.io/heapster-amd64:v1.6.0-beta.1
         imagePullPolicy: Always
         command:
         - /eventer

--- a/deploy/kube-config/standalone-with-apiserver/heapster-deployment.yaml
+++ b/deploy/kube-config/standalone-with-apiserver/heapster-deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: heapster
-        image: k8s.gcr.io/heapster-amd64:v1.5.3
+        image: k8s.gcr.io/heapster-amd64:v1.6.0-beta.1
         command:
         - /heapster
         - --source=kubernetes.summary_api:''

--- a/deploy/kube-config/standalone/heapster-controller.yaml
+++ b/deploy/kube-config/standalone/heapster-controller.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: heapster
       containers:
       - name: heapster
-        image: k8s.gcr.io/heapster-amd64:v1.5.3
+        image: k8s.gcr.io/heapster-amd64:v1.6.0-beta.1
         imagePullPolicy: IfNotPresent
         command:
         - /heapster


### PR DESCRIPTION
**What this PR does**
Start Kubernetes release 1.6.

This is the last minor release, since Heapster is deprecated and doesn't accept new features.

