### PR TITLE
change the func name of creating influxdb sink

### DIFF
--- a/metrics/sinks/influxdb/influxdb.go
+++ b/metrics/sinks/influxdb/influxdb.go
@@ -291,7 +291,7 @@ func (sink *influxdbSink) createRetentionPolicy() error {
 }
 
 // Returns a thread-compatible implementation of influxdb interactions.
-func new(c influxdb_common.InfluxdbConfig) core.DataSink {
+func newSink(c influxdb_common.InfluxdbConfig) core.DataSink {
 	client, err := influxdb_common.NewClient(c)
 	if err != nil {
 		glog.Errorf("issues while creating an InfluxDB sink: %v, will retry on use", err)
@@ -308,7 +308,7 @@ func CreateInfluxdbSink(uri *url.URL) (core.DataSink, error) {
 	if err != nil {
 		return nil, err
 	}
-	sink := new(*config)
+	sink := newSink(*config)
 	glog.Infof("created influxdb sink with options: host:%s user:%s db:%s", config.Host, config.User, config.DbName)
 	return sink, nil
 }


### PR DESCRIPTION
In golang. `new` is a built-in function although you can  define your own `new` function. But when you use a ide with code quality check,It will emit some warnings.
![lalpby0v5ekmfm_my80cxa_604_203 png_620x10000q90g](https://user-images.githubusercontent.com/3116693/44305595-d00d4380-a3ad-11e8-9b29-d135e3ce1245.jpg)
![lalpby0v5ekmfn7mkc0bxw_455_145 png_620x10000q90g](https://user-images.githubusercontent.com/3116693/44305596-d00d4380-a3ad-11e8-9e68-bdd01f60c26f.jpg)
Because the built-in `new` means `it returns a pointer to type T a value of type *T, it allocates and zeroes the memory. ` 

**What this PR does**
change the constructor name of influxdb sink.