### PR TITLE
Revert Heapster version in deployment files to 1.5.4

### DIFF
--- a/deploy/kube-config/google/heapster.yaml
+++ b/deploy/kube-config/google/heapster.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: heapster
       containers:
       - name: heapster
-        image: k8s.gcr.io/heapster-amd64:v1.6.0-beta.1
+        image: k8s.gcr.io/heapster-amd64:v1.5.4
         imagePullPolicy: IfNotPresent
         command:
         - /heapster

--- a/deploy/kube-config/influxdb/heapster.yaml
+++ b/deploy/kube-config/influxdb/heapster.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: heapster
       containers:
       - name: heapster
-        image: k8s.gcr.io/heapster-amd64:v1.6.0-beta.1
+        image: k8s.gcr.io/heapster-amd64:v1.5.4
         imagePullPolicy: IfNotPresent
         command:
         - /heapster

--- a/deploy/kube-config/standalone-test/heapster-controller.yaml
+++ b/deploy/kube-config/standalone-test/heapster-controller.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: heapster
       containers:
       - name: heapster-test
-        image: k8s.gcr.io/heapster-amd64:v1.6.0-beta.1
+        image: k8s.gcr.io/heapster-amd64:v1.5.4
         imagePullPolicy: Always
         command:
         - /heapster

--- a/deploy/kube-config/standalone-with-apiserver/heapster-deployment.yaml
+++ b/deploy/kube-config/standalone-with-apiserver/heapster-deployment.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - name: heapster
-        image: k8s.gcr.io/heapster-amd64:v1.6.0-beta.1
+        image: k8s.gcr.io/heapster-amd64:v1.5.4
         command:
         - /heapster
         - --source=kubernetes.summary_api:''

--- a/deploy/kube-config/standalone/heapster-controller.yaml
+++ b/deploy/kube-config/standalone/heapster-controller.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: heapster
       containers:
       - name: heapster
-        image: k8s.gcr.io/heapster-amd64:v1.6.0-beta.1
+        image: k8s.gcr.io/heapster-amd64:v1.5.4
         imagePullPolicy: IfNotPresent
         command:
         - /heapster


### PR DESCRIPTION
**What this PR does**
Reverts change introduced in PR #2068. Heapster is during the release process, but it's not yet tested and therefore the image is not yet publicly available. This fixes reference deployments.