### PR TITLE
Update influxdb.go

### DIFF
--- a/metrics/sinks/influxdb/influxdb.go
+++ b/metrics/sinks/influxdb/influxdb.go
@@ -181,7 +181,7 @@ func (sink *influxdbSink) ExportData(dataBatch *core.DataBatch) {
 			}
 		}
 	}
-	if len(dataPoints) >= 0 {
+	if len(dataPoints) > 0 {
 		sink.concurrentSendData(dataPoints)
 	}
 


### PR DESCRIPTION
We use influxdb sink to write data to `telegraf` with influxdb data format. influxdb sink will send data if the size is times of the maxSendBatchSize(10000) or reaching the end of dataBatch. But if the dataBatch is just the times of the maxSendBatchSize,influxdb sink will still write an empty string to the backend. Influxdb will handle the empty with 204 no data but telegraf will panic. And I think if there is node dataBatch left,Influxdb sink should not write an empty string even there is no harm to the real influxdb.

**What this PR does**
Change the condition of sending data in influxdb sink.

