### PR TITLE
fix retention policy in influxdb sink

### DIFF
--- a/metrics/sinks/influxdb/influxdb.go
+++ b/metrics/sinks/influxdb/influxdb.go
@@ -29,7 +29,7 @@ import (
 )
 
 type influxdbSink struct {
-	client influxdb_common.InfluxdbClient
+	client   influxdb_common.InfluxdbClient
 	sync.RWMutex
 	c        influxdb_common.InfluxdbConfig
 	dbExists bool
@@ -257,17 +257,48 @@ func (sink *influxdbSink) createDatabase() error {
 	if sink.dbExists {
 		return nil
 	}
+
+	//query databases and check the specific database is exist or not.
 	q := influxdb.Query{
-		Command: fmt.Sprintf(`CREATE DATABASE %s WITH NAME "default"`, sink.c.DbName),
+		Command: "SHOW DATABASES",
 	}
 
-	if resp, err := sink.client.Query(q); err != nil {
-		if !(resp != nil && resp.Err != nil && strings.Contains(resp.Err.Error(), "already exists")) {
-			err := sink.createRetentionPolicy()
-			if err != nil {
-				return err
+	resp, err := sink.client.Query(q)
+
+	if err != nil {
+		return err
+	}
+
+	if len(resp.Results) == 1 && len(resp.Results[0].Series) == 1 {
+		values := resp.Results[0].Series[0].Values
+		for _, name := range values {
+			if sink.c.DbName == name[0].(string) {
+				sink.dbExists = true
+				//If the database is exist,we should exit right now.
+				return nil
 			}
 		}
+
+		q = influxdb.Query{
+			Command: fmt.Sprintf(`CREATE DATABASE %s`, sink.c.DbName),
+		}
+
+		_, err := sink.client.Query(q)
+		if err != nil {
+			return err
+		}
+
+		/**
+			heapster should on create retention policy on the creation of database.
+			although you can change the retention duration in params,
+			but heapster will not alter a existing database's retention policies.
+		 */
+		err = sink.createRetentionPolicy()
+		if err != nil {
+			return err
+		}
+	} else {
+		return fmt.Errorf("Failed to query databases from influxdb")
 	}
 
 	sink.dbExists = true

--- a/metrics/sinks/influxdb/influxdb.go
+++ b/metrics/sinks/influxdb/influxdb.go
@@ -29,7 +29,7 @@ import (
 )
 
 type influxdbSink struct {
-	client influxdb_common.InfluxdbClient
+	client   influxdb_common.InfluxdbClient
 	sync.RWMutex
 	c        influxdb_common.InfluxdbConfig
 	dbExists bool
@@ -205,8 +205,7 @@ func (sink *influxdbSink) sendData(dataPoints []influxdb.Point) {
 	}()
 
 	if err := sink.createDatabase(); err != nil {
-		glog.Errorf("Failed to create influxdb: %v", err)
-		return
+		glog.Warningf("Failed to create influxdb: %v", err)
 	}
 	bp := influxdb.BatchPoints{
 		Points:          dataPoints,

--- a/metrics/sinks/influxdb/influxdb.go
+++ b/metrics/sinks/influxdb/influxdb.go
@@ -29,7 +29,7 @@ import (
 )
 
 type influxdbSink struct {
-	client   influxdb_common.InfluxdbClient
+	client influxdb_common.InfluxdbClient
 	sync.RWMutex
 	c        influxdb_common.InfluxdbConfig
 	dbExists bool
@@ -289,10 +289,10 @@ func (sink *influxdbSink) createDatabase() error {
 		}
 
 		/**
-			heapster should on create retention policy on the creation of database.
-			although you can change the retention duration in params,
-			but heapster will not alter a existing database's retention policies.
-		 */
+		heapster should on create retention policy on the creation of database.
+		although you can change the retention duration in params,
+		but heapster will not alter a existing database's retention policies.
+		*/
 		err = sink.createRetentionPolicy()
 		if err != nil {
 			return err

--- a/metrics/sinks/influxdb/influxdb_test.go
+++ b/metrics/sinks/influxdb/influxdb_test.go
@@ -23,11 +23,11 @@ import (
 	"net/http/httptest"
 	"net/url"
 
+	influxdb "github.com/influxdata/influxdb/client"
 	influx_models "github.com/influxdata/influxdb/models"
 	"github.com/stretchr/testify/assert"
 	util "k8s.io/client-go/util/testing"
 	influxdb_common "k8s.io/heapster/common/influxdb"
-	influxdb "github.com/influxdata/influxdb/client"
 	"k8s.io/heapster/metrics/core"
 )
 
@@ -38,7 +38,7 @@ type fakeInfluxDBDataSink struct {
 
 func (sink *fakeInfluxDBDataSink) sendData(dataPoints []influxdb.Point) {
 	bp := influxdb.BatchPoints{
-		Points:          dataPoints,
+		Points: dataPoints,
 	}
 	if _, err := sink.fakeDbClient.Write(bp); err != nil {
 		return

--- a/metrics/sinks/influxdb/influxdb_test.go
+++ b/metrics/sinks/influxdb/influxdb_test.go
@@ -35,22 +35,12 @@ type fakeInfluxDBDataSink struct {
 	fakeDbClient *influxdb_common.FakeInfluxDBClient
 }
 
-func newRawInfluxSink() *fakeInfluxdbSink {
-	return &fakeInfluxdbSink{
-		&influxdbSink{
-			client:  influxdb_common.Client,
-			c:       influxdb_common.Config,
-			conChan: make(chan struct{}, influxdb_common.Config.Concurrency),
-		},
+func newRawInfluxSink() *influxdbSink {
+	return &influxdbSink{
+		client:  influxdb_common.Client,
+		c:       influxdb_common.Config,
+		conChan: make(chan struct{}, influxdb_common.Config.Concurrency),
 	}
-}
-
-type fakeInfluxdbSink struct {
-	*influxdbSink
-}
-
-func (f *fakeInfluxdbSink) createDatabase() error {
-	return nil
 }
 
 func NewFakeSink() fakeInfluxDBDataSink {

--- a/metrics/sinks/influxdb/influxdb_test.go
+++ b/metrics/sinks/influxdb/influxdb_test.go
@@ -27,12 +27,22 @@ import (
 	"github.com/stretchr/testify/assert"
 	util "k8s.io/client-go/util/testing"
 	influxdb_common "k8s.io/heapster/common/influxdb"
+	influxdb "github.com/influxdata/influxdb/client"
 	"k8s.io/heapster/metrics/core"
 )
 
 type fakeInfluxDBDataSink struct {
 	core.DataSink
 	fakeDbClient *influxdb_common.FakeInfluxDBClient
+}
+
+func (sink *fakeInfluxDBDataSink) sendData(dataPoints []influxdb.Point) {
+	bp := influxdb.BatchPoints{
+		Points:          dataPoints,
+	}
+	if _, err := sink.fakeDbClient.Write(bp); err != nil {
+		return
+	}
 }
 
 func newRawInfluxSink() *influxdbSink {

--- a/metrics/sinks/influxdb/influxdb_test.go
+++ b/metrics/sinks/influxdb/influxdb_test.go
@@ -23,7 +23,6 @@ import (
 	"net/http/httptest"
 	"net/url"
 
-	influxdb "github.com/influxdata/influxdb/client"
 	influx_models "github.com/influxdata/influxdb/models"
 	"github.com/stretchr/testify/assert"
 	util "k8s.io/client-go/util/testing"
@@ -36,21 +35,22 @@ type fakeInfluxDBDataSink struct {
 	fakeDbClient *influxdb_common.FakeInfluxDBClient
 }
 
-func (sink *fakeInfluxDBDataSink) sendData(dataPoints []influxdb.Point) {
-	bp := influxdb.BatchPoints{
-		Points: dataPoints,
-	}
-	if _, err := sink.fakeDbClient.Write(bp); err != nil {
-		return
+func newRawInfluxSink() *fakeInfluxdbSink {
+	return &fakeInfluxdbSink{
+		&influxdbSink{
+			client:  influxdb_common.Client,
+			c:       influxdb_common.Config,
+			conChan: make(chan struct{}, influxdb_common.Config.Concurrency),
+		},
 	}
 }
 
-func newRawInfluxSink() *influxdbSink {
-	return &influxdbSink{
-		client:  influxdb_common.Client,
-		c:       influxdb_common.Config,
-		conChan: make(chan struct{}, influxdb_common.Config.Concurrency),
-	}
+type fakeInfluxdbSink struct {
+	*influxdbSink
+}
+
+func (f *fakeInfluxdbSink) createDatabase() error {
+	return nil
 }
 
 func NewFakeSink() fakeInfluxDBDataSink {


### PR DESCRIPTION
Here is the influxdb retention policy creation in master branch. 
```
q := influxdb.Query{
	Command: fmt.Sprintf(`CREATE DATABASE %s WITH NAME "default"`, sink.c.DbName),
}

if resp, err := sink.client.Query(q); err != nil {
  if !(resp != nil && resp.Err != nil && strings.Contains(resp.Err.Error(), "already exists")) {
		err := sink.createRetentionPolicy()
		if err != nil {
			return err
		}
	}
}
```
If the database is not exist,heapster will create a retention policy named `default` without duration. The retention policy with duration will only be called when the query `CREATE DATABASE %s WITH NAME "default"` failed.  

but this query will never fail,even the database has been existed. It will return the msg below.
```
HTTP/1.1 200 OK
Content-Type: application/json
Request-Id: 36d40f46-aabf-11e8-802d-000000000000
X-Influxdb-Build: OSS
X-Influxdb-Version: unknown
X-Request-Id: 36d40f46-aabf-11e8-802d-000000000000
Date: Tue, 28 Aug 2018 12:38:07 GMT
Transfer-Encoding: chunked

{"results":[{"statement_id":0}]}
``` 
So I change the condition of checking database existing with query `SHOW DATABASES`,And create retention policy with duration when the database is not exist before and created by heapster.