### PR TITLE
Fix retention policy in influxdb sink

### DIFF
--- a/metrics/sinks/influxdb/influxdb.go
+++ b/metrics/sinks/influxdb/influxdb.go
@@ -274,8 +274,8 @@ func (sink *influxdbSink) createDatabase() error {
 		for _, name := range values {
 			if sink.c.DbName == name[0].(string) {
 				sink.dbExists = true
-				//If the database exists,we should exit right now.
-				glog.Infof("The specific database %s is exist", sink.c.DbName)
+				// If the database exists, we should exit right now.
+				glog.Infof("The specific database %s exists", sink.c.DbName)
 				return nil
 			}
 		}

--- a/metrics/sinks/influxdb/influxdb.go
+++ b/metrics/sinks/influxdb/influxdb.go
@@ -29,7 +29,7 @@ import (
 )
 
 type influxdbSink struct {
-	client   influxdb_common.InfluxdbClient
+	client influxdb_common.InfluxdbClient
 	sync.RWMutex
 	c        influxdb_common.InfluxdbConfig
 	dbExists bool

--- a/metrics/sinks/influxdb/influxdb.go
+++ b/metrics/sinks/influxdb/influxdb.go
@@ -29,7 +29,7 @@ import (
 )
 
 type influxdbSink struct {
-	client influxdb_common.InfluxdbClient
+	client   influxdb_common.InfluxdbClient
 	sync.RWMutex
 	c        influxdb_common.InfluxdbConfig
 	dbExists bool
@@ -258,7 +258,7 @@ func (sink *influxdbSink) createDatabase() error {
 		return nil
 	}
 
-	//query databases and check the specific database is exist or not.
+	//check the specific database is exist or not/check whether the specific database exist or not
 	q := influxdb.Query{
 		Command: "SHOW DATABASES",
 	}
@@ -269,7 +269,7 @@ func (sink *influxdbSink) createDatabase() error {
 		return err
 	}
 
-	if len(resp.Results) == 1 && len(resp.Results[0].Series) == 1 {
+	if resp != nil && len(resp.Results) == 1 && len(resp.Results[0].Series) == 1 {
 		values := resp.Results[0].Series[0].Values
 		for _, name := range values {
 			if sink.c.DbName == name[0].(string) {

--- a/metrics/sinks/influxdb/influxdb.go
+++ b/metrics/sinks/influxdb/influxdb.go
@@ -258,7 +258,7 @@ func (sink *influxdbSink) createDatabase() error {
 		return nil
 	}
 
-	//check whether the specific database exist or not
+	// check whether the specific database exist or not
 	q := influxdb.Query{
 		Command: "SHOW DATABASES",
 	}
@@ -275,6 +275,7 @@ func (sink *influxdbSink) createDatabase() error {
 			if sink.c.DbName == name[0].(string) {
 				sink.dbExists = true
 				//If the database is exist,we should exit right now.
+				glog.Infof("The specific database %s is exist", sink.c.DbName)
 				return nil
 			}
 		}
@@ -285,6 +286,7 @@ func (sink *influxdbSink) createDatabase() error {
 
 		_, err := sink.client.Query(q)
 		if err != nil {
+			glog.Errorf("Failed to create database in influxdb,because of %s", err.Error())
 			return err
 		}
 
@@ -295,6 +297,7 @@ func (sink *influxdbSink) createDatabase() error {
 		*/
 		err = sink.createRetentionPolicy()
 		if err != nil {
+			glog.Errorf("Failed to create retention policy on database,because of %s", err.Error())
 			return err
 		}
 	} else {

--- a/metrics/sinks/influxdb/influxdb.go
+++ b/metrics/sinks/influxdb/influxdb.go
@@ -258,7 +258,7 @@ func (sink *influxdbSink) createDatabase() error {
 		return nil
 	}
 
-	//check the specific database is exist or not/check whether the specific database exist or not
+	//check whether the specific database exist or not
 	q := influxdb.Query{
 		Command: "SHOW DATABASES",
 	}

--- a/metrics/sinks/influxdb/influxdb.go
+++ b/metrics/sinks/influxdb/influxdb.go
@@ -29,7 +29,7 @@ import (
 )
 
 type influxdbSink struct {
-	client influxdb_common.InfluxdbClient
+	client   influxdb_common.InfluxdbClient
 	sync.RWMutex
 	c        influxdb_common.InfluxdbConfig
 	dbExists bool
@@ -181,7 +181,7 @@ func (sink *influxdbSink) ExportData(dataBatch *core.DataBatch) {
 			}
 		}
 	}
-	if len(dataPoints) > 0 {
+	if len(dataPoints) >= 0 {
 		sink.concurrentSendData(dataPoints)
 	}
 
@@ -205,7 +205,7 @@ func (sink *influxdbSink) sendData(dataPoints []influxdb.Point) {
 	}()
 
 	if err := sink.createDatabase(); err != nil {
-		glog.Errorf("Failed to create influxdb: %v", err)
+		glog.Warningf("Failed to create influxdb: %v", err)
 		return
 	}
 	bp := influxdb.BatchPoints{
@@ -257,17 +257,48 @@ func (sink *influxdbSink) createDatabase() error {
 	if sink.dbExists {
 		return nil
 	}
+
+	//query databases and check the specific database is exist or not.
 	q := influxdb.Query{
-		Command: fmt.Sprintf(`CREATE DATABASE %s WITH NAME "default"`, sink.c.DbName),
+		Command: "SHOW DATABASES",
 	}
 
-	if resp, err := sink.client.Query(q); err != nil {
-		if !(resp != nil && resp.Err != nil && strings.Contains(resp.Err.Error(), "already exists")) {
-			err := sink.createRetentionPolicy()
-			if err != nil {
-				return err
+	resp, err := sink.client.Query(q)
+
+	if err != nil {
+		return err
+	}
+
+	if len(resp.Results) == 1 && len(resp.Results[0].Series) == 1 {
+		values := resp.Results[0].Series[0].Values
+		for _, name := range values {
+			if sink.c.DbName == name[0].(string) {
+				sink.dbExists = true
+				//If the database is exist,we should exit right now.
+				return nil
 			}
 		}
+
+		q = influxdb.Query{
+			Command: fmt.Sprintf(`CREATE DATABASE %s`, sink.c.DbName),
+		}
+
+		_, err := sink.client.Query(q)
+		if err != nil {
+			return err
+		}
+
+		/**
+		heapster should on create retention policy on the creation of database.
+		although you can change the retention duration in params,
+		but heapster will not alter a existing database's retention policies.
+		*/
+		err = sink.createRetentionPolicy()
+		if err != nil {
+			return err
+		}
+	} else {
+		return fmt.Errorf("Failed to query databases from influxdb")
 	}
 
 	sink.dbExists = true

--- a/metrics/sinks/influxdb/influxdb.go
+++ b/metrics/sinks/influxdb/influxdb.go
@@ -181,7 +181,7 @@ func (sink *influxdbSink) ExportData(dataBatch *core.DataBatch) {
 			}
 		}
 	}
-	if len(dataPoints) >= 0 {
+	if len(dataPoints) > 0 {
 		sink.concurrentSendData(dataPoints)
 	}
 
@@ -205,7 +205,7 @@ func (sink *influxdbSink) sendData(dataPoints []influxdb.Point) {
 	}()
 
 	if err := sink.createDatabase(); err != nil {
-		glog.Warningf("Failed to create influxdb: %v", err)
+		glog.Errorf("Failed to create influxdb: %v", err)
 		return
 	}
 	bp := influxdb.BatchPoints{

--- a/metrics/sinks/influxdb/influxdb.go
+++ b/metrics/sinks/influxdb/influxdb.go
@@ -295,7 +295,7 @@ func (sink *influxdbSink) createDatabase() error {
 		// but heapster will not alter a existing database's retention policies.
 		err = sink.createRetentionPolicy()
 		if err != nil {
-			glog.Errorf("Failed to create retention policy on database,because of %s", err.Error())
+			glog.Errorf("Failed to create retention policy on database:%s", err.Error())
 			return err
 		}
 	} else {

--- a/metrics/sinks/influxdb/influxdb.go
+++ b/metrics/sinks/influxdb/influxdb.go
@@ -258,7 +258,7 @@ func (sink *influxdbSink) createDatabase() error {
 		return nil
 	}
 
-	// check whether the specific database exist or not
+	// check whether the specific database exists or not
 	q := influxdb.Query{
 		Command: "SHOW DATABASES",
 	}
@@ -274,7 +274,7 @@ func (sink *influxdbSink) createDatabase() error {
 		for _, name := range values {
 			if sink.c.DbName == name[0].(string) {
 				sink.dbExists = true
-				//If the database is exist,we should exit right now.
+				//If the database exists,we should exit right now.
 				glog.Infof("The specific database %s is exist", sink.c.DbName)
 				return nil
 			}
@@ -286,15 +286,13 @@ func (sink *influxdbSink) createDatabase() error {
 
 		_, err := sink.client.Query(q)
 		if err != nil {
-			glog.Errorf("Failed to create database in influxdb,because of %s", err.Error())
+			glog.Errorf("Failed to create database in influxdb:%s", err.Error())
 			return err
 		}
 
-		/**
-		heapster should on create retention policy on the creation of database.
-		although you can change the retention duration in params,
-		but heapster will not alter a existing database's retention policies.
-		*/
+		// heapster should on create retention policy on the creation of database.
+		// although you can change the retention duration in params,
+		// but heapster will not alter a existing database's retention policies.
 		err = sink.createRetentionPolicy()
 		if err != nil {
 			glog.Errorf("Failed to create retention policy on database,because of %s", err.Error())

--- a/metrics/sinks/influxdb/influxdb_test.go
+++ b/metrics/sinks/influxdb/influxdb_test.go
@@ -37,9 +37,10 @@ type fakeInfluxDBDataSink struct {
 
 func newRawInfluxSink() *influxdbSink {
 	return &influxdbSink{
-		client:  influxdb_common.Client,
-		c:       influxdb_common.Config,
-		conChan: make(chan struct{}, influxdb_common.Config.Concurrency),
+		client:   influxdb_common.Client,
+		c:        influxdb_common.Config,
+		dbExists: true,
+		conChan:  make(chan struct{}, influxdb_common.Config.Concurrency),
 	}
 }
 


### PR DESCRIPTION
Here is the influxdb retention policy creation in master branch. 
```
q := influxdb.Query{
	Command: fmt.Sprintf(`CREATE DATABASE %s WITH NAME "default"`, sink.c.DbName),
}

if resp, err := sink.client.Query(q); err != nil {
  if !(resp != nil && resp.Err != nil && strings.Contains(resp.Err.Error(), "already exists")) {
		err := sink.createRetentionPolicy()
		if err != nil {
			return err
		}
	}
}
```
If the database is not exist,heapster will create a retention policy named `default` without duration. The retention policy with duration will only be called when the query `CREATE DATABASE %s WITH NAME "default"` failed.  

but this query will never fail,even the database has been existed. It will return the msg below.
```
HTTP/1.1 200 OK
Content-Type: application/json
Request-Id: 36d40f46-aabf-11e8-802d-000000000000
X-Influxdb-Build: OSS
X-Influxdb-Version: unknown
X-Request-Id: 36d40f46-aabf-11e8-802d-000000000000
Date: Tue, 28 Aug 2018 12:38:07 GMT
Transfer-Encoding: chunked

{"results":[{"statement_id":0}]}
``` 
So I change the condition of checking database existing with query `SHOW DATABASES`,And create retention policy with duration when the database is not exist before and created by heapster.

**What this PR does**
fixes #2084