### PR TITLE
Fix grammatical error in the warning message

### DIFF
--- a/metrics/sinks/elasticsearch/driver.go
+++ b/metrics/sinks/elasticsearch/driver.go
@@ -77,7 +77,7 @@ func (sink *elasticSearchSink) ExportData(dataBatch *core.DataBatch) {
 		}
 		err := sink.flushData()
 		if err != nil {
-			glog.Warningf("Failed to flushing data to ElasticSearch sink: %v", err)
+			glog.Warningf("Failed to flush data to ElasticSearch sink: %v", err)
 		}
 	}
 }


### PR DESCRIPTION
Fix grammatical error in the warning message:
Line 80: Failed to flushing data->Failed to flush data